### PR TITLE
Improve Frame groupBy semantics

### DIFF
--- a/docs/content/csharp/Series.cs
+++ b/docs/content/csharp/Series.cs
@@ -183,9 +183,7 @@ namespace CSharp
 
 			// [aggreg-group]
 			// Group random numbers by the first digit & get distribution
-			var buckets = randNums.GroupBy
-				( kvp => (int)(kvp.Value * 10), 
-				  kvp => OptionalValue.Create(kvp.Value.KeyCount) );
+            var buckets = randNums.GroupBy(kvp => (int)(kvp.Value * 10)).Select(kvp => kvp.Value.KeyCount);
 			buckets.Print();
 			// [/aggreg-group]
 

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -216,6 +216,7 @@ and internal DelayedIndexBuilder() =
     member x.Create(keys, ordered) = builder.Create(keys, ordered)
     member x.Aggregate(index, aggregation, vector, selector) = builder.Aggregate(index, aggregation, vector, selector)
     member x.GroupBy(index, keySel, vector, valueSel) = builder.GroupBy(index, keySel, vector, valueSel)
+    member x.GroupWith(index, keys, vec) = builder.GroupWith(index, keys, vec)
     member x.OrderIndex(sc) = builder.OrderIndex(sc)
     member x.Union(sc1, sc2) = builder.Union(sc1, sc2)
     member x.Append(sc1, sc2, transform) = builder.Append(sc1, sc2, transform)

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -215,8 +215,7 @@ and internal DelayedIndexBuilder() =
   interface IIndexBuilder with
     member x.Create(keys, ordered) = builder.Create(keys, ordered)
     member x.Aggregate(index, aggregation, vector, selector) = builder.Aggregate(index, aggregation, vector, selector)
-    member x.GroupBy(index, keySel, vector, valueSel) = builder.GroupBy(index, keySel, vector, valueSel)
-    member x.GroupWith(index, keys, vec) = builder.GroupWith(index, keys, vec)
+    member x.GroupBy(index, keySel, vector) = builder.GroupBy(index, keySel, vector)
     member x.OrderIndex(sc) = builder.OrderIndex(sc)
     member x.Union(sc1, sc2) = builder.Union(sc1, sc2)
     member x.Append(sc1, sc2, transform) = builder.Append(sc1, sc2, transform)

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -214,6 +214,7 @@ module Frame =
 
   let groupRowsUsing selector (frame:Frame<'R, 'C>) = 
     frame.Rows |> Series.groupInto selector (fun k g -> g) |> FrameUtils.collapseSeriesSeries
+  
   let groupColsUsing selector (frame:Frame<'R, 'C>) = 
     frame.Columns |> Series.groupInto selector (fun k g -> g |> FrameUtils.fromColumns) |> collapseCols
 
@@ -235,6 +236,8 @@ module Frame =
   let groupColsByInt column frame : Frame<_, int * _> = groupColsBy column frame
   let groupColsByString column frame : Frame<_, string * _> = groupColsBy column frame
   let groupColsByBool column frame : Frame<_, bool * _> = groupColsBy column frame
+
+  let groupRowsWith labels (frame:Frame<'R,'C>) : Series<'K, _> = frame.GroupRowsWith(labels)
 
   // ----------------------------------------------------------------------------------------------
   // Pivot table

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -197,72 +197,6 @@ module Frame =
   let getSeries column (frame:Frame<'R, 'C>) : Series<'R, float> = frame.GetSeries(column)
 
   // ----------------------------------------------------------------------------------------------
