### PR TITLE
A few additions to the mainline version

### DIFF
--- a/docs/content/features.fsx
+++ b/docs/content/features.fsx
@@ -670,6 +670,61 @@ were omitted):
       2  ->  76    88        
       3  ->  67    286      
                   
+
+<a name="pivot"></a>
+Summarizing data with pivot table
+---------------------------------
+
+In the previous section, we looked at grouping, which is a very general 
+data manipulation operation. However, very often we want to perform two operations
+at the same time - group the data by certain keys and produce an aggregate. This
+combination is captured by the concept of a _pivot table_. 
+
+A pivot table is a useful tool if you want to summarize data in the frame based
+on two keys that are available in the rows of the data frame. 
+
+For example, given the titanic data set that [we loaded earlier](#creating-csv) and
+explored in the previous section, we might want to compare the survival rate for males 
+and females. The pivot table makes this possible using just a single call:
+*)
+titanic 
+|> Frame.pivotTable 
+    // Returns a new row key
+    (fun k r -> r.GetAs<string>("Sex")) 
+    // Returns a new column key
+    (fun k r -> r.GetAs<bool>("Survived")) 
+    // Specifies aggregation for sub-frames
+    Frame.countRows 
+(**
+The `pivotTable` function (and the corresponding `PivotTable` method) take three arguments.
+The first two specify functions that, given a row in the original frame, return a new
+row key and column key, respectively. In the above example, the new row key is
+the `Sex` value and the new column key is whether a person survived or not. As a result
+we get the following two by two table:
+
+              False True
+    male   -> 468   109      
+    female -> 81    233      
+
+The pivot table operation takes the source frame, partitions the data (rows) based on the 
+new row and column keys and then aggregates each frame using the specified aggregation. In the
+above example, we used `Frame.countRows` to simply return number of people in each sub-group.
+However, we could easily calculate other statistic - such as average age:
+*) 
+titanic 
+|> Frame.pivotTable 
+    (fun k r -> r.GetAs<string>("Sex")) 
+    (fun k r -> r.GetAs<bool>("Survived")) 
+    (fun frame -> frame?Age |> Series.mean)
+|> round
+(**
+The results suggest that older males were less likely survive than younger males, but 
+older females were more likely to survive then younger females:
+
+              False True 
+    male   -> 32    27   
+    female -> 25    29   
+
 <a name="indexing"></a>
 Hierarchical indexing
 ---------------------

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -76,6 +76,7 @@
                 <li><a href="@Root/features.html#dataframe">Frame manipulation</a></li>
                 <li><a href="@Root/features.html#slicing">Advanced slicing</a></li>
                 <li><a href="@Root/features.html#grouping">Grouping data</a></li>
+                <li><a href="@Root/features.html#pivot">Pivot table</a></li>
                 <li><a href="@Root/features.html#indexing">Hierarchical indexing</a></li>
                 <li><a href="@Root/features.html#missing">Missing values</a></li>
               </ul>

--- a/src/Deedle/Common/Address.fs
+++ b/src/Deedle/Common/Address.fs
@@ -1,33 +1,19 @@
 ﻿/// An `Address` value is used as an interface between vectors and indices. The index maps
 /// keys of various types to address, which is then used to get a value from the vector.
-/// 
-/// ## Details
-///
-/// In the most common case, the address will be `int` (and can represent index in an array),
-/// but it is possible to imagine other addresses - `int64` could be used with arrays of 
-/// arrays (to handle very large data). A lazily loaded vector might use something completely
-/// different (perhaps a date?). In principle this should be generic, but that is hard to do - 
-/// we want something like:
-///
-///     Series.Create : \forall 'TKey, 'TValue. \exists 'TAddress. 
-///       Index<'TKey, 'TAddress> * Vector<'TAddress, 'TValue> -> Series<'TKey, 'TValue>
-///
-/// The .NET encoding of this is a bit ugly. So instead, we just have `Address` which currently
-/// supports `Int` and `Int64`, but we keep all operations in the `Address` module, so that
-/// this can be easily extended.
+/// In the current implementation, the address is just `int64`, but most address-related
+/// functionality is in a separate module to make this easy to change.
 module Deedle.Addressing
 
+/// Represents a type used for addressing values in a vector
 type Address = int64
-
-/// ArrayVectors assume that the address is an integer
-let (|IntAddress|) = function _ : int64 as n -> int n
-let int32Convertor v = int64 v
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Address =
-  let increment (x:Address) = (x + 1L)
-  let decrement (x:Address) = (x - 1L)
-  let generateRange (lo:Address, hi:Address) = ( if hi < lo then seq { lo .. -1L .. hi } else seq { lo .. hi } )
-  let add (a:Address, b:Address) = a + b
-  let rangeOf(seq) = 0L, ((Seq.length seq) - 1) |> int64
-  let getRange = function (seq:_[]), IntAddress lo, IntAddress hi -> if hi >= lo then seq.[lo .. hi] else [| |]
+  let zero = 0L
+  let inline asInt (x:Address) = int x
+  let inline ofInt (x:int) : Address = int64 x
+  let inline ofInt64 (x:int64) : Address = x
+  let inline increment (x:Address) = (x + 1L)
+  let inline decrement (x:Address) = (x - 1L)
+  let generateRange (lo:Address, hi:Address) = 
+    if hi < lo then seq { lo .. -1L .. hi } else seq { lo .. hi }

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -705,7 +705,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Series operations]
   member frame.TryGetSeries<'R>(column:'TColumnKey, lookup) =
