### PR TITLE
Reifed index keys, addresses -> int64

### DIFF
--- a/src/Deedle/Common/Address.fs
+++ b/src/Deedle/Common/Address.fs
@@ -17,41 +17,17 @@
 /// this can be easily extended.
 module Deedle.Addressing
 
-type Address = 
-  | Int of int
-  | Int64 of int64
+type Address = int64
 
 /// ArrayVectors assume that the address is an integer
-let (|IntAddress|) = function
-  | Address.Int n -> n
-  | _ -> failwith "ArrayVectorBuilder: Only int addresses are supported."
+let (|IntAddress|) = function _ : int64 as n -> int n
+let int32Convertor v = int64 v
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Address =
-  let increment = function
-    | Int lo -> Int (lo + 1)
-    | _ -> failwith "Not supported"
-  let decrement = function
-    | Int lo -> Int (lo - 1)
-    | _ -> failwith "Not supported"
-  let generateRange = function
-    | Int lo, Int hi -> 
-        ( if hi < lo then seq { lo .. -1 .. hi } 
-          else seq { lo .. hi } ) |> Seq.map Int
-    | _ -> failwith "Not supported"
-
-  let int32Convertor = 
-    Some(fun v -> Int v)
-
-  let add = function
-    | Int a, Int b -> Int (a + b)
-    | _ -> failwith "Not supported"
-
-  let rangeOf(seq) = 
-    Int 0, Int ((Seq.length seq) - 1)
-
-  let getRange = function 
-    | (seq:_[]), Int lo, Int hi ->
-        if hi >= lo then seq.[lo .. hi]
-        else [| |]
-    | _ -> failwith "Not supported"
+  let increment (x:Address) = (x + 1L)
+  let decrement (x:Address) = (x - 1L)
+  let generateRange (lo:Address, hi:Address) = ( if hi < lo then seq { lo .. -1L .. hi } else seq { lo .. hi } )
+  let add (a:Address, b:Address) = a + b
+  let rangeOf(seq) = 0L, ((Seq.length seq) - 1) |> int64
+  let getRange = function (seq:_[]), IntAddress lo, IntAddress hi -> if hi >= lo then seq.[lo .. hi] else [| |]

--- a/src/Deedle/Deedle.fsproj
+++ b/src/Deedle/Deedle.fsproj
@@ -63,6 +63,7 @@
     <Compile Include="Indices\MultiKey.fs" />
     <Compile Include="Indices\Index.fs" />
     <Compile Include="Indices\LinearIndex.fs" />
+    <Compile Include="Indices\IndexExtensions.fs" />
     <Compile Include="JoinHelpers.fs" />
     <Compile Include="Series.fs" />
     <Compile Include="SeriesModule.fs" />

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -120,8 +120,8 @@ type internal DelayedSource<'K, 'V when 'K : equality>
     ( rangeMin:'K, rangeMax:'K, ranges:Ranges<'K>, 
       loader:DelayedSourceRanges<'K> -> DelayedSourceData<'K, 'V>) =
 
-  static let vectorBuilder = ArrayVector.ArrayVectorBuilder.Instance
-  static let indexBuilder = Linear.LinearIndexBuilder.Instance
+  static let vectorBuilder = VectorBuilder.Instance
+  static let indexBuilder = IndexBuilder.Instance
 
   let comparer = System.Collections.Generic.Comparer<'K>.Default
   let (<) a b = comparer.Compare(a, b) < 0
@@ -211,7 +211,7 @@ and internal DelayedIndexFunction<'K, 'R when 'K : equality> =
 /// index and if it is DelayedIndex, then it uses the `Source` to build a new `Source`
 /// with a restricted range.
 and internal DelayedIndexBuilder() =
-  let builder = Linear.LinearIndexBuilder.Instance
+  let builder = IndexBuilder.Instance
   interface IIndexBuilder with
     member x.Create(keys, ordered) = builder.Create(keys, ordered)
     member x.Aggregate(index, aggregation, vector, selector) = builder.Aggregate(index, aggregation, vector, selector)
@@ -377,5 +377,5 @@ type DelayedSeries =
       ranges |> Array.map (fun (l, h) -> loader l h))
     let index = DelayedIndex(series)
     let vector = DelayedVector(series)
