### PR TITLE
#142 alternate take, keeping semantics same

### DIFF
--- a/docs/content/csharp/Series.cs
+++ b/docs/content/csharp/Series.cs
@@ -183,9 +183,7 @@ namespace CSharp
 
 			// [aggreg-group]
 			// Group random numbers by the first digit & get distribution
-			var buckets = randNums.GroupBy
-				( kvp => (int)(kvp.Value * 10), 
-				  kvp => OptionalValue.Create(kvp.Value.KeyCount) );
+			var buckets = randNums.GroupBy(kvp => (int)(kvp.Value * 10)).Select(kvp => OptionalValue.Create(kvp.Value.KeyCount));
 			buckets.Print();
 			// [/aggreg-group]
 

--- a/docs/content/csharp/Series.cs
+++ b/docs/content/csharp/Series.cs
@@ -183,7 +183,9 @@ namespace CSharp
 
 			// [aggreg-group]
 			// Group random numbers by the first digit & get distribution
-			var buckets = randNums.GroupBy(kvp => (int)(kvp.Value * 10)).Select(kvp => OptionalValue.Create(kvp.Value.KeyCount));
+			var buckets = randNums
+                .GroupBy(kvp => (int)(kvp.Value * 10))
+                .Select(kvp => OptionalValue.Create(kvp.Value.KeyCount));
 			buckets.Print();
 			// [/aggreg-group]
 

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -215,7 +215,7 @@ and internal DelayedIndexBuilder() =
   interface IIndexBuilder with
     member x.Create(keys, ordered) = builder.Create(keys, ordered)
     member x.Aggregate(index, aggregation, vector, selector) = builder.Aggregate(index, aggregation, vector, selector)