-    frame.tryGetColVector(column, lookup, fun _ -> true) 
+    tryGetColVector(column, lookup, fun _ -> true) 
     |> OptionalValue.map (fun v -> Series.Create(rowIndex, changeType<'R> v))
 
   /// [category:Series operations]

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -6,6 +6,7 @@
 
 open Deedle
 open Deedle.Keys
+open Deedle.Addressing
 open Deedle.Internal
 open Deedle.Indices
 open Deedle.Vectors
@@ -459,10 +460,10 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Accessors and slicing]
   member frame.TryGetRowAt(index) = 
-    frame.Rows.Vector.GetValue(Addressing.int32Convertor index)
+    frame.Rows.Vector.GetValue(Address.ofInt index)
   /// [category:Accessors and slicing]
   member frame.GetRowKeyAt(index) = 
-    frame.RowIndex.KeyAt(Addressing.int32Convertor index)
+    frame.RowIndex.KeyAt(Address.ofInt index)
   /// [category:Accessors and slicing]
   member frame.GetRowAt(index) = 
     frame.TryGetRowAt(index).Value

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -98,7 +98,9 @@ module Frame =
   /// [category:Accessing frame data and lookup]
   [<CompiledName("TryLookupColObservation")>]
   let tryLookupColObservation column lookup (frame:Frame<'R, 'C>) = 
-    frame.TryGetSeriesObservation(column, lookup) |> OptionalValue.asOption |> Option.map (fun kvp -> kvp.Key, kvp.Value)
+    frame.TryGetSeriesObservation(column, lookup) 
+    |> OptionalValue.asOption 
+    |> Option.map (fun kvp -> kvp.Key, kvp.Value)
 
   /// Returns a specified row from a data frame. If the data frame has 
   /// ordered row index, the lookup semantics can be used to get row with 

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -43,20 +43,15 @@ type LinearIndex<'K when 'K : equality>
             with _ -> false
     | _ -> false )
 
-  // These are used for NearestSmaller/NearestGreater lookup and 
-  // might not work for big data sets...
-  let keysArray = lazy Array.ofSeq keys
-  let keysArrayRev = lazy (Array.ofSeq keys |> Array.rev)
-
   let makeLookup () = 
     let dict = Dictionary<'K, Address>()
     let mutable idx = 0L
-    do for k in keys do 
-        match dict.TryGetValue(k) with
-        | true, list -> 
+    for k in keys do 
+      match dict.TryGetValue(k) with
+      | true, list -> 
           let info = sprintf "Duplicate key '%A'. Duplicate keys are not allowed in the index." k
           invalidArg "keys" info
-        | _ -> 
+      | _ -> 
           dict.[k] <- idx  
           idx <- idx + 1L
     dict