-    let vectorBuilder = ArrayVectorBuilder.Instance
+    let vectorBuilder = VectorBuilder.Instance
     Series<'K, 'V>(index, vector, vectorBuilder, DelayedIndexBuilder())

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -62,8 +62,8 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   let mutable isEmpty = rowIndex.IsEmpty && columnIndex.IsEmpty
 
   /// Vector builder
-  let vectorBuilder = Vectors.ArrayVector.ArrayVectorBuilder.Instance
-  let indexBuilder = Indices.Linear.LinearIndexBuilder.Instance
+  let vectorBuilder = VectorBuilder.Instance
+  let indexBuilder = IndexBuilder.Instance
 
   // TODO: Perhaps assert that the 'data' vector has all things required by column index
   // (to simplify various handling below)
@@ -1105,9 +1105,9 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 /// can confuse the type inference in various ways).
 and FrameUtils = 
   // Current vector builder to be used for creating frames
-  static member vectorBuilder = Vectors.ArrayVector.ArrayVectorBuilder.Instance 
+  static member vectorBuilder = VectorBuilder.Instance 
   // Current index builder to be used for creating frames
-  static member indexBuilder = Indices.Linear.LinearIndexBuilder.Instance
+  static member indexBuilder = IndexBuilder.Instance
 
   /// Create data frame containing a single column
   static member createColumn<'TColumnKey, 'TRowKey when 'TColumnKey : equality and 'TRowKey : equality>
@@ -1118,7 +1118,7 @@ and FrameUtils =
   /// Create data frame containing a single row
   static member createRow(row:'TRowKey, series:Series<'TColumnKey, 'TValue>) = 
     let data = series.Vector.SelectMissing(fun v -> 
-      let res = Vectors.ArrayVector.ArrayVectorBuilder.Instance.CreateMissing [| v |] 
+      let res = VectorBuilder.Instance.CreateMissing [| v |] 
       OptionalValue(res :> IVector))
     Frame(Index.ofKeys [row], series.Index, data)
 

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -459,10 +459,10 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Accessors and slicing]
   member frame.TryGetRowAt(index) = 
-    frame.Rows.Vector.GetValue(Addressing.Int index)
+    frame.Rows.Vector.GetValue(Addressing.int32Convertor index)
   /// [category:Accessors and slicing]
   member frame.GetRowKeyAt(index) = 
-    frame.RowIndex.KeyAt(Addressing.Int index)
+    frame.RowIndex.KeyAt(Addressing.int32Convertor index)
   /// [category:Accessors and slicing]
   member frame.GetRowAt(index) = 
     frame.TryGetRowAt(index).Value

--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -15,8 +15,8 @@ module internal Reflection =
   open System.Collections
   open System.Collections.Generic
 
-  let indexBuilder = Indices.Linear.LinearIndexBuilder.Instance
-  let vectorBuilder = Vectors.ArrayVector.ArrayVectorBuilder.Instance
+  let indexBuilder = IndexBuilder.Instance
+  let vectorBuilder = VectorBuilder.Instance
 
   /// Helper function that creates IVector<'T> and casts it to IVector
   let createTypedVectorHelper<'T> (input:seq<OptionalValue<obj>>) =

--- a/src/Deedle/Indices/IndexExtensions.fs
+++ b/src/Deedle/Indices/IndexExtensions.fs
@@ -1,0 +1,16 @@
+﻿namespace Deedle 
+
+open Deedle.Internal
+open Deedle.Indices
+open Deedle.Indices.Linear
+
+// ------------------------------------------------------------------------------------------------
+// F# friendly operations for creating vectors
+// ------------------------------------------------------------------------------------------------
+
+/// Set concrete IIndexBuilder implementation
+[<AutoOpen>]
+module FSharpIndexBuilderImplementation =
+  type IndexBuilder = 
+    /// Returns concrete implementation for IVectorBuilder
+    static member Instance = Deedle.Indices.Linear.LinearIndexBuilder.Instance

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -198,7 +198,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
       LinearIndex(index.Mappings |> Seq.map fst |> ReadOnlyCollection.ofSeq, LinearIndexBuilder.Instance), newVector
 
   /// Instance of the index builder (specialized to Int32 addresses)
