### PR TITLE
Implementation of #102

### DIFF
--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -461,6 +461,18 @@ type FrameExtensions =
   static member IndexRowsWith(frame:Frame<'R, 'C>, keys:seq<'TNewRowIndex>) =
     frame |> Frame.indexRowsWith keys
 
+  /// Replace the row index of the frame with a sequence of row keys generated using
+  /// a function invoked on each row.
+  ///
+  /// ## Parameters
+  ///  - `frame` - Source data frame whose row index are to be replaced.
+  ///  - `f` - A function from row (as object series) to new row key value
+  ///
+  /// [category:Data structure manipulation]
+  [<Extension>]
+  static member IndexRowsUsing(frame:Frame<'R, 'C>, f:Func<ObjectSeries<'C>,'R2>) =
+    frame |> Frame.indexRowsUsing f.Invoke
+
   /// Replace the column index of the frame with the provided sequence of column keys.
   /// The columns of the frame are assigned keys according to the current order, or in a
   /// non-deterministic way, if the current column index is not ordered.

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -358,6 +358,18 @@ module Frame =
     let newData = frame.Data.Select(getRange)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData)
 
+  /// Replace the row index of the frame with a sequence of row keys generated using
+  /// a function invoked on each row.
+  ///
+  /// ## Parameters
+  ///  - `frame` - Source data frame whose row index are to be replaced.
+  ///  - `f` - A function from row (as object series) to new row key value
+  ///
+  /// [category:Data structure manipulation]
+  [<CompiledName("IndexRowsUsing")>]
+  let indexRowsUsing (f: ObjectSeries<'C> -> 'R2) (frame:Frame<'R1,'C>) =
+    indexRowsWith (frame.Rows |> Series.map (fun k v -> f v) |> Series.values) frame
+
   /// Returns a transposed data frame. The rows of the original data frame are used as the
   /// columns of the new one (and vice versa). Use this operation if you have a data frame
   /// and you mostly need to access its rows as a series (because accessing columns as a 

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -737,3 +737,20 @@ let ``Can group titanic data by boolean column "Survived"``() =
     |> Series.mapValues Frame.countRows
   actual |> shouldEqual (series [false => 549; true => 342])
 
+  
+// ----------------------------------------------------------------------------------------------
+// Index operations
+// ----------------------------------------------------------------------------------------------
+
+[<Test>]
+let ``Can index rows using transformation function``() =
+  let actual = 
+    Frame.ofColumns [ "A" => series [ 1 => 1.0; 2 => 2.0 ]; 
+                      "B" => series [ 1 => 2.0; 2 => 3.0 ] ]
+    |> Frame.indexRowsUsing (fun r -> r.GetAs<float>("A") + 2.0)
+
+  let expected = 
+    Frame.ofColumns [ "A" => series [ 3.0 => 1.0; 4.0 => 2.0 ]; 
+                      "B" => series [ 3.0 => 2.0; 4.0 => 3.0 ] ]
+
+  actual |> shouldEqual expected


### PR DESCRIPTION
One thing I don't understand. In a bunch of Indexing operations, there is the comment:

  /// The elements of the series are assigned index according to the current order, or in a
  /// non-deterministic way, if the current index is not ordered.

I don't understand the sense in which this might ever be "non-deterministic" depending on current index, but shouldn't it always be according to current order?