@@ -64,7 +59,7 @@ type LinearIndex<'K when 'K : equality>
   let lookup = lazy makeLookup()
 
   /// Exposes keys array for use in the index builder
-  member internal index.KeysArray = keysArray
+  member internal index.KeyCollection = keys
 
   /// Implements structural equality check against another index
   override index.Equals(another) = 
@@ -83,7 +78,7 @@ type LinearIndex<'K when 'K : equality>
     member x.Builder = builder
 
     /// Perform reverse lookup and return key for an address
-    member x.KeyAt(Addressing.IntAddress address) = keysArray.Value.[address]
+    member x.KeyAt(address) = keys.[Address.asInt address]
 
     /// Returns whether the specified index is empty
     member x.IsEmpty = keys |> Seq.isEmpty
@@ -91,72 +86,50 @@ type LinearIndex<'K when 'K : equality>
     /// Returns the range of keys - makes sense only for ordered index
     member x.KeyRange = 
       if not ordered.Value then invalidOp "KeyRange is not supported for unordered index."
-      Seq.head keys, Seq.head keysArrayRev.Value
+      keys.[0], keys.[keys.Count - 1]
 
     /// Get the address for the specified key.
     /// The 'semantics' specifies fancy lookup methods.
     member x.Lookup(key, semantics, check) = 
-      match lookup.Value.TryGetValue(key), semantics, Some Addressing.int32Convertor with
+      match lookup.Value.TryGetValue(key), semantics with
 
       // When the value exists directly and the user requires exact match, we 
       // just return it (ignoring the fact that Vector value may be missing)
-      | (true, res), Lookup.Exact, _ -> OptionalValue((key, res))
+      | (true, res), Lookup.Exact -> OptionalValue((key, res))
       // otherwise, only return it if there is associated value
-      | (true, res), _, _ when check res -> OptionalValue((key, res))
+      | (true, res), _ when check res -> OptionalValue((key, res))
       // if we find it, but 'check' does not like it & we're looking for exact, we return missing
-      | (true, _), Lookup.Exact, _ -> OptionalValue.Missing
+      | (true, _), Lookup.Exact -> OptionalValue.Missing
 
       // If we can convert array index to address, we can use binary search!
       // (Find the index & generate all previous/next indices so that we can 'check' them)
-      | _, Lookup.NearestSmaller, Some asAddr when ordered.Value ->
-          let addrOpt = Array.binarySearchNearestSmaller key comparer keysArray.Value
+      | _, Lookup.NearestSmaller when ordered.Value ->
+          let addrOpt = Array.binarySearchNearestSmaller key comparer keys
           let indices = addrOpt |> Option.map (fun v -> seq { v .. -1 .. 0 })
           let indices = defaultArg indices Seq.empty
           indices 
-          |> Seq.filter (asAddr >> check)
+          |> Seq.filter (Address.ofInt >> check)
           |> Seq.headOrNone
           |> OptionalValue.ofOption
-          |> OptionalValue.map (fun idx -> keysArray.Value.[idx], asAddr idx)
+          |> OptionalValue.map (fun idx -> keys.[idx], Address.ofInt idx)
 
-      | _, Lookup.NearestGreater, Some asAddr when ordered.Value ->
-          let addrOpt = Array.binarySearchNearestGreater key comparer keysArray.Value
-          let indices = addrOpt |> Option.map (fun v -> seq { v .. keysArray.Value.Length - 1 })
+      | _, Lookup.NearestGreater when ordered.Value ->
+          let addrOpt = Array.binarySearchNearestGreater key comparer keys
+          let indices = addrOpt |> Option.map (fun v -> seq { v .. keys.Count - 1 })
           let indices = defaultArg indices Seq.empty
           indices 
-          |> Seq.filter (asAddr >> check)
+          |> Seq.filter (Address.ofInt >> check)
           |> Seq.headOrNone
           |> OptionalValue.ofOption