-  static let indexBuilder = LinearIndexBuilder(Vectors.ArrayVector.ArrayVectorBuilder.Instance)
+  static let indexBuilder = LinearIndexBuilder(VectorBuilder.Instance)
   /// Provides a global access to an instance of LinearIndexBuilder
   static member Instance = indexBuilder :> IIndexBuilder
 

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -14,12 +14,13 @@ open Deedle.Addressing
 open Deedle.Internal
 open Deedle.Indices
 open System.Diagnostics
+open System.Collections.ObjectModel
 
 /// An index that maps keys `K` to offsets `Address`. The keys cannot be duplicated.
 /// The construction checks if the keys are ordered (using the provided or the default
 /// comparer for `K`) and disallows certain operations on unordered indices.
 type LinearIndex<'K when 'K : equality> 
-  internal (keys:seq<'K>, builder, ?ordered) =
+  internal (keys:ReadOnlyCollection<'K>, builder, ?ordered) =
 
   // Build a lookup table etc.
   let comparer = Comparer<'K>.Default
@@ -47,15 +48,20 @@ type LinearIndex<'K when 'K : equality>
   let keysArray = lazy Array.ofSeq keys
   let keysArrayRev = lazy (Array.ofSeq keys |> Array.rev)
 
-  let lookup = Dictionary<'K, Address>()
-  let addresses = Address.generateRange(Address.rangeOf(keys))
-  let mappings = Seq.zip keys addresses
-  do for k, v in mappings do 
-       match lookup.TryGetValue(k) with
-       | true, list -> 
+  let makeLookup () = 
+    let dict = Dictionary<'K, Address>()
+    let mutable idx = 0L
+    do for k in keys do 
+        match dict.TryGetValue(k) with
+        | true, list -> 
           let info = sprintf "Duplicate key '%A'. Duplicate keys are not allowed in the index." k
           invalidArg "keys" info
-       | _ -> lookup.[k] <- v  
+        | _ -> 
+          dict.[k] <- idx  
+          idx <- idx + 1L
+    dict
+
+  let lookup = lazy makeLookup()
 
   /// Exposes keys array for use in the index builder
   member internal index.KeysArray = keysArray
@@ -64,16 +70,16 @@ type LinearIndex<'K when 'K : equality>
   override index.Equals(another) = 
     match another with
     | null -> false
-    | :? IIndex<'K> as another -> Seq.structuralEquals mappings another.Mappings
+    | :? IIndex<'K> as another -> Seq.structuralEquals keys another.Keys
     | _ -> false
 
   /// Implement structural hashing against another index
   override index.GetHashCode() =
-    mappings |> Seq.structuralHash
+    keys |> Seq.structuralHash
 
   interface IIndex<'K> with
-    member x.Keys = keys
-    member x.KeyCount = int64 lookup.Count
+    member x.Keys = seq { for k in keys -> k }
+    member x.KeyCount = int64 keys.Count
     member x.Builder = builder
 
     /// Perform reverse lookup and return key for an address
@@ -90,7 +96,7 @@ type LinearIndex<'K when 'K : equality>
     /// Get the address for the specified key.
     /// The 'semantics' specifies fancy lookup methods.
     member x.Lookup(key, semantics, check) = 
-      match lookup.TryGetValue(key), semantics, Some Addressing.int32Convertor with
+      match lookup.Value.TryGetValue(key), semantics, Some Addressing.int32Convertor with
 
       // When the value exists directly and the user requires exact match, we 
       // just return it (ignoring the fact that Vector value may be missing)
@@ -148,7 +154,7 @@ type LinearIndex<'K when 'K : equality>
       | _ -> OptionalValue.Missing
 
     /// Returns all mappings of the index (key -> address) 
-    member x.Mappings = mappings
+    member x.Mappings = keys |> Seq.mapi (fun i k -> k, Addressing.int32Convertor i)
     /// Returns the range used by the index
     member x.Range = Address.rangeOf(keys)
     /// Are the keys of the index ordered?
@@ -169,7 +175,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
   /// and apply the transformations on two specified vector constructors
   let returnUsingAlignedSequence joined vector1 vector2 ordered : (IIndex<_> * _ * _) = 
     // Create a new index using the sorted keys
-    let newIndex = LinearIndex<_>(seq { for k, _, _ in joined -> k}, LinearIndexBuilder.Instance, ?ordered=ordered)
+    let newIndex = LinearIndex<_>(seq { for k, _, _ in joined -> k} |> ReadOnlyCollection.ofSeq, LinearIndexBuilder.Instance, ?ordered=ordered)
     let range = (newIndex :> IIndex<_>).Range
 
     // Create relocation transformations for both vectors
@@ -189,7 +195,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
     | _ ->
       let relocs = index.Mappings |> Seq.mapi (fun i (k, a) -> Addressing.int32Convertor i, a)
       let newVector = Vectors.Relocate(vector, Address.rangeOf(index.Mappings), relocs)
-      LinearIndex(index.Mappings |> Seq.map fst, LinearIndexBuilder.Instance), newVector
+      LinearIndex(index.Mappings |> Seq.map fst |> ReadOnlyCollection.ofSeq, LinearIndexBuilder.Instance), newVector
 
   /// Instance of the index builder (specialized to Int32 addresses)
   static let indexBuilder = LinearIndexBuilder(Vectors.ArrayVector.ArrayVectorBuilder.Instance)
@@ -204,7 +210,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
 
     /// Create an index from the specified data
     member builder.Create<'K when 'K : equality>(keys, ordered) = 
-      upcast LinearIndex<'K>(keys, builder, ?ordered=ordered)
+      upcast LinearIndex<'K>(ReadOnlyCollection.ofSeq keys, builder, ?ordered=ordered)
 
     /// Aggregate ordered index
     member builder.Aggregate<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality>
@@ -288,7 +294,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
     member builder.OrderIndex( (index, vector) ) =
       let keys = Array.ofSeq index.Keys
       Array.sortInPlaceWith (fun a b -> index.Comparer.Compare(a, b)) keys
-      let newIndex = LinearIndex(keys, builder, true) :> IIndex<_>
+      let newIndex = LinearIndex(ReadOnlyCollection.ofArray keys, builder, true) :> IIndex<_>
       let relocations = 
         seq { for key, oldAddress in index.Mappings ->
                 let newAddress = newIndex.Lookup(key, Lookup.Exact, fun _ -> true) 
@@ -346,7 +352,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
              let newKey = f oldAddress
              if newKey.HasValue then yield newKey.Value, oldAddress |]
       
-      let newIndex = LinearIndex<'TNewKey>(Seq.map fst newKeys, builder)
+      let newIndex = LinearIndex<'TNewKey>(Seq.map fst newKeys |> ReadOnlyCollection.ofSeq, builder)
       let newRange = (newIndex :> IIndex<_>).Range
       let relocations = Seq.zip (Address.generateRange(newRange)) (Seq.map snd newKeys)
       upcast newIndex, Vectors.Relocate(vector, newRange, relocations)
@@ -367,7 +373,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
              if searchKey.Matches(key) then yield addr, key |]
       let range = Address.rangeOf(matching)
       let relocs = Seq.zip (Address.generateRange(range)) (Seq.map fst matching)
-      let newIndex = LinearIndex<_>(Seq.map snd matching, builder, index.IsOrdered)
+      let newIndex = LinearIndex<_>(Seq.map snd matching |> ReadOnlyCollection.ofSeq, builder, index.IsOrdered)
       let newVector = Vectors.Relocate(vector, range, relocs)
       upcast newIndex, newVector
 
@@ -378,7 +384,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
       | OptionalValue.Present(addr) ->
           let newVector = Vectors.DropRange(vector, (snd addr, snd addr))
           let newKeys = index.Keys |> Seq.filter ((<>) key)
-          let newIndex = LinearIndex<_>(newKeys, builder, index.IsOrdered)
+          let newIndex = LinearIndex<_>(newKeys |> ReadOnlyCollection.ofSeq, builder, index.IsOrdered)
           upcast newIndex, newVector
       | _ ->
           invalidArg "key" (sprintf "The key '%O' is not present in the index." key)
@@ -409,8 +415,8 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
 
           let newKeys = Address.getRange(index.KeysArray.Value, lo, hi) |> Array.ofSeq
           let newVector = Vectors.GetRange(vector, (lo, hi))
-          upcast LinearIndex<_>(newKeys, builder, (index :> IIndex<_>).IsOrdered), newVector
-      | _ -> upcast LinearIndex<_>([], builder, index.IsOrdered), Vectors.Empty
+          upcast LinearIndex<_>(ReadOnlyCollection.ofArray newKeys, builder, (index :> IIndex<_>).IsOrdered), newVector
+      | _ -> upcast LinearIndex<_>(ReadOnlyCollection.ofArray [||], builder, index.IsOrdered), Vectors.Empty
 
 // --------------------------------------------------------------------------------------
 // Functions for creatin linear indices

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -77,10 +77,7 @@ type LinearIndex<'K when 'K : equality>
     member x.Builder = builder
 
     /// Perform reverse lookup and return key for an address
-    member x.KeyAt(address) =
-      match address with 
-      | Address.Int i -> keysArray.Value.[i]
-      | _ -> invalidOp "This type of index does not support reverse lookup"
+    member x.KeyAt(Addressing.IntAddress address) = keysArray.Value.[address]
 
     /// Returns whether the specified index is empty
     member x.IsEmpty = keys |> Seq.isEmpty
@@ -93,7 +90,7 @@ type LinearIndex<'K when 'K : equality>
     /// Get the address for the specified key.
     /// The 'semantics' specifies fancy lookup methods.
     member x.Lookup(key, semantics, check) = 
-      match lookup.TryGetValue(key), semantics, Address.int32Convertor with
+      match lookup.TryGetValue(key), semantics, Some Addressing.int32Convertor with
 
       // When the value exists directly and the user requires exact match, we 
       // just return it (ignoring the fact that Vector value may be missing)
@@ -190,7 +187,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
     match index with
     | :? LinearIndex<_> as lin -> lin, vector
     | _ ->
-      let relocs = index.Mappings |> Seq.mapi (fun i (k, a) -> Address.Int i, a)
+      let relocs = index.Mappings |> Seq.mapi (fun i (k, a) -> Addressing.int32Convertor i, a)
       let newVector = Vectors.Relocate(vector, Address.rangeOf(index.Mappings), relocs)
       LinearIndex(index.Mappings |> Seq.map fst, LinearIndexBuilder.Instance), newVector
 

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -242,10 +242,10 @@ and
   ///
   /// [category:Accessors and slicing]
   member x.TryGetAt(index) = 
-    x.Vector.GetValue(Addressing.Int index)
+    x.Vector.GetValue(Addressing.int32Convertor index)
   /// [category:Accessors and slicing]
   member x.GetKeyAt(index) = 
-    x.Index.KeyAt(Addressing.Int index)
+    x.Index.KeyAt(Addressing.int32Convertor index)
   /// [category:Accessors and slicing]
   member x.GetAt(index) = 
     x.TryGetAt(index).Value

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -875,8 +875,8 @@ and
     Series(pairs |> Seq.map (fun kvp -> kvp.Key), pairs |> Seq.map (fun kvp -> kvp.Value))
 
   new(keys:seq<_>, values:seq<_>) = 
-    let vectorBuilder = Vectors.ArrayVector.ArrayVectorBuilder.Instance
-    let indexBuilder = Indices.Linear.LinearIndexBuilder.Instance
+    let vectorBuilder = VectorBuilder.Instance
+    let indexBuilder = IndexBuilder.Instance
     Series( Index.ofKeys keys, vectorBuilder.Create (Array.ofSeq values),
             vectorBuilder, indexBuilder )
 

--- a/src/Deedle/SeriesExtensions.fs
+++ b/src/Deedle/SeriesExtensions.fs
@@ -45,8 +45,8 @@ type EnumerableExtensions =
 
 type internal Series =
   /// Vector & index builders
-  static member internal vectorBuilder = Vectors.ArrayVector.ArrayVectorBuilder.Instance
-  static member internal indexBuilder = Indices.Linear.LinearIndexBuilder.Instance
+  static member internal vectorBuilder = VectorBuilder.Instance
+  static member internal indexBuilder = IndexBuilder.Instance
 
   static member internal Create(data:seq<'V>) =
     let lookup = data |> Seq.mapi (fun i _ -> i)

--- a/src/Deedle/Vectors/VectorExtensions.fs
+++ b/src/Deedle/Vectors/VectorExtensions.fs
@@ -5,8 +5,15 @@ open Deedle.Vectors
 open Deedle.Vectors.ArrayVector
 
 // ------------------------------------------------------------------------------------------------
-// F# frienly operations for creating vectors
+// F# friendly operations for creating vectors
 // ------------------------------------------------------------------------------------------------
+
+/// Set concrete IVectorBuilder implementation
+[<AutoOpen>]
+module FSharpVectorBuilderImplementation =
+  type VectorBuilder = 
+    /// Returns concrete implementation for IVectorBuilder
+    static member Instance = ArrayVectorBuilder.Instance
 
 /// Defines non-generic `Vector` type that provides functions for building vectors
 /// (hard-bound to `ArrayVectorBuilder` type). In F#, the module is automatically opened
@@ -22,23 +29,23 @@ module FSharpVectorExtensions =
     /// Creates a vector that stores the specified data in an array.
     /// Values such as `null` and `Double.NaN` are turned into missing values.
     static member inline ofValues<'T>(data:'T[]) = 
-      ArrayVectorBuilder.Instance.Create(data)
+      VectorBuilder.Instance.Create(data)
 
     /// Creates a vector that stores the specified data in an array.
     /// Values such as `null` and `Double.NaN` are turned into missing values.
     static member inline ofValues<'T>(data:seq<'T>) = 
