### PR TITLE
Remove dependency on FSharp.Data.DesignTime to be able target .NET 4.0 (Fixes #28)

### DIFF
--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -256,7 +256,6 @@ namespace Deedle.Internal
 
 open System
 open System.Linq
-open System.Drawing
 open Deedle
 open System.Collections.Generic
 open System.Collections.ObjectModel

--- a/src/Deedle/Deedle.fsproj
+++ b/src/Deedle/Deedle.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Deedle</RootNamespace>
     <AssemblyName>Deedle</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <Name>Deedle</Name>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -81,8 +81,8 @@
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
-    <Reference Include="FSharp.Data.DesignTime">
-      <HintPath>..\..\packages\FSharp.Data.1.1.10\lib\net40\FSharp.Data.DesignTime.dll</HintPath>
+    <Reference Include="FSharp.Data">
+      <HintPath>..\..\packages\FSharp.Data.1.2.0\lib\net40\FSharp.Data.dll</HintPath>
     </Reference>
     <Reference Include="MathNet.Numerics">
       <HintPath>..\..\packages\MathNet.Numerics.2.6.1\lib\net40\MathNet.Numerics.dll</HintPath>

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -12,7 +12,7 @@ open System.ComponentModel
 open System.Runtime.InteropServices
 open System.Runtime.CompilerServices
 open System.Collections.Generic
-
+open FSharp.Data.Runtime
 open Deedle.Keys
 open Deedle.Vectors 
 
@@ -50,7 +50,7 @@ type Frame =
     use reader = new StreamReader(location)
     FrameUtils.readCsv 
       reader (if hasHeaders.HasValue then Some hasHeaders.Value else None)
-      (Some (not skipTypeInference)) (Some inferRows) (Some schema) "NaN,NA,#N/A,:" 
+      (Some (not skipTypeInference)) (Some inferRows) (Some schema) TextConversions.DefaultMissingValues 
       (if separators = null then None else Some separators) (Some culture)
 
   /// Load data frame from a CSV file. The operation automatically reads column names from the 
@@ -80,7 +80,7 @@ type Frame =
       [<Optional>] schema, [<Optional>] separators, [<Optional>] culture) =
     FrameUtils.readCsv 
       (new StreamReader(stream)) (if hasHeaders.HasValue then Some hasHeaders.Value else None)
-      (Some (not skipTypeInference)) (Some inferRows) (Some schema) "NaN,NA,#N/A,:" 
+      (Some (not skipTypeInference)) (Some inferRows) (Some schema) TextConversions.DefaultMissingValues 
       (if separators = null then None else Some separators) (Some culture)
 
   // ----------------------------------------------------------------------------------------------
@@ -257,7 +257,7 @@ module FSharpFrameExtensions =
     ///    values in the CSV file (such as `"en-US"`). The default is invariant culture. 
     static member ReadCsv(path:string, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators, ?culture) =
       use reader = new StreamReader(path)
-      FrameUtils.readCsv reader hasHeaders inferTypes inferRows schema "NaN,NA,#N/A,:" separators culture
+      FrameUtils.readCsv reader hasHeaders inferTypes inferRows schema TextConversions.DefaultMissingValues separators culture
 
     /// Load data frame from a CSV file. The operation automatically reads column names from the 
     /// CSV file (if they are present) and infers the type of values for each column. Columns
@@ -280,7 +280,7 @@ module FSharpFrameExtensions =
     ///  * `culture` - Specifies the name of the culture that is used when parsing 
     ///    values in the CSV file (such as `"en-US"`). The default is invariant culture. 
     static member ReadCsv(stream:Stream, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators, ?culture) =
-      FrameUtils.readCsv (new StreamReader(stream)) hasHeaders inferTypes inferRows schema "NaN,NA,#N/A,:" separators culture
+      FrameUtils.readCsv (new StreamReader(stream)) hasHeaders inferTypes inferRows schema TextConversions.DefaultMissingValues separators culture
       
     /// Creates a data frame with ordinal Integer index from a sequence of rows.
     /// The column indices of individual rows are unioned, so if a row has fewer

--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -81,15 +81,15 @@ module internal Reflection =
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module internal FrameUtils = 
-  open FSharp.Data
   open System
-  open System.Data
-  open System.IO
   open System.Collections.Generic
+  open System.Data
   open System.Globalization