-          |> OptionalValue.map (fun idx -> keysArray.Value.[idx], asAddr idx)
-
-      // When we cannot convert array index to address, we have to use sequential search...
-      //
-      // Find the index of the first key that is greater than the one specified
-      // (generate address range and find the address using 'skipWhile')
-      | _, Lookup.NearestGreater, None when ordered.Value ->
-          Seq.zip keysArray.Value (Address.generateRange(Address.rangeOf(keys)))
-          |> Seq.skipWhile (fun (k, _) -> comparer.Compare(k, key) < 0) 
-          |> Seq.filter (snd >> check)
-          |> Seq.headOrNone
-          |> OptionalValue.ofOption
-
-      // Find the index of the last key before the specified one
-      // (generate address range prefixed with None, find the first greater key
-      // and then return the previous address from the prefixed sequence)
-      | _, Lookup.NearestSmaller, None when ordered.Value ->
-          let lo, hi = Address.rangeOf(keys)
-          Seq.zip keysArrayRev.Value (Address.generateRange(hi, lo))
-          |> Seq.skipWhile (fun (k, _) -> comparer.Compare(k, key) > 0) 
-          |> Seq.filter (snd >> check)
-          |> Seq.headOrNone
-          |> OptionalValue.ofOption
+          |> OptionalValue.map (fun idx -> keys.[idx], Address.ofInt idx)
 
       // If we did not find the key (or when we're unsorted & user wants fancy semantics), fail
       | _ -> OptionalValue.Missing
 
     /// Returns all mappings of the index (key -> address) 
-    member x.Mappings = keys |> Seq.mapi (fun i k -> k, Addressing.int32Convertor i)
+    member x.Mappings = keys |> Seq.mapi (fun i k -> k, Address.ofInt i)
     /// Returns the range used by the index
-    member x.Range = Address.rangeOf(keys)
+    member x.Range = Address.zero, Address.ofInt keys.Count
     /// Are the keys of the index ordered?
     member x.IsOrdered = ordered.Value
     member x.Comparer = comparer
@@ -193,8 +166,9 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
     match index with
     | :? LinearIndex<_> as lin -> lin, vector
     | _ ->
-      let relocs = index.Mappings |> Seq.mapi (fun i (k, a) -> Addressing.int32Convertor i, a)
-      let newVector = Vectors.Relocate(vector, Address.rangeOf(index.Mappings), relocs)
+      let relocs = index.Mappings |> Seq.mapi (fun i (k, a) -> Address.ofInt i, a)
+      let range = Address.zero, Address.ofInt64 (index.KeyCount - 1L)
+      let newVector = Vectors.Relocate(vector, range, relocs)
       LinearIndex(index.Mappings |> Seq.map fst |> ReadOnlyCollection.ofSeq, LinearIndexBuilder.Instance), newVector
 
   /// Instance of the index builder (specialized to Int32 addresses)
@@ -251,11 +225,12 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
           if k.HasValue then Some(k.Value, v) else None)
         windows 
         |> Seq.map (fun (key, win) ->
+          let winRange = Address.ofInt 0, Address.ofInt (Seq.length win - 1)
           let relocations = 
-            seq { for k, newAddr in Seq.zip win (Address.generateRange(Address.rangeOf(win))) -> 
+            seq { for k, newAddr in Seq.zip win (Address.generateRange(winRange)) -> 
                     newAddr, index.Lookup(k, Lookup.Exact, fun _ -> true).Value |> snd }
           let newIndex = builder.Create(win, None)
-          key, (newIndex, Vectors.Relocate(vector, Address.rangeOf(win), relocations)))
+          key, (newIndex, Vectors.Relocate(vector, winRange, relocations)))
         |> Array.ofSeq
 
       /// Build a new index & vector by applying value selector
@@ -277,11 +252,12 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
         let windows = index.Keys |> Seq.chunkedUsing index.Comparer dir keys 
         windows 
         |> Seq.map (fun (key, win) ->
+          let winRange = Address.ofInt 0, Address.ofInt (Seq.length win - 1)
           let relocations = 
-            seq { for k, newAddr in Seq.zip win (Address.generateRange(Address.rangeOf(win))) -> 
+            seq { for k, newAddr in Seq.zip win (Address.generateRange(winRange)) -> 
                     newAddr, index.Lookup(k, Lookup.Exact, fun _ -> true).Value |> snd }
           let newIndex = builder.Create(win, None)
-          key, (newIndex, Vectors.Relocate(vector, Address.rangeOf(win), relocations)))
+          key, (newIndex, Vectors.Relocate(vector, winRange, relocations)))
         |> Array.ofSeq
 
       /// Build a new index & vector by applying value selector