-    member x.GroupBy(index, keySel, vector, valueSel) = builder.GroupBy(index, keySel, vector, valueSel)
+    member x.GroupBy(index, keySel, vector) = builder.GroupBy(index, keySel, vector)
     member x.OrderIndex(sc) = builder.OrderIndex(sc)
     member x.Union(sc1, sc2) = builder.Union(sc1, sc2)
     member x.Append(sc1, sc2, transform) = builder.Append(sc1, sc2, transform)

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -604,6 +604,24 @@ type FrameExtensions =
   static member ExpandColumns(frame:Frame<'R, string>, names) =
     FrameUtils.expandColumns (set names) frame
 
+  /// Given a data frame whose row index has two levels, create a series
+  /// whose keys are the unique first level keys, and whose values are 
+  /// those corresponding frames selected from the original data.  
+  ///
+  /// [category:Data structure manipulation]
+  [<Extension>]
+  static member Nest(frame:Frame<Tuple<'TRowKey1, 'TRowKey2>, 'TColumnKey>) =
+    frame |> Frame.mapRowKeys (fun t -> (t.Item1, t.Item2)) |> Frame.nest
+
+  /// Given a series whose values are frames, create a frame resulting
+  /// from the concatenation of all the frames' rows, with the resulting 
+  /// keys having two levels. This is the inverse operation to nest.
+  ///
+  /// [category:Data structure manipulation]
+  [<Extension>]
+  static member Unnest(series:Series<'TRowKey1, Frame<'TRowKey2, 'TColumnKey>>) =
+    series |> Frame.unnest |> Frame.mapRowKeys (fun (k1, k2) -> Tuple<'TRowKey1, 'TRowKey2>(k1, k2))
+
   // ----------------------------------------------------------------------------------------------
   // Input and output
   // ----------------------------------------------------------------------------------------------

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -276,12 +276,11 @@ and IIndexBuilder =
     selector:(DataSegmentKind * SeriesConstruction<'K> -> 'TNewKey * OptionalValue<'R>)
       -> IIndex<'TNewKey> * IVector<'R>
 
-  /// Group a (possibly unordered) index using the specified `keySelector` function.
-  /// The operation builds a new index with the selected keys and a matching vector
-  /// with values produced by the `valueSelector` function.
-  abstract GroupBy : IIndex<'K> * keySelector:('K -> OptionalValue<'TNewKey>) * VectorConstruction *
-    valueSelector:('TNewKey * SeriesConstruction<'K> -> OptionalValue<'R>) -> IIndex<'TNewKey> * IVector<'R>
-
+  /// Group a (possibly unordered) index according to a provided sequence of labels.
+  /// The operation results in a sequence of unique labels along with corresponding 
+  /// series construction objects which can be applied to arbitrary vectors/columns.
+  abstract GroupBy : index:IIndex<'K> * keySelector:('K -> OptionalValue<'TNewKey>) * VectorConstruction -> 
+    ('TNewKey * SeriesConstruction<'K>) seq when 'TNewKey : equality
 
   /// Aggregate data into non-overlapping chunks by aligning them to the
   /// specified keys. The second parameter specifies the direction. If it is

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -217,30 +217,21 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
       let vect = vectorBuilder.CreateMissing(Array.map snd keyValues)
       newIndex, vect
 
-
-    /// Group an (un)ordered index
-    member builder.GroupBy<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality>
-        (index:IIndex<'K>, keySel:'K -> OptionalValue<'TNewKey>, vector, valueSel:_ * _ -> OptionalValue<'R>) =
+    member builder.GroupBy<'K, 'TNewKey when 'K : equality and 'TNewKey : equality>
+        (index:IIndex<'K>,  keySel:'K -> OptionalValue<'TNewKey>, vector) =
       let builder = (builder :> IIndexBuilder)
-      let ranges =
-        // Build a sequence of indices & vector constructions representing the groups
-        let windows = index.Keys |> Seq.groupBy keySel |> Seq.choose (fun (k, v) -> 
-          if k.HasValue then Some(k.Value, v) else None)
-        windows 
-        |> Seq.map (fun (key, win) ->
-          let len = Seq.length win |> int64
-          let relocations = 
+      
+      // Build a sequence of indices & vector constructions representing the groups
+      let windows = index.Keys |> Seq.groupBy keySel |> Seq.choose (fun (k, v) -> 
+        if k.HasValue then Some(k.Value, v) else None)
+      windows 
+      |> Seq.map (fun (key, win) ->
+        let len = Seq.length win |> int64
+        let relocations = 
             seq { for k, newAddr in Seq.zip win (Address.generateRange(0L, len-1L)) -> 
-                    newAddr, index.Lookup(k, Lookup.Exact, fun _ -> true).Value |> snd }
-          let newIndex = builder.Create(win, None)
-          key, (newIndex, Vectors.Relocate(vector, len, relocations)))
-        |> Array.ofSeq
-
-      /// Build a new index & vector by applying value selector
-      let keys = ranges |> Seq.map (fun (k, _) -> k)
-      let newIndex = builder.Create(keys, None)
-      let vect = ranges |> Seq.map valueSel |> Array.ofSeq |> vectorBuilder.CreateMissing
-      newIndex, vect
+                  newAddr, index.Lookup(k, Lookup.Exact, fun _ -> true).Value |> snd }
+        let newIndex = builder.Create(win, None)
+        key, (newIndex, Vectors.Relocate(vector, len, relocations)))
 
     /// Create chunks based on the specified key sequence
     member builder.Resample<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality> 

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -605,19 +605,20 @@ and
   ///    each group of collected elements.
   ///
   /// [category:Windowing, chunking and grouping]
-  member x.GroupBy(keySelector:Func<_, _>, valueSelector:Func<_, _>) =
-    let newIndex, newVector = 
-      indexBuilder.GroupBy
-        ( x.Index, 
-          (fun key -> 
-              x.TryGet(key) |> OptionalValue.map (fun v -> 
-                let kvp = KeyValuePair(key, v)
-                keySelector.Invoke(kvp))), Vectors.Return 0, 
-          (fun (newKey, (index, cmd)) -> 
-              let group = Series<_, _>(index, vectorBuilder.Build(cmd, [| vector |]), vectorBuilder, indexBuilder)
-              let kvp = KeyValuePair(newKey, group)
-              valueSelector.Invoke(kvp) ) )
-    Series<'TNewKey, 'R>(newIndex, newVector, vectorBuilder, indexBuilder)
+  member x.GroupBy(keySelector:Func<_, _>) =
+    let cmd = 
+      indexBuilder.GroupBy(
+        x.Index, 
+        (fun key -> 
+          x.TryGet(key) 
+          |> OptionalValue.map (fun v -> 
+              let kvp = KeyValuePair(key, v)
+              keySelector.Invoke(kvp))), 
+        VectorConstruction.Return 0)
+    let newIndex  = Index.ofKeys (cmd |> Seq.map fst)
+    let newGroups = cmd |> Seq.map snd |> Seq.map (fun sc -> 
+        Series(fst sc, vectorBuilder.Build(snd sc, [| x.Vector |]), vectorBuilder, indexBuilder))
+    Series<'TNewKey, _>(newIndex, Vector.ofValues newGroups, vectorBuilder, indexBuilder)
 
   // ----------------------------------------------------------------------------------------------
   // Indexing

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -293,7 +293,6 @@ let slowStack() =
 let ``Can group 10x5k data frame by row of type string (in less than a few seconds)`` () =
   let big = frame [ for d in 0 .. 10 -> string d => series [ for i in 0 .. 5000 -> string i => string (i % 1000) ] ]
   let grouped = big |> Frame.groupRowsByString "1"
-  grouped.RowKeys |> Seq.iter (fun rk -> System.Console.WriteLine("{0}", rk))
   grouped.Rows.[ ("998","998") ].GetAs<int>("0") |> shouldEqual 998
 
 [<Test>]

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -293,6 +293,7 @@ let slowStack() =
 let ``Can group 10x5k data frame by row of type string (in less than a few seconds)`` () =
   let big = frame [ for d in 0 .. 10 -> string d => series [ for i in 0 .. 5000 -> string i => string (i % 1000) ] ]
   let grouped = big |> Frame.groupRowsByString "1"
+  grouped.RowKeys |> Seq.iter (fun rk -> System.Console.WriteLine("{0}", rk))
   grouped.Rows.[ ("998","998") ].GetAs<int>("0") |> shouldEqual 998
 
 [<Test>]


### PR DESCRIPTION
This is an alternate way to speed up #142. It's about 20% slower than the GH142 branch PR, because nest and groupby are two separate operations ...

```
open Deedle
open System

let genRandomNumbers count =
  let rnd = System.Random()
  List.init count (fun _ -> (float <| rnd.Next()) / (float Int32.MaxValue))

let r = genRandomNumbers 1000000
let x = [for i in r -> if i > 0.5 then "x" else "y" ]
let s = Series.ofValues(x)
let n = Series.ofValues(r)
let f = Frame.ofColumns ["s" => s]
f?n <- n

let means = f.GroupRowsBy<string>("s") |> Frame.nest |> Series.mapValues (fun df -> df?n |> Series.mean)
```