-  // Grouping and hierarchical indexing
-  // ----------------------------------------------------------------------------------------------
-
-  let collapseCols (series:Series<'K, Frame<'K1, 'K2>>) = 
-    series 
-    |> Series.map (fun k1 df -> df.Columns |> Series.mapKeys(fun k2 -> (k1, k2)) |> FrameUtils.fromColumns)
-    |> Series.values 
-    |> Seq.toList
-    |> function
-       | head :: tail -> head.AppendN(tail)
-       | []           -> Frame([], [])
-
-  let collapseRows (series:Series<'K, Frame<'K1, 'K2>>) = 
-    FrameUtils.collapseFrameSeries series
-
-  let groupRowsUsing selector (frame:Frame<'R, 'C>) = 
-    frame.Rows |> Series.groupInto selector (fun k g -> g) |> FrameUtils.collapseSeriesSeries
-  
-  let groupColsUsing selector (frame:Frame<'R, 'C>) = 
-    frame.Columns |> Series.groupInto selector (fun k g -> g |> FrameUtils.fromColumns) |> collapseCols
-
-  let groupRowsBy column (frame:Frame<'R, 'C>) = 
-    frame.Rows |> Series.groupInto (fun _ v -> v.GetAs<'K>(column)) (fun _ g -> g)
-    |> FrameUtils.collapseSeriesSeries
-
-  let groupColsBy column (frame:Frame<'R, 'C>) = 
-    frame.Columns |> Series.groupInto 
-      (fun _ v -> v.GetAs<'K>(column)) 
-      (fun k g -> g |> FrameUtils.fromColumns)
-    |> collapseCols
-
-  let groupRowsByObj column frame : Frame<obj * _, _> = groupRowsBy column frame
-  let groupRowsByInt column frame : Frame<int * _, _> = groupRowsBy column frame
-  let groupRowsByString column frame : Frame<string * _, _> = groupRowsBy column frame
-  let groupRowsByBool column frame : Frame<bool * _, _> = groupRowsBy column frame
-  let groupColsByObj column frame : Frame<_, obj * _> = groupColsBy column frame
-  let groupColsByInt column frame : Frame<_, int * _> = groupColsBy column frame
-  let groupColsByString column frame : Frame<_, string * _> = groupColsBy column frame
-  let groupColsByBool column frame : Frame<_, bool * _> = groupColsBy column frame
-
-  let groupRowsWith labels (frame:Frame<'R,'C>) : Series<'K, _> = frame.GroupRowsWith(labels)
-
-  // ----------------------------------------------------------------------------------------------
-  // Pivot table
-  // ----------------------------------------------------------------------------------------------
-  
-  /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data 
-  /// frame representing a table: column labels are field names & table values are observations
-  /// of those fields. pivotTable buckets the rows along two axes, according to the results of 
-  /// the functions `rowGrp` and `colGrp`; and then computes a value for the frame of rows that
-  /// land in each bucket.
-  ///
-  /// ## Parameters
-  ///  - `rowGrp` - A function from rowkey & row to group value for the resulting row index
-  ///  - `colGrp` - A function from rowkey & row to group value for the resulting col index
-  ///  - `op` - A function computing a value from the corresponding bucket frame 
-  ///
-  /// [category:Frame operations]
-  let pivotTable (rowGrp:'R -> ObjectSeries<'C> -> 'RNew) (colGrp:'R -> ObjectSeries<'C> -> 'CNew) (op:Frame<'R, 'C> -> 'T) (frame:Frame<'R, 'C>): Frame<'RNew, 'CNew> =
-    frame.Rows                                                                    //    Series<'R,ObjectSeries<'C>>
-    |> Series.groupInto (fun r g -> colGrp r g) (fun _ g -> g)                    // -> Series<'CNew, Series<'R,ObjectSeries<'C>>>
-    |> Series.mapValues (Series.groupInto (fun c g -> rowGrp c g) (fun _ g -> g)) // -> Series<'CNew, Series<'RNew, Series<'R',ObjectSeries<'C>>>>
-    |> Series.mapValues (Series.mapValues (FrameUtils.fromRows >> op))            // -> Series<'CNew, Series<'RNew, 'T>>
-    |> FrameUtils.fromColumns                                                     // -> Frame<'RNew, 'CNew, 'T>
-
-  // ----------------------------------------------------------------------------------------------
   // Operations
   // ----------------------------------------------------------------------------------------------
 
@@ -749,6 +683,56 @@ module Frame =
   let inline minRowBy column (frame:Frame<'R, 'C>) = 
     frame.Rows |> Series.minBy (fun row -> row.GetAs<float>(column))
 
+
+  // ----------------------------------------------------------------------------------------------
+  // Grouping and hierarchical indexing
+  // ----------------------------------------------------------------------------------------------
+
+  let groupRowsUsing selector (frame:Frame<'R, 'C>) = 
+    frame.GroupRowsUsing selector
+  
+  let groupColsUsing selector (frame:Frame<'R, 'C>) = 
+    frame.Columns |> Series.groupInto selector (fun k g -> g |> FrameUtils.fromColumns) //|> collapseCols
+
+  let groupRowsBy column (frame:Frame<'R, 'C>) = 
+    frame.GroupRowsBy(column)
+
+  let groupColsBy column (frame:Frame<'R, 'C>) = 
+    frame.Columns |> Series.groupInto 
+      (fun _ v -> v.GetAs<'K>(column)) 
+      (fun k g -> g |> FrameUtils.fromColumns)
+
+  let groupRowsByObj column frame : Series<obj, _> = groupRowsBy column frame
+  let groupRowsByInt column frame : Series<int, _> = groupRowsBy column frame
+  let groupRowsByString column frame : Series<string, _> = groupRowsBy column frame
+  let groupRowsByBool column frame : Series<bool, _> = groupRowsBy column frame
+  let groupColsByObj column frame : Series<obj,  _> = groupColsBy column frame
+  let groupColsByInt column frame : Series<int, _> = groupColsBy column frame
+  let groupColsByString column frame : Series<string, _> = groupColsBy column frame
+  let groupColsByBool column frame : Series<bool, _> = groupColsBy column frame
+
+  // ----------------------------------------------------------------------------------------------
+  // Pivot table
+  // ----------------------------------------------------------------------------------------------
+  
+  /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data 
+  /// frame representing a table: column labels are field names & table values are observations
+  /// of those fields. pivotTable buckets the rows along two axes, according to the results of 
+  /// the functions `rowGrp` and `colGrp`; and then computes a value for the frame of rows that
+  /// land in each bucket.
+  ///
+  /// ## Parameters
+  ///  - `rowGrp` - A function from rowkey & row to group value for the resulting row index
+  ///  - `colGrp` - A function from rowkey & row to group value for the resulting col index
+  ///  - `op` - A function computing a value from the corresponding bucket frame 
+  ///
+  /// [category:Frame operations]
+  let pivotTable (rowGrp:'R -> ObjectSeries<'C> -> 'RNew) (colGrp:'R -> ObjectSeries<'C> -> 'CNew) (op:Frame<'R, 'C> -> 'T) (frame:Frame<'R, 'C>): Frame<'RNew, 'CNew> =
+    frame.Rows                                                                    //    Series<'R,ObjectSeries<'C>>
+    |> Series.groupInto (fun r g -> colGrp r g) (fun _ g -> g)                    // -> Series<'CNew, Series<'R,ObjectSeries<'C>>>
+    |> Series.mapValues (Series.groupInto (fun c g -> rowGrp c g) (fun _ g -> g)) // -> Series<'CNew, Series<'RNew, Series<'R',ObjectSeries<'C>>>>
+    |> Series.mapValues (Series.mapValues (FrameUtils.fromRows >> op))            // -> Series<'CNew, Series<'RNew, 'T>>
+    |> FrameUtils.fromColumns                                                     // -> Frame<'RNew, 'CNew, 'T>
 
   // ----------------------------------------------------------------------------------------------
   // Hierarchical aggregation

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -279,15 +279,8 @@ and IIndexBuilder =
   /// Group a (possibly unordered) index according to a provided sequence of labels.
   /// The operation results in a sequence of unique labels along with corresponding 
   /// series construction objects which can be applied to arbitrary vectors/columns.
-  abstract GroupWith : index:IIndex<'K> * labels:seq<'TNewKey> * VectorConstruction -> 
+  abstract GroupBy : index:IIndex<'K> * keySelector:('K -> OptionalValue<'TNewKey>) * VectorConstruction -> 
     ('TNewKey * SeriesConstruction<'K>) seq when 'TNewKey : equality
-
-  /// Group a (possibly unordered) index using the specified `keySelector` function.
-  /// The operation builds a new index with the selected keys and a matching vector
-  /// with values produced by the `valueSelector` function.
-  abstract GroupBy : IIndex<'K> * keySelector:('K -> OptionalValue<'TNewKey>) * VectorConstruction *
-    valueSelector:('TNewKey * SeriesConstruction<'K> -> OptionalValue<'R>) -> IIndex<'TNewKey> * IVector<'R>
-
 
   /// Aggregate data into non-overlapping chunks by aligning them to the
   /// specified keys. The second parameter specifies the direction. If it is

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -276,6 +276,12 @@ and IIndexBuilder =
     selector:(DataSegmentKind * SeriesConstruction<'K> -> 'TNewKey * OptionalValue<'R>)
       -> IIndex<'TNewKey> * IVector<'R>
 
+  /// Group a (possibly unordered) index according to a provided sequence of labels.
+  /// The operation results in a sequence of unique labels along with corresponding 
+  /// series construction objects which can be applied to arbitrary vectors/columns.
+  abstract GroupWith : index:IIndex<'K> * labels:seq<'TNewKey> * VectorConstruction -> 
+    ('TNewKey * SeriesConstruction<'K>) seq when 'TNewKey : equality
+
   /// Group a (possibly unordered) index using the specified `keySelector` function.
   /// The operation builds a new index with the selected keys and a matching vector
   /// with values produced by the `valueSelector` function.

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -218,11 +218,12 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
       newIndex, vect
 
     /// Group an (un)ordered index
-    member builder.GroupWith<'K, 'TNewKey when 'K : equality and 'TNewKey : equality>
-        (index:IIndex<'K>, keys:seq<'TNewKey>, vector) =
+    member builder.GroupBy<'K, 'TNewKey when 'K : equality and 'TNewKey : equality>
+        (index:IIndex<'K>,  keySel:'K -> OptionalValue<'TNewKey>, vector) =
       let builder = (builder :> IIndexBuilder)
       // Build a sequence of indices & vector constructions representing the groups
-      let windows = index.Keys |> Seq.zip keys |> Seq.groupBy (fun (k, _) -> k) |> Seq.map (fun (k, s) -> (k, s |> Seq.map snd))
+      let windows = index.Keys |> Seq.groupBy keySel |> Seq.choose (fun (k, v) -> 
+        if k.HasValue then Some(k.Value, v) else None)
       windows 
       |> Seq.map (fun (key, win) ->
           let len = Seq.length win |> int64
@@ -233,28 +234,28 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
           key, (newIndex, Vectors.Relocate(vector, len, relocations)))
 
     /// Group an (un)ordered index
-    member builder.GroupBy<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality>
-        (index:IIndex<'K>, keySel:'K -> OptionalValue<'TNewKey>, vector, valueSel:_ * _ -> OptionalValue<'R>) =
-      let builder = (builder :> IIndexBuilder)
-      let ranges =
-        // Build a sequence of indices & vector constructions representing the groups
-        let windows = index.Keys |> Seq.groupBy keySel |> Seq.choose (fun (k, v) -> 
-          if k.HasValue then Some(k.Value, v) else None)
-        windows 
-        |> Seq.map (fun (key, win) ->
-          let len = Seq.length win |> int64
-          let relocations = 
-            seq { for k, newAddr in Seq.zip win (Address.generateRange(0L, len-1L)) -> 
-                    newAddr, index.Lookup(k, Lookup.Exact, fun _ -> true).Value |> snd }
-          let newIndex = builder.Create(win, None)
-          key, (newIndex, Vectors.Relocate(vector, len, relocations)))
-        |> Array.ofSeq
-
-      /// Build a new index & vector by applying value selector
-      let keys = ranges |> Seq.map (fun (k, _) -> k)
-      let newIndex = builder.Create(keys, None)
-      let vect = ranges |> Seq.map valueSel |> Array.ofSeq |> vectorBuilder.CreateMissing
-      newIndex, vect
+//    member builder.GroupBy<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality>
+//        (index:IIndex<'K>, keySel:'K -> OptionalValue<'TNewKey>, vector, valueSel:_ * _ -> OptionalValue<'R>) =
+//      let builder = (builder :> IIndexBuilder)
+//      let ranges =
+//        // Build a sequence of indices & vector constructions representing the groups
+//        let windows = index.Keys |> Seq.groupBy keySel |> Seq.choose (fun (k, v) -> 
+//          if k.HasValue then Some(k.Value, v) else None)
+//        windows 
+//        |> Seq.map (fun (key, win) ->
+//          let len = Seq.length win |> int64
+//          let relocations = 
+//            seq { for k, newAddr in Seq.zip win (Address.generateRange(0L, len-1L)) -> 
+//                    newAddr, index.Lookup(k, Lookup.Exact, fun _ -> true).Value |> snd }
+//          let newIndex = builder.Create(win, None)
+//          key, (newIndex, Vectors.Relocate(vector, len, relocations)))
+//        |> Array.ofSeq
+//
+//      /// Build a new index & vector by applying value selector
+//      let keys = ranges |> Seq.map (fun (k, _) -> k)
+//      let newIndex = builder.Create(keys, None)
+//      let vect = ranges |> Seq.map valueSel |> Array.ofSeq |> vectorBuilder.CreateMissing
+//      newIndex, vect
 
     /// Create chunks based on the specified key sequence
     member builder.Resample<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality> 

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -217,6 +217,20 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
       let vect = vectorBuilder.CreateMissing(Array.map snd keyValues)
       newIndex, vect
 
+    /// Group an (un)ordered index
+    member builder.GroupWith<'K, 'TNewKey when 'K : equality and 'TNewKey : equality>
+        (index:IIndex<'K>, keys:seq<'TNewKey>, vector) =
+      let builder = (builder :> IIndexBuilder)
+      // Build a sequence of indices & vector constructions representing the groups
+      let windows = index.Keys |> Seq.zip keys |> Seq.groupBy (fun (k, _) -> k) |> Seq.map (fun (k, s) -> (k, s |> Seq.map snd))
+      windows 
+      |> Seq.map (fun (key, win) ->
+          let len = Seq.length win |> int64
+          let relocations = 
+            seq { for k, newAddr in Seq.zip win (Address.generateRange(0L, len-1L)) -> 
+                  newAddr, index.Lookup(k, Lookup.Exact, fun _ -> true).Value |> snd }
+          let newIndex = builder.Create(win, None)
+          key, (newIndex, Vectors.Relocate(vector, len, relocations)))
 
     /// Group an (un)ordered index
     member builder.GroupBy<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality>

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -908,12 +908,23 @@ type ObjectSeries<'K when 'K : equality> internal(index:IIndex<_>, vector, vecto
   member x.GetAs<'R>(column) : 'R = 
     Convert.changeType<'R> (x.Get(column))
 
+  member x.GetAs<'R>(column, fallback) : 'R =
+    let address = index.Lookup(column, Lookup.Exact, fun _ -> true) 
+    match address with
+    | OptionalValue.Present a -> 
+        match (vector.GetValue(snd a)) with
+        | OptionalValue.Present v -> Convert.changeType<'R> v
+        | OptionalValue.Missing   -> fallback
+    | OptionalValue.Missing -> keyNotFound column 
+
   member x.GetAtAs<'R>(index) : 'R = 
     Convert.changeType<'R> (x.GetAt(index))
 
   member x.TryGetAs<'R>(column) : OptionalValue<'R> = 
     x.TryGet(column) |> OptionalValue.map (fun v -> Convert.changeType<'R> v)
-  static member (?) (series:ObjectSeries<_>, name:string) = series.GetAs<float>(name)
+
+  static member (?) (series:ObjectSeries<_>, name:string) = 
+    series.GetAs<float>(name)
 
   member x.TryAs<'R>(strict) =
     match box vector with

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -924,7 +924,7 @@ type ObjectSeries<'K when 'K : equality> internal(index:IIndex<_>, vector, vecto
     x.TryGet(column) |> OptionalValue.map (fun v -> Convert.changeType<'R> v)
 
   static member (?) (series:ObjectSeries<_>, name:string) = 
-    series.GetAs<float>(name)
+    series.GetAs<float>(name, nan)
 
   member x.TryAs<'R>(strict) =
     match box vector with

--- a/src/Deedle/SeriesExtensions.fs
+++ b/src/Deedle/SeriesExtensions.fs
@@ -58,7 +58,6 @@ type internal Series =
   static member internal CreateUntyped(index:IIndex<'K>, data:IVector<obj>) = 
     ObjectSeries<'K>(index, data, Series.vectorBuilder, Series.indexBuilder)
 
-
 type SeriesBuilder<'K, 'V when 'K : equality and 'V : equality>() = 
   let mutable keys = []
   let mutable values = []

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -864,6 +864,19 @@ module Series =
   let groupBy (keySelector:'K -> 'T -> 'TNewKey) (series:Series<'K, 'T>) =
     groupInto keySelector (fun k s -> s) series
 
+  /// Groups a series (ordered or unordered) using the specified label sequence (`keys`) 
+  /// and then returns a series of (nested) series as the result. The outer series is indexed 
+  /// by the unique labels; the nested series are indexed by the original index keys.
+  ///
+  /// ## Parameters
+  ///  - `keys` - A list of labels that is used for aggregation. The new key must support equality 
+  ///    testing.
+  ///  - `series` - An input series to be grouped. 
+  ///
+  /// [category:Windowing, chunking and grouping]
+  let groupWith keys (series:Series<'K, 'T>) =
+    series.GroupWith(keys)
+
   // ----------------------------------------------------------------------------------------------
   // Handling of missing values
   // ----------------------------------------------------------------------------------------------

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -250,10 +250,7 @@ module Series =
   /// [category:Statistics]
   [<CompiledName("FlattenLevel")>]
   let inline flattenLevel (level:'K1 -> 'K2) op (series:Series<_, 'S>) : Series<_, 'V> = 
-    series.GroupBy
-      ( (fun kvp -> level kvp.Key),
-        (fun kvp -> OptionalValue(op kvp.Value)))
-
+    series.GroupBy(fun kvp -> level kvp.Key) |> mapValues op
 
   let force (series:Series<'K, 'V>) = 
     series.Materialize()
@@ -338,9 +335,8 @@ module Series =
   [<CompilerMessageAttribute("This is an internal function and should not be used directly", 10002, IsHidden=true)>]
   [<CompiledName("InternalApplyLevel")>]
   let inline fastApplyLevel keySelector flist foptlist fseq (series:Series<_, _>) : Series<_, _> = 
-    series.GroupBy
-      ( (fun kvp -> keySelector kvp.Key),
-        (fun kvp -> OptionalValue(fastAggregation flist foptlist fseq kvp.Value)))
+    series.GroupBy(fun kvp -> keySelector kvp.Key)
+    |> mapValues (fastAggregation flist foptlist fseq)
 
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `level` and then aggregates elements in each group
@@ -357,9 +353,7 @@ module Series =
   /// [category:Statistics]
   [<CompiledName("StatisticsLevel")>]
   let inline statLevel (level:'K1 -> 'K2) op (series:Series<_, 'V>) : Series<_, 'R> = 
-    series.GroupBy
-      ( (fun kvp -> level kvp.Key),
-        (fun kvp -> OptionalValue(stat op kvp.Value)))
+    series.GroupBy(fun kvp -> level kvp.Key) |> mapValues (stat op)
 
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `level` and then aggregates series representing each group
@@ -376,9 +370,7 @@ module Series =
   /// [category:Statistics]
   [<CompiledName("ApplyLevel")>]
   let inline applyLevel (level:'K1 -> 'K2) op (series:Series<_, 'V>) : Series<_, 'R> = 
-    series.GroupBy
-      ( (fun kvp -> level kvp.Key),
-        (fun kvp -> OptionalValue(op kvp.Value)))
+    series.GroupBy(fun kvp -> level kvp.Key) |> mapValues op
 
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `level` and then returns a new series containing
@@ -512,9 +504,7 @@ module Series =
   /// [category:Statistics]
   [<CompiledName("ReduceLevel")>]
   let reduceLevel (level:'K1 -> 'K2) op (series:Series<_, 'T>) = 
-    series.GroupBy
-      ( (fun (KeyValue(key, _)) -> level key),
-        (fun (KeyValue(_, ser)) -> OptionalValue(reduce op ser)))
+    series.GroupBy(fun (KeyValue(key, _)) -> level key) |> mapValues (reduce op)
 
   // ----------------------------------------------------------------------------------------------
   // Windowing, chunking and grouping
@@ -849,7 +839,7 @@ module Series =
   ///
   /// [category:Windowing, chunking and grouping]
   let groupInto (keySelector:'K -> 'T -> 'TNewKey) f (series:Series<'K, 'T>) : Series<'TNewKey, 'TNewValue> =
-    series.GroupBy((fun (KeyValue(k,v)) -> keySelector k v), fun (KeyValue(k,s)) -> OptionalValue(f k s))
+    series.GroupBy(fun (KeyValue(k,v)) -> keySelector k v) |> map (fun k s -> f k s)
 
   /// Groups a series (ordered or unordered) using the specified key selector (`keySelector`) 
   /// and then returns a series of (nested) series as the result. The outer series is indexed by
@@ -863,19 +853,6 @@ module Series =
   /// [category:Windowing, chunking and grouping]
   let groupBy (keySelector:'K -> 'T -> 'TNewKey) (series:Series<'K, 'T>) =
     groupInto keySelector (fun k s -> s) series
-
-  /// Groups a series (ordered or unordered) using the specified label sequence (`keys`) 
-  /// and then returns a series of (nested) series as the result. The outer series is indexed 
-  /// by the unique labels; the nested series are indexed by the original index keys.
-  ///
-  /// ## Parameters
-  ///  - `keys` - A list of labels that is used for aggregation. The new key must support equality 
-  ///    testing.
-  ///  - `series` - An input series to be grouped. 
-  ///
-  /// [category:Windowing, chunking and grouping]
-  let groupWith keys (series:Series<'K, 'T>) =
-    series.GroupWith(keys)
 
   // ----------------------------------------------------------------------------------------------
   // Handling of missing values

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -74,7 +74,7 @@ let testOne() =
   for i in 1 .. 20 do
     timed(fun () ->
    
-        let bySex = titanic |> Frame.groupRowsByString "Sex"
+        let bySex = titanic |> Frame.groupRowsByString "Sex" |> Frame.unnest
         let survivedBySex = bySex.Columns.["Survived"].As<bool>()
         let survivals = 
             survivedBySex

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -292,13 +292,13 @@ let slowStack() =
 [<Test>]
 let ``Can group 10x5k data frame by row of type string (in less than a few seconds)`` () =
   let big = frame [ for d in 0 .. 10 -> string d => series [ for i in 0 .. 5000 -> string i => string (i % 1000) ] ]
-  let grouped = big |> Frame.groupRowsByString "1"
+  let grouped = big |> Frame.groupRowsByString "1" |> Frame.unnest
   grouped.Rows.[ ("998","998") ].GetAs<int>("0") |> shouldEqual 998
 
 [<Test>]
 let ``Can group 10x5k data frame by row of type string and nest it (in less than a few seconds)`` () =
   let big = frame [ for d in 0 .. 10 -> string d => series [ for i in 0 .. 5000 -> string i => string (i % 1000) ] ]
-  let grouped = big |> Frame.groupRowsByString "1" 
+  let grouped = big |> Frame.groupRowsByString "1" |> Frame.unnest
   let nest = grouped |> Frame.nest
   nest |> Series.countKeys |> shouldEqual 1000
 
@@ -433,6 +433,7 @@ let ``AppendN works on non-primitives`` () =
 
 
   let df2 = df |> Frame.groupRowsByString("Y") 
+               |> Frame.unnest
                |> Frame.nest
                |> Frame.unnest
 
@@ -853,7 +854,6 @@ let ``Can group titanic data by boolean column "Survived"``() =
   let actual =
     titanic()
     |> Frame.groupRowsByBool "Survived"
-    |> Frame.nest
     |> Series.mapValues Frame.countRows
   actual |> shouldEqual (series [false => 549; true => 342])
 


### PR DESCRIPTION
The current suite of Frame.groupBy functions suffers a few problems:
- it forces an unnest after grouping, but you often just re-nest immediately to do an operation
- it operates row-wise, but should operate column-wise

This pull request addresses these issues. On the following benchmark, I get approx 10x speedup.

```
let genRandomNumbers count =
  let rnd = System.Random()
  List.init count (fun _ -> (float <| rnd.Next()) / (float Int32.MaxValue))

let r = genRandomNumbers 1000000
let x = [for i in r -> if i > 0.0 then "x" else "y" ]
let s = Series.ofValues(x)
let n = Series.ofValues(r)
let f = Frame.ofColumns ["s" => s]
f?n <- n

let means = f |> Frame.groupRowsByString("s") |> Series.mapValues (fun s -> s?n |> Series.mean)
```