@@ -372,7 +348,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
       let matching = 
         [| for key, addr in index.Mappings do
              if searchKey.Matches(key) then yield addr, key |]
-      let range = Address.rangeOf(matching)
+      let range = Address.ofInt 0, Address.ofInt (matching.Length - 1)
       let relocs = Seq.zip (Address.generateRange(range)) (Seq.map fst matching)
       let newIndex = LinearIndex<_>(Seq.map snd matching |> ReadOnlyCollection.ofSeq, builder, index.IsOrdered)
       let newVector = Vectors.Relocate(vector, range, relocs)
@@ -396,13 +372,13 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
     member builder.GetRange<'K when 'K : equality >
         (index:IIndex<'K>, lo, hi, vector) =
       // Default values are specified by the entire range
-      let defaults = lazy Address.rangeOf(index.Keys)
+      let defaults = Address.zero, Address.ofInt64 index.KeyCount
       let getBound offs semantics proj = 
         let (|Lookup|_|) x = 
           match index.Lookup(x, semantics, fun _ -> true) with 
           | OptionalValue.Present(_, v) -> Some v | _ -> None
         match offs with 
-        | None -> Some(proj defaults.Value, BoundaryBehavior.Inclusive)
+        | None -> Some(proj defaults, BoundaryBehavior.Inclusive)
         | Some (Lookup i, bound) -> Some(i, bound)
         | _ -> None
 
@@ -413,10 +389,11 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
           let hi = if snd hi = BoundaryBehavior.Exclusive then Address.decrement (fst hi) else fst hi
 
           let index, vector = asLinearIndex index vector 
-
-          let newKeys = Address.getRange(index.KeysArray.Value, lo, hi) |> Array.ofSeq
+          let newKeys = 
+            let lo, hi = Address.asInt lo, Address.asInt hi
+            if hi >= lo then index.KeyCollection.[lo .. hi] else ReadOnlyCollection.empty
           let newVector = Vectors.GetRange(vector, (lo, hi))
-          upcast LinearIndex<_>(ReadOnlyCollection.ofArray newKeys, builder, (index :> IIndex<_>).IsOrdered), newVector
+          upcast LinearIndex<_>(newKeys, builder, (index :> IIndex<_>).IsOrdered), newVector
       | _ -> upcast LinearIndex<_>(ReadOnlyCollection.ofArray [||], builder, index.IsOrdered), Vectors.Empty
 
 // --------------------------------------------------------------------------------------

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -129,7 +129,7 @@ type LinearIndex<'K when 'K : equality>
     /// Returns all mappings of the index (key -> address) 
     member x.Mappings = keys |> Seq.mapi (fun i k -> k, Address.ofInt i)
     /// Returns the range used by the index
-    member x.Range = Address.zero, Address.ofInt keys.Count
+    member x.Range = Address.zero, Address.ofInt (keys.Count - 1)
     /// Are the keys of the index ordered?
     member x.IsOrdered = ordered.Value
     member x.Comparer = comparer
@@ -372,7 +372,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
     member builder.GetRange<'K when 'K : equality >
         (index:IIndex<'K>, lo, hi, vector) =
       // Default values are specified by the entire range
-      let defaults = Address.zero, Address.ofInt64 index.KeyCount
+      let defaults = Address.zero, Address.ofInt64 (index.KeyCount - 1L)
       let getBound offs semantics proj = 
         let (|Lookup|_|) x = 
           match index.Lookup(x, semantics, fun _ -> true) with 

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -4,6 +4,7 @@ open System
 open System.ComponentModel
 open System.Collections.Generic
 
+open Deedle.Addressing
 open Deedle.Internal
 open Deedle.JoinHelpers
 open Deedle.Indices
@@ -242,10 +243,10 @@ and
   ///
   /// [category:Accessors and slicing]
   member x.TryGetAt(index) = 
-    x.Vector.GetValue(Addressing.int32Convertor index)
+    x.Vector.GetValue(Address.ofInt index)
   /// [category:Accessors and slicing]
   member x.GetKeyAt(index) = 
-    x.Index.KeyAt(Addressing.int32Convertor index)
+    x.Index.KeyAt(Address.ofInt index)
   /// [category:Accessors and slicing]
   member x.GetAt(index) = 
     x.TryGetAt(index).Value

--- a/src/Deedle/Vectors/ArrayVector.fs
+++ b/src/Deedle/Vectors/ArrayVector.fs
@@ -117,33 +117,37 @@ type ArrayVectorBuilder() =
               invalidOp "Type mismatch - cannot fill values of the vector!"
               
 
-      | Relocate(source, (IntAddress loRange, IntAddress hiRange), relocations) ->
+      | Relocate(source, (loRange, hiRange), relocations) ->
           // Create a new array with specified size and move values from the
           // old array (source) to the new, according to 'relocations'
-          let newData = Array.zeroCreate (hiRange - loRange + 1)
+          let newData = Array.zeroCreate ((Address.asInt hiRange) - (Address.asInt loRange) + 1)
           match builder.buildArrayVector source arguments with 
           | VectorOptional data ->
-              for IntAddress newIndex, IntAddress oldIndex in relocations do
+              for newIndex, oldIndex in relocations do
+                let newIndex, oldIndex = Address.asInt newIndex, Address.asInt oldIndex
                 if oldIndex < data.Length && oldIndex >= 0 then
                   newData.[newIndex] <- data.[oldIndex]
           | VectorNonOptional data ->
-              for IntAddress newIndex, IntAddress oldIndex in relocations do
+              for newIndex, oldIndex in relocations do
+                let newIndex, oldIndex = Address.asInt newIndex, Address.asInt oldIndex
                 if oldIndex < data.Length && oldIndex >= 0 then
                   newData.[newIndex] <- OptionalValue(data.[oldIndex])
           vectorBuilder.CreateMissing(newData)
 
-      | DropRange(source, (IntAddress loRange, IntAddress hiRange)) ->
+      | DropRange(source, (loRange, hiRange)) ->
           // Create a new array without the specified range. For Optional, call the 
           // builder recursively as this may turn Optional representation to NonOptional
+          let loRange, hiRange = Address.asInt loRange, Address.asInt hiRange
           match builder.buildArrayVector source arguments with 
           | VectorOptional data -> 
               vectorBuilder.CreateMissing(Array.dropRange loRange hiRange data) 
           | VectorNonOptional data -> 
               VectorNonOptional(Array.dropRange loRange hiRange data) |> av
 
-      | GetRange(source, (IntAddress loRange, IntAddress hiRange)) ->
+      | GetRange(source, (loRange, hiRange)) ->
           // Get the specified sub-range. For Optional, call the builder recursively 
           // as this may turn Optional representation to NonOptional
+          let loRange, hiRange = Address.asInt loRange, Address.asInt hiRange
           if hiRange < loRange then VectorNonOptional [||] |> av else
           match builder.buildArrayVector source arguments with 
           | VectorOptional data -> 
@@ -219,7 +223,8 @@ and ArrayVector<'T> internal (representation:ArrayVectorData<'T>) =
     member x.ElementType = typeof<'T>
     member x.SuppressPrinting = false
 
-    member vector.GetObject(IntAddress index) = 
+    member vector.GetObject(index) = 
+      let index = Address.asInt index
       match representation with
       | VectorOptional data when index < data.Length -> data.[index] |> OptionalValue.map box 
       | VectorNonOptional data when index < data.Length -> OptionalValue(box data.[index])
@@ -227,7 +232,8 @@ and ArrayVector<'T> internal (representation:ArrayVectorData<'T>) =
 
   // Implement the typed vector interface
   interface IVector<'T> with
