### PR TITLE
Reading CSV should not ignore the schema parameter

### DIFF
--- a/Deedle.Tests.sln
+++ b/Deedle.Tests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.20827.3
+VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{6D802F6C-A258-4F6B-B1E4-03B24D319126}"
 	ProjectSection(SolutionItems) = preProject

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -67,14 +67,32 @@ let testAll () =
 open Deedle
 
 let testOne() =
-  let d1 = Array.init 1000000 float
-  let d2 = Array.init 1000000 float
+  //let d1 = Array.init 1000000 float
+  //let d2 = Array.init 1000000 float
 
-  for i in 1 .. 5 do
-    timed(fun () -> 
+  let titanic = Frame.ReadCsv(__SOURCE_DIRECTORY__ + @"\..\..\docs\content\data\Titanic.csv")
+  for i in 1 .. 20 do
+    timed(fun () ->
+   
+        let bySex = titanic |> Frame.groupRowsByString "Sex"
+        let survivedBySex = bySex.Columns.["Survived"].As<bool>()
+        let survivals = 
+            survivedBySex
+            |> Series.applyLevel Pair.get1Of2 (fun sr -> 
+                sr.Values |> Seq.countBy id |> series)
+            |> Frame.ofRows
+            |> Frame.indexColsWith ["Survived"; "Died"]
+        survivals?Total <- 
+            bySex
+            |> Frame.applyLevel Pair.get1Of2 Series.countKeys
+        let summary = 
+              [ "Survived (%)" => survivals?Survived / survivals?Total * 100.0
+                "Died (%)" => survivals?Died/ survivals?Total * 100.0 ] |> frame
+
+        ()
       //CSharp.Tests.DynamicFrameTests.CanAddSeriesDynamically()
       //CSharp.Tests.DynamicFrameTests.CanGetSeriesDynamically()
-      Tests.Frame.``Can group 10x5k data frame by row of type string and nest it (in less than a few seconds)``()
+//      Tests.Frame.``Can group 10x5k data frame by row of type string and nest it (in less than a few seconds)``()
 //      Series(d1, d2).[300000.0 .. 600000.0] |> Series.filter (fun k _ -> true) |> Series.mean
 //      |> ignore
 

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -61,6 +61,24 @@ let ``Can read MSFT data from CSV file without header row`` () =
   actual |> shouldEqual expected 
 
 [<Test>]
+let ``Can read MSFT data from CSV with no headers & no type inference``() =
+  let df = Frame.ReadCsv(__SOURCE_DIRECTORY__ + "/data/MSFT.csv", hasHeaders=false, inferTypes=false) 
+  df.RowKeys |> Seq.length |> shouldEqual 6528
+  df.ColumnKeys |> List.ofSeq |> shouldEqual ["Column1"; "Column2"; "Column3"; "Column4"; "Column5"; "Column6"; "Column7"]
+
+[<Test>]
+let ``Can read MSFT data from CSV with explicit schema``() =
+  let df = Frame.ReadCsv(__SOURCE_DIRECTORY__ + "/data/MSFT.csv", schema="A (string),B,C,D,E,F,G (float)") 
+  let actual = List.ofSeq df.ColumnKeys
+  actual |> shouldEqual ["A";"B";"C";"D";"E";"F";"G"]
+
+[<Test>]
+let ``Can read MSFT data from CSV and rename``() =
+  let df = Frame.ReadCsv(__SOURCE_DIRECTORY__ + "/data/MSFT.csv", schema="Day,Adj Close->Adjusted") 
+  let actual = List.ofSeq df.ColumnKeys
+  actual |> shouldEqual ["Day"; "Open"; "High"; "Low"; "Close"; "Volume"; "Adjusted"]
+
+[<Test>]
 let ``Can save MSFT data as CSV file and read it afterwards (with default args)`` () =
   let file = System.IO.Path.GetTempFileName()
   let expected = msft()


### PR DESCRIPTION
Answers this SO question :-)
- http://stackoverflow.com/questions/20674975/deedle-whats-the-schema-format-for-readcsv

Please ignore the changes in `tests/Deedle.Tests.Console/Program.fs` - this is just a file with random code for perf testing (executable console app so that it can be easily profiled).
