### PR TITLE
Added zipInto and zipAlignInto for Series and Frame (+one bug fix)

### DIFF
--- a/src/FrameExtensions.fs
+++ b/src/FrameExtensions.fs
@@ -620,6 +620,25 @@ type FrameExtensions =
   [<Extension>]
   static member DropSparseColumns(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.dropSparseCols frame
 
+    
+// ------------------------------------------------------------------------------------------------
+// Appending and joining
+// ------------------------------------------------------------------------------------------------
+  
+  /// [category:Appending and joining]
+  [<Extension>]
+  static member ZipInto<'KRow,'KColumn, 'TLeft,'TRight,'TResult when 'KRow : equality and 'KColumn : equality>(frameLeft:Frame<'KRow, 'KColumn>, frameRight:Frame<'KRow, 'KColumn>, resultSelector:Func<'TLeft,'TRight,'TResult>) =
+    (frameLeft, frameRight) 
+    ||> Frame.zipInto (resultSelector.Invoke |> FuncConvert.FuncFromTupled)
+
+  /// [category:Appending and joining]
+  [<Extension>]
+  static member ZipAlignInto<'KRow,'KColumn, 'TLeft,'TRight,'TResult when 'KRow : equality and 'KColumn : equality>(frameLeft:Frame<'KRow, 'KColumn>, frameRight:Frame<'KRow, 'KColumn>, resultSelector:Func<'TLeft,'TRight,'TResult>, columnKind, rowKind, lookup) =
+    (frameLeft, frameRight) 
+    ||> Frame.zipAlignInto (resultSelector.Invoke |> FuncConvert.FuncFromTupled) columnKind rowKind lookup
+
+
+
 type KeyValue =
   static member Create<'K, 'V>(key:'K, value:'V) = KeyValuePair(key, value)
 

--- a/src/Series.fs
+++ b/src/Series.fs
@@ -318,7 +318,7 @@ and Series<'K, 'V when 'K : equality>
   /// [category:Appending and joining]
   member series.Join<'V2>(otherSeries:Series<'K, 'V2>, kind, lookup) =
     let restrictToThisIndex (restriction:IIndex<_>) (sourceIndex:IIndex<_>) vector = 
-      if restriction.Ordered && sourceIndex.Ordered then
+      if lookup = Lookup.Exact && restriction.Ordered && sourceIndex.Ordered then
         let min, max = index.KeyRange
         sourceIndex.Builder.GetRange(sourceIndex, Some(min, BoundaryBehavior.Inclusive), Some(max, BoundaryBehavior.Inclusive), vector)
       else sourceIndex, vector

--- a/src/SeriesModule.fs
+++ b/src/SeriesModule.fs
@@ -1007,3 +1007,22 @@ module Series =
   let inline lookupTimeAt start interval dir lookup (series:Series< ^K , ^V >) = 
     let add dt ts = (^K: (static member (+) : ^K * TimeSpan -> ^K) (dt, ts))
     Implementation.lookupTimeInternal add (Some start) interval dir lookup series
+
+
+// ------------------------------------------------------------------------------------------------
+// Appending and joining
+// ------------------------------------------------------------------------------------------------
+  
+  /// [category:Appending and joining]
+  let inline zipAlignInto (op:'V1->'V2->'R) kind lookup (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) : Series<'K, 'R> =
+    let joined = series1.Join(series2, kind, lookup)
+    joined.SelectOptional(fun (KeyValue(_, v)) -> 
+      match v with
+      | OptionalValue.Present(OptionalValue.Present a, OptionalValue.Present b) -> 
+          OptionalValue(op a b)
+      | _ -> OptionalValue.Missing )
+
+  /// [category:Appending and joining]
+  let inline zipInto (op:'V1->'V2->'R) (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) : Series<'K, 'R> =
+    zipAlignInto op JoinKind.Inner Lookup.Exact (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>)
+


### PR DESCRIPTION
Added `zipInto` and `zipAlignInto` for Series and Frame with tests, plus one bug fix (same as issue #30 but for series)

The start of the discussion is here: https://github.com/BlueMountainCapital/FSharp.DataFrame/pull/32#issuecomment-26060404

I think the name of these functions should be  `zipInto` and `zipAlignInto` to avoid confusion with Join/Align methods in the Frame type. First, we keep `Into` convention. Second, `Join` and `Align` have special meaning in the Frame type - they are used to put two frames together side by side, so that the new frame will be wider/taller with previous values after these operations, while 'Zip' merges frames by row and column keys and produces a new frame with is generally narrower and shorter and with transformed values. 

`ZipInto` operation _on series_ makes one series from two and it is very similar to the LINQ Join method as well as to the LINQ Zip method - join and zip here are very close in meaning. `ZipInto` operation _on frames_ takes only columns with same names and applies `Series.zipInto` on each pair of matching columns. `ZipAlignInto` operation on frames is a combination of `ZipInto` and `Align`: it seeks matching column names, applies `Series.zipAlignInto` on each matching series pair and keeps all or some non-matched series untouched (depending on JoinKind for columns).

I have added a number of tests for these functions on series and frames. For frames the tests show a real use case (how to calculate enterprise value for fake companies) and could be a starting point for documentation. I am glad to write documentation on these function after we agree on naming, method signatures, etc.