-    member vector.GetValue(IntAddress index) = 
+    member vector.GetValue(index) = 
+      let index = Address.asInt index
       match representation with
       | VectorOptional data when index < data.Length -> data.[index]
       | VectorNonOptional data when index < data.Length -> OptionalValue(data.[index])

--- a/src/Deedle/Vectors/Vector.fs
+++ b/src/Deedle/Vectors/Vector.fs
@@ -1,7 +1,6 @@
 ﻿namespace Deedle.Vectors
 
 open Deedle
-//open System.Collections.Generic
 open System.Collections.ObjectModel
 
 /// Provides a way to get the data of an arbitrary vector. This is a concrete type used 

--- a/tests/Deedle.Tests/Common.fs
+++ b/tests/Deedle.Tests/Common.fs
@@ -9,6 +9,7 @@ module Deedle.Tests.Common
 
 open System
 open System.Collections.Generic
+open System.Collections.ObjectModel
 open FsUnit
 open FsCheck
 open NUnit.Framework
@@ -47,24 +48,32 @@ let ``Array.dropRange drops inclusive range from an array`` () =
 [<Test>]
 let ``Binary searching for nearest greater value works`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
-  Array.binarySearchNearestGreater 5 comparer [| 1; 2; 4; 6 |] |> shouldEqual (Some 3)
-  Array.binarySearchNearestGreater 6 comparer [| 1; 2; 4; 6 |] |> shouldEqual (Some 3)
-  Array.binarySearchNearestGreater 7 comparer [| 1; 2; 4; 6 |] |> shouldEqual None
-  Array.binarySearchNearestGreater 5 comparer [| |] |> shouldEqual None
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestGreater 5 comparer |> shouldEqual (Some 3)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestGreater 6 comparer |> shouldEqual (Some 3)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestGreater 7 comparer |> shouldEqual None
+  new ReadOnlyCollection<_> [| |]
+  |> Array.binarySearchNearestGreater 5 comparer |> shouldEqual None
     
 [<Test>]
 let ``Binary searching for nearest smaller value works`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