-  open ProviderImplementation
-  open FSharp.Data.RuntimeImplementation
-  open FSharp.Data.RuntimeImplementation.StructuralTypes
+  open System.IO
+  open FSharp.Data
+  open FSharp.Data.Runtime
+  open FSharp.Data.Runtime.CsvInference
+  open FSharp.Data.Runtime.StructuralTypes
 
   let internal formatter (f:'T -> string) = 
     typeof<'T>, (fun (o:obj) -> f (unbox o))
@@ -228,10 +228,9 @@ module internal FrameUtils =
 
 
   /// Load data from a CSV file using F# Data API
-  let readCsv (reader:TextReader) hasHeaders inferTypes inferRows schema (missingValues:string) separators culture =
+  let readCsv (reader:TextReader) hasHeaders inferTypes inferRows schema (missingValues:string[]) separators culture =
     let schema = defaultArg schema ""
     let schema = if schema = null then "" else schema
-    let missingValuesArr = missingValues.Split(',')
     let inferRows = defaultArg inferRows 0
     let safeMode = false // Irrelevant - all DF values can be missing
     let preferOptionals = true // Ignored
@@ -240,11 +239,12 @@ module internal FrameUtils =
     let cultureInfo = System.Globalization.CultureInfo.GetCultureInfo(culture)
 
     let createVector typ (data:string[]) = 
-      if typ = typeof<bool> then Vector.ofOptionalValues (Array.map (fun s -> Operations.ConvertBoolean(culture, Some(s))) data) :> IVector
-      elif typ = typeof<decimal> then Vector.ofOptionalValues (Array.map (fun s -> Operations.ConvertDecimal(culture, Some(s))) data) :> IVector
-      elif typ = typeof<float> then Vector.ofOptionalValues (Array.map (fun s -> Operations.ConvertFloat(culture, missingValues, Some(s))) data) :> IVector
-      elif typ = typeof<int> then Vector.ofOptionalValues (Array.map (fun s -> Operations.ConvertInteger(culture, Some(s))) data) :> IVector
-      elif typ = typeof<int64> then Vector.ofOptionalValues (Array.map (fun s -> Operations.ConvertInteger64(culture, Some(s))) data) :> IVector
+      let missingValuesStr = String.Join(",", missingValues)
+      if typ = typeof<bool> then Vector.ofOptionalValues (Array.map (fun s -> TextRuntime.ConvertBoolean(culture, Some(s))) data) :> IVector
+      elif typ = typeof<decimal> then Vector.ofOptionalValues (Array.map (fun s -> TextRuntime.ConvertDecimal(culture, Some(s))) data) :> IVector
+      elif typ = typeof<float> then Vector.ofOptionalValues (Array.map (fun s -> TextRuntime.ConvertFloat(culture, missingValuesStr, Some(s))) data) :> IVector
+      elif typ = typeof<int> then Vector.ofOptionalValues (Array.map (fun s -> TextRuntime.ConvertInteger(culture, Some(s))) data) :> IVector
+      elif typ = typeof<int64> then Vector.ofOptionalValues (Array.map (fun s -> TextRuntime.ConvertInteger64(culture, Some(s))) data) :> IVector
       else Vector.ofValues data :> IVector
 
     // If 'inferTypes' is specified (or by default), use the CSV type inference
@@ -254,9 +254,7 @@ module internal FrameUtils =
     let data = Csv.CsvFile.Load(reader, ?separators=separators, ?hasHeaders=hasHeaders)
     let inferedProperties = 
       if not (inferTypes = Some false) then
-        CsvInference.inferType 
-          data inferRows (missingValuesArr, cultureInfo) schema safeMode preferOptionals
-        ||> CsvInference.getFields preferOptionals
+        data.InferColumnTypes(inferRows, missingValues, cultureInfo, schema, safeMode, preferOptionals)
       else 
         if data.Headers.IsNone then failwith "CSV file is missing headers!"
         [ for c in data.Headers.Value -> 

--- a/src/Deedle/packages.config
+++ b/src/Deedle/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FSharp.Charting" version="0.87" targetFramework="net45" />
-  <package id="FSharp.Data" version="1.1.10" targetFramework="net45" />
+  <package id="FSharp.Data" version="1.2.0" targetFramework="net40" />
   <package id="MathNet.Numerics" version="2.6.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
@tpetricek, this needs to wait for FSharp.Data 2.0.0 to be published before being merged