-      ArrayVectorBuilder.Instance.Create(Array.ofSeq data)
+      VectorBuilder.Instance.Create(Array.ofSeq data)
 
     /// Creates a vector that stores the specified data in an array.
     /// Missing values can be specified explicitly as `None`, but other values 
     /// such as `null` and `Double.NaN` are turned into missing values too.
     static member inline ofOptionalValues<'T>(data:seq<option<'T>>) = 
-      ArrayVectorBuilder.Instance.CreateMissing(data |> Seq.map OptionalValue.ofOption |> Array.ofSeq)
+      VectorBuilder.Instance.CreateMissing(data |> Seq.map OptionalValue.ofOption |> Array.ofSeq)
 
     /// Missing values can be specified explicitly as `OptionalValue.Missing`, but 
     /// other values such as `null` and `Double.NaN` are turned into missing values too.
     static member inline ofOptionalValues<'T>(data:seq<OptionalValue<'T>>) = 
-      ArrayVectorBuilder.Instance.CreateMissing(data |> Array.ofSeq)
+      VectorBuilder.Instance.CreateMissing(data |> Array.ofSeq)
 
 // ------------------------------------------------------------------------------------------------
 // C# frienly operations for creating vectors
@@ -55,22 +62,22 @@ type Vector =
   /// Values such as `null` and `Double.NaN` are turned into missing values.
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member inline Create<'T>(data:'T[]) = 
-    ArrayVectorBuilder.Instance.Create(data)
+    VectorBuilder.Instance.Create(data)
 
   /// Creates a vector that stores the specified data in an array.
   /// Values such as `null` and `Double.NaN` are turned into missing values.
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member inline Create<'T>(data:seq<'T>) = 
-    ArrayVectorBuilder.Instance.Create(Array.ofSeq data)
+    VectorBuilder.Instance.Create(Array.ofSeq data)
 
   /// Creates a vector that stores the specified data in an array.
   /// Values such as `null` and `Double.NaN` are turned into missing values.
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member inline CreateMissing<'T>(data:seq<OptionalValue<'T>>) = 
-    ArrayVectorBuilder.Instance.CreateMissing(data |> Array.ofSeq)
+    VectorBuilder.Instance.CreateMissing(data |> Array.ofSeq)
 
   /// Creates a vector that stores the specified data in an array.
   /// Values such as `null` and `Double.NaN` are turned into missing values.
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member inline CreateMissing(data:seq<System.Nullable<'T>>) = 
-    ArrayVectorBuilder.Instance.CreateMissing(data |> Array.ofSeq |> Array.map OptionalValue.ofNullable)
+    VectorBuilder.Instance.CreateMissing(data |> Array.ofSeq |> Array.map OptionalValue.ofNullable)

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -87,7 +87,7 @@ let ``Series with different data are not considered equal``() =
 [<Test>] 
 let ``Should throw useful message when there are duplicate keys`` () =
   let actual =
-    try let s = series [ 42 => "A"; 42 => "B" ] in ""
+    try let s = series [ 42 => "A"; 42 => "B" ] in s.Get(42)
     with e -> e.Message
   actual |> should contain "42"
 


### PR DESCRIPTION
This addresses a few to-dos
- make address int64 based
- make LinearIndex use ReadOnlyCollection (eager evaluation of keys)
- consolidate definition of VectorBuilder / IndexBuilder