-  Array.binarySearchNearestSmaller 5 comparer [| 1; 2; 4; 6 |] |> shouldEqual (Some 2)
-  Array.binarySearchNearestSmaller 6 comparer [| 1; 2; 4; 6 |] |> shouldEqual (Some 3)
-  Array.binarySearchNearestSmaller 0 comparer [| 1; 2; 4; 6 |] |> shouldEqual None
-  Array.binarySearchNearestSmaller 5 comparer [| |] |> shouldEqual None
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestSmaller 5 comparer |> shouldEqual (Some 2)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestSmaller 6 comparer |> shouldEqual (Some 3)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestSmaller 0 comparer |> shouldEqual None
+  new ReadOnlyCollection<_> [| |]
+  |> Array.binarySearchNearestSmaller 5 comparer |> shouldEqual None
     
 [<Test>]
 let ``Binary searching for nearest greater value satisfies laws`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
   Check.QuickThrowOnFailure(fun (input:int[]) (key:int) -> 
-    let input = Array.sort input
+    let input = new ReadOnlyCollection<_>(Array.sort input)
     match Array.binarySearchNearestGreater key comparer input with
     | Some idx -> input.[idx] >= key
     | None -> Seq.forall (fun v -> v < key) input )
@@ -73,7 +82,7 @@ let ``Binary searching for nearest greater value satisfies laws`` () =
 let ``Binary searching for nearest smaller value satisfies laws`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
   Check.QuickThrowOnFailure(fun (input:int[]) (key:int) -> 
-    let input = Array.sort input
+    let input = new ReadOnlyCollection<_>(Array.sort input)
     match Array.binarySearchNearestSmaller key comparer input with
     | Some idx -> input.[idx] <= key
     | None -> Seq.forall (fun v -> v > key) input )


### PR DESCRIPTION
- I further simplified the `Addressing` module, renamed some functions (there were some names that have lost meaning like `int32converter). Hopefully, this makes it a bit more understandable. I also marked functions as`inline` (but have not measured it)
- I did some more changes in `LinearIndex`. Most importantly, the index used to create an array with the keys (and then also a reversed array, when needed). This is no longer necessary, because we can just index in the collection of keys directly. I also deleted some cases in `Lookup` (big red chunk below) which were supposed to handle the case when address cannot be converted to integer.
- I added some documentation for pivot table - it's cool!
