### PR TITLE
Mostly optimizations

### DIFF
--- a/docs/content/csharp/Frame.cs
+++ b/docs/content/csharp/Frame.cs
@@ -60,8 +60,8 @@ namespace CSharp
 
       // [index-date]
       // Get MSFT & FB stock prices indexed by data
-      var msft = msftRaw.IndexRows<DateTime>("Date").OrderRows();
-      var fb = fbRaw.IndexRows<DateTime>("Date").OrderRows();
+      var msft = msftRaw.IndexRows<DateTime>("Date").SortRowsByKey();
+      var fb = fbRaw.IndexRows<DateTime>("Date").SortRowsByKey();
       
       // And rename columns to avoid overlap
       msft.RenameSeries(s => "Msft" + s);

--- a/docs/content/csharp/Series.cs
+++ b/docs/content/csharp/Series.cs
@@ -63,7 +63,7 @@ namespace CSharp
 
       // [create-csv]
       var frame = Frame.ReadCsv(Path.Combine(root, "../data/stocks/msft.csv"));
-      var frameDate = frame.IndexRows<DateTime>("Date").OrderRows();
+      var frameDate = frame.IndexRows<DateTime>("Date").SortRowsByKey();
       var msftOpen = frameDate.GetSeries<double>("Open");
       msftOpen.Print();
       // [/create-csv]

--- a/src/Deedle/Common/Address.fs
+++ b/src/Deedle/Common/Address.fs
@@ -12,6 +12,7 @@ module Address =
   let Invalid = -1L
   let zero = 0L
   let inline asInt (x:Address) = int x
+  let inline asInt64 (x:Address) : int64 = x
   let inline ofInt (x:int) : Address = int64 x
   let inline ofInt64 (x:int64) : Address = x
   let inline increment (x:Address) = (x + 1L)

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -104,6 +104,7 @@ module internal Ranges =
 open Ranges
 open System.Threading.Tasks
 open System.Collections.Generic
+open System.Collections.ObjectModel
 
 /// Specifies the ranges for which data need to be provided
 type internal DelayedSourceRanges<'K> = (('K * BoundaryBehavior) * ('K * BoundaryBehavior))[]
@@ -214,7 +215,8 @@ and internal DelayedIndexFunction<'K, 'R when 'K : equality> =
 and internal DelayedIndexBuilder() =
   let builder = IndexBuilder.Instance
   interface IIndexBuilder with
-    member x.Create(keys, ordered) = builder.Create(keys, ordered)
+    member x.Create(keys:seq<_>, ordered) = builder.Create(keys, ordered)
+    member x.Create(keys:ReadOnlyCollection<_>, ordered) = builder.Create(keys, ordered)
     member x.Aggregate(index, aggregation, vector, selector) = builder.Aggregate(index, aggregation, vector, selector)
     member x.GroupBy(index, keySel, vector) = builder.GroupBy(index, keySel, vector)
     member x.OrderIndex(sc) = builder.OrderIndex(sc)

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -227,7 +227,7 @@ and internal DelayedIndexBuilder() =
     member x.WithIndex(index1, f, vector) = builder.WithIndex(index1, f, vector)
     member x.Reindex(index1, index2, semantics, vector, cond) = builder.Reindex(index1, index2, semantics, vector, cond)
     member x.DropItem(sc, key) = builder.DropItem(sc, key)
-    member x.Resample(index, keys, close, vect, ks, vs) = builder.Resample(index, keys, close, vect, ks, vs)
+    member x.Resample(index, keys, close, vect, selector) = builder.Resample(index, keys, close, vect, selector)
     
     member x.Project(index:IIndex<'K>) = 
       // If the index is delayed, then projection evaluates it

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -453,18 +453,18 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Accessors and slicing]
   member frame.Rows =
-    let values = rowIndex.Keys |> Seq.map (fun k ->
-      let rowAddress = rowIndex.Locate(k)
-      let rowReader = createObjRowReader data vectorBuilder columnIndex.Mappings rowAddress
-      Series.CreateUntyped(columnIndex, rowReader))    
-    RowSeries(Series<_, _>(rowIndex, Vector.ofValues values, vectorBuilder, indexBuilder))
+    let getRow addr =
+       let rowReader = createObjRowReader data vectorBuilder columnIndex.KeyCount addr
+       Series.CreateUntyped(columnIndex, rowReader)
+    let values = Array.init (int rowIndex.KeyCount) (fun a -> getRow (Address.ofInt a))
+    RowSeries(Series<_, _>(rowIndex, vectorBuilder.Create(values), vectorBuilder, indexBuilder))
 
   /// [category:Accessors and slicing]
   member frame.RowsDense = 
     let emptySeries = Series<_, _>(rowIndex, Vector.ofValues [], vectorBuilder, indexBuilder)
     let res = emptySeries.SelectOptional (fun row ->
       let rowAddress = rowIndex.Locate(row.Key)
-      let rowVec = createObjRowReader data vectorBuilder columnIndex.Mappings rowAddress
+      let rowVec = createObjRowReader data vectorBuilder columnIndex.KeyCount rowAddress
       let all = columnIndex.Mappings |> Seq.forall (fun (key, addr) -> rowVec.GetValue(addr).HasValue)
       if all then OptionalValue(Series.CreateUntyped(columnIndex, rowVec))
       else OptionalValue.Missing )
@@ -504,7 +504,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     if index < 0 || int64 index >= rowIndex.KeyCount then
       raise (new ArgumentOutOfRangeException("index", "Index must be positive and smaller than the number of rows."))
     let rowAddress = Address.ofInt index
-    Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.Mappings rowAddress)
+    Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.KeyCount rowAddress)
 
   /// Returns a row with the specieifed key wrapped in `OptionalValue`. When the specified key 
   /// is not found, the result is `OptionalValue.Missing`. This method is generic and returns the result 
@@ -518,7 +518,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.TryGetRow<'T>(rowKey) : OptionalValue<Series<_, 'T>> =
     let rowAddress = rowIndex.Locate(rowKey)
     if rowAddress = Address.Invalid then OptionalValue.Missing
-    else OptionalValue(Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.Mappings rowAddress))
+    else OptionalValue(Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.KeyCount rowAddress))
 
   /// Returns a row with the specieifed key wrapped in `OptionalValue`. When the specified key 
   /// is not found, the result is `OptionalValue.Missing`. This method is generic and returns the result 
@@ -534,7 +534,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.TryGetRow<'T>(rowKey, lookup) : OptionalValue<Series<_, 'T>> =
     let rowAddress = rowIndex.Lookup(rowKey, lookup, fun _ -> true)
     if not rowAddress.HasValue then OptionalValue.Missing
-    else OptionalValue(Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.Mappings (snd rowAddress.Value)))
+    else OptionalValue(Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.KeyCount (snd rowAddress.Value)))
 
   /// Returns a row with the specieifed key. This method is generic and returns the result 
   /// as a series containing values of the specified type. To get heterogeneous series of 
@@ -572,7 +572,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let rowAddress = rowIndex.Lookup(rowKey, lookup, fun _ -> true)
     if not rowAddress.HasValue then OptionalValue.Missing
     else 
-      let row = Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.Mappings (snd rowAddress.Value))
+      let row = Series.Create(columnIndex, createRowReader data vectorBuilder columnIndex.KeyCount (snd rowAddress.Value))
       OptionalValue(KeyValuePair(fst rowAddress.Value, row))
   
   // ----------------------------------------------------------------------------------------------

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -434,9 +434,9 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     rowIndex.Mappings |> Seq.isEmpty
 
   /// [category:Accessors and slicing]
-  member frame.RowKeys = rowIndex.Keys
+  member frame.RowKeys = rowIndex.Keys :> seq<_>
   /// [category:Accessors and slicing]
-  member frame.ColumnKeys = columnIndex.Keys
+  member frame.ColumnKeys = columnIndex.Keys :> seq<_>
 
   /// [category:Accessors and slicing]
   member frame.Columns = 

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -612,18 +612,7 @@ type FrameExtensions =
   /// 
   /// [category:Data structure manipulation]
   [<Extension>]
-  static member OrderRows(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.orderRows frame
-
-  /// Returns a data frame that contains the same data as the input, 
-  /// but whose rows are an ordered series. This allows using operations that are
-  /// only available on indexed series such as alignment and inexact lookup.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be ordered.
-  /// 
-  /// [category:Data structure manipulation]
-  [<Extension>]
-  static member SortByRowKey(frame:Frame<'TRowKey, 'TColumnKey>) = frame |> Frame.orderRows
+  static member SortRowsByKey(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortRowsByKey frame
 
   /// Returns a data frame that contains the same data as the input, 
   /// but whose columns are an ordered series. This allows using operations that are
@@ -634,18 +623,7 @@ type FrameExtensions =
   /// 
   /// [category:Data structure manipulation]
   [<Extension>]
-  static member OrderColumns(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.orderCols frame
-
-  /// Returns a data frame that contains the same data as the input, 
-  /// but whose columns are an ordered series. This allows using operations that are
-  /// only available on indexed series such as alignment and inexact lookup.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be ordered.
-  /// 
-  /// [category:Data structure manipulation]
-  [<Extension>]
-  static member SortByColKey(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.orderCols frame
+  static member SortColumnsByKey(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortColsByKey frame
 
   /// Returns a data frame that contains the same data as the input, 
   /// but whose rows are sorted by some column.
@@ -1053,4 +1031,17 @@ type FrameExtensions =
   /// [category:Missing values]
   [<Extension>]
   static member DropSparseColumns(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.dropSparseCols frame
+
+  // ----------------------------------------------------------------------------------------------
+  // Obsolete - kept for temporary compatibility
+  // ----------------------------------------------------------------------------------------------
+
+  [<Extension; Obsolete("Use SortByKeys instead. This function will be removed in futrue versions.")>]
+  static member OrderRows(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortRowsByKey frame
+  [<Extension; Obsolete("Use SortByKeys instead. This function will be removed in futrue versions.")>]
+  static member SortByRowKey(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortRowsByKey frame
+  [<Extension; Obsolete("Use SortByKeys instead. This function will be removed in futrue versions.")>]
+  static member OrderColumns(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortColsByKey frame
+  [<Extension; Obsolete("Use SortByKeys instead. This function will be removed in futrue versions.")>]
+  static member SortByColKey(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortColsByKey frame
   

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -485,8 +485,8 @@ module Frame =
   ///  - `frame` - Source data frame to be ordered.
   /// 
   /// [category:Data structure manipulation]
-  [<CompiledName("OrderRows")>]
-  let orderRows (frame:Frame<'R, 'C>) = 
+  [<CompiledName("SortRowsByKey")>]
+  let sortRowsByKey (frame:Frame<'R, 'C>) = 
     let newRowIndex, rowCmd = frame.IndexBuilder.OrderIndex(frame.RowIndex, Vectors.Return 0)
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder rowCmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData)
@@ -538,8 +538,8 @@ module Frame =
   ///  - `frame` - Source data frame to be ordered.
   /// 
   /// [category:Data structure manipulation]
-  [<CompiledName("OrderColumns")>]
-  let orderCols (frame:Frame<'R, 'C>) = 
+  [<CompiledName("SortColumnsByKey")>]
+  let sortColsByKey (frame:Frame<'R, 'C>) = 
     let newColIndex, rowCmd = frame.IndexBuilder.OrderIndex(frame.ColumnIndex, Vectors.Return 0)
     let newData = frame.VectorBuilder.Build(rowCmd, [| frame.Data |])
     Frame<_, _>(frame.RowIndex, newColIndex, newData)
@@ -1101,3 +1101,12 @@ module Frame =
   /// Returns data of the data frame as a 2D array containing data as `float` values.
   /// Missing data are represented as `Double.NaN` in the returned array.
   let toArray2D (frame:Frame<'R, 'C>) = frame.ToArray2D<float>()
+
+  // ----------------------------------------------------------------------------------------------
+  // Obsolete - kept for temporary compatibility
+  // ----------------------------------------------------------------------------------------------
+
+  [<Obsolete("Use sortRowsByKey instead. This function will be removed in futrue versions.")>]
+  let orderRows (frame:Frame<'R, 'C>) = sortRowsByKey frame
+  [<Obsolete("Use sortColsByKey instead. This function will be removed in futrue versions.")>]
+  let orderCols (frame:Frame<'R, 'C>) = sortColsByKey frame

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -295,8 +295,8 @@ and IIndexBuilder =
   /// `Direction.Backward`, the key is the last element (note that this does not 
   /// hold at the boundaries where values before/after the key may also be included)
   abstract Resample : IIndex<'K> * seq<'K> * Direction * source:VectorConstruction *
-    valueSelector:('TNewKey * SeriesConstruction<'K> -> OptionalValue<'R>) *
-    keySelector:('K * SeriesConstruction<'K> -> 'TNewKey) -> IIndex<'TNewKey> * IVector<'R>
+    selector:('K * SeriesConstruction<'K> -> 'TNewKey * OptionalValue<'R>) 
+      -> IIndex<'TNewKey> * IVector<'R>
 
   /// Given an index and vector construction, return a new index asynchronously
   /// to allow composing evaluation of lazy series. The command to be applied to

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -111,6 +111,7 @@ open Deedle.Keys
 open Deedle.Internal
 open Deedle.Addressing
 open Deedle.Vectors
+open System.Collections.ObjectModel
 
 /// Specifies the boundary behavior for the `IIndexBuilder.GetRange` operation
 /// (whether the boundary elements should be included or not)
@@ -123,7 +124,7 @@ type BoundaryBehavior = Inclusive | Exclusive
 /// Values of this type are constructed using the associated `IIndexBuilder` type.
 type IIndex<'K when 'K : equality> = 
   /// Returns a sequence of all keys in the index.
-  abstract Keys : seq<'K>
+  abstract Keys : ReadOnlyCollection<'K>
 
   /// Performs reverse lookup - and returns key for a specified address
   abstract KeyAt : Address -> 'K
@@ -198,6 +199,12 @@ and IIndexBuilder =
   /// should check and infer this from the data.
   abstract Create : seq<'K> * Option<bool> -> IIndex<'K>
   
+  /// Create a new index using the specified keys. This overload takes data as ReadOnlyCollection
+  /// and so it is more efficient if the caller already has the keys in an allocated collection.
+  /// Optionally, the caller can specify if the index keys are ordered or not. When the value 
+  /// is not set, the construction should check and infer this from the data.
+  abstract Create : ReadOnlyCollection<'K> * Option<bool> -> IIndex<'K>
+
   /// When we perform some projection on the vector (e.g. `Series.map`), then we may also
   /// need to perform some transformation on the index (because it will typically turn delayed
   /// index into an evaluated index). This operation represents that - it should return 

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -73,7 +73,7 @@ type LinearIndex<'K when 'K : equality>
     keys |> Seq.structuralHash
 
   interface IIndex<'K> with
-    member x.Keys = seq { for k in keys -> k }
+    member x.Keys = keys
     member x.KeyCount = int64 keys.Count
     member x.Builder = builder
 
@@ -138,6 +138,49 @@ type LinearIndex<'K when 'K : equality>
     member x.IsOrdered = ordered.Value
     member x.Comparer = comparer
 
+// --------------------------------------------------------------------------------------
+// A lazy index that represents subrange of some other index 
+// (optimization for windowing and chunking functions)
+// --------------------------------------------------------------------------------------
+
+/// A virtual index that represents a subrange of a specified index. This is useful for
+/// windowing operations where we do not want to allocate a new index for each window. 
+/// This index can be cheaply constructed and it implements many of the standard functions
+/// without actually allocating the index (e.g. KeyCount, KeyAt, IsEmpty). For more 
+/// complex index manipulations (including lookup), an actual index is constructed lazily.
+type LinearRangeIndex<'K when 'K : equality> 
+  internal (index:IIndex<'K>, startAddress:int64, endAddress:int64) =
+
+  /// Actual index that is created only when needed
+  let actualIndex = new Lazy<_>(fun () ->
+    let actualKeys = Array.init (int (endAddress - startAddress + 1L)) (fun i -> 
+        index.Keys.[int startAddress + i]) |> ReadOnlyCollection.ofArray
+    index.Builder.Create
+      ( actualKeys, if index.IsOrdered then Some(true) else None) )
+  
+  // Equality and hashing delegates to the actual index
+  override index.Equals(another) = actualIndex.Value.Equals(another) 
+  override index.GetHashCode() = actualIndex.Value.GetHashCode()
+
+  interface IIndex<'K> with
+    // Operations that can be implemented without evaluating the index
+    member x.KeyCount = endAddress - startAddress + 1L
+    member x.KeyAt(address) = index.KeyAt(Address.ofInt64 (startAddress + (Address.asInt64 address)))
+    member x.IsEmpty = endAddress < startAddress
+    member x.Builder = index.Builder
+    member x.Comparer = index.Comparer
+
+    // KeyRange and IsOrdered are easy if we know that the range is sorted
+    member x.KeyRange = 
+      if not index.IsOrdered then actualIndex.Value.KeyRange
+      else index.KeyAt(startAddress), index.KeyAt(endAddress)
+    member x.IsOrdered = index.IsOrdered || actualIndex.Value.IsOrdered
+
+    // The rest of the functionality is delegated to 'actualIndex'
+    member x.Keys = actualIndex.Value.Keys
+    member x.Locate(key) = actualIndex.Value.Locate(key)
+    member x.Lookup(key, semantics, check) = actualIndex.Value.Lookup(key, semantics, check)
+    member x.Mappings = actualIndex.Value.Mappings
 
 // --------------------------------------------------------------------------------------
 // Linear index builder - provides operations for indices (like unioning, 
@@ -186,8 +229,12 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
     member builder.AsyncMaterialize( (index, vector) ) = async.Return(index), vector
 
     /// Create an index from the specified data
-    member builder.Create<'K when 'K : equality>(keys, ordered) = 
+    member builder.Create<'K when 'K : equality>(keys:seq<_>, ordered) : IIndex<'K> = 
       upcast LinearIndex<'K>(ReadOnlyCollection.ofSeq keys, builder, ?ordered=ordered)
+
+    /// Create an index from the specified data
+    member builder.Create<'K when 'K : equality>(keys:ReadOnlyCollection<_>, ordered) : IIndex<'K> = 
+      upcast LinearIndex<'K>(keys, builder, ?ordered=ordered)
 
     /// Aggregate ordered index
     member builder.Aggregate<'K, 'TNewKey, 'R when 'K : equality and 'TNewKey : equality>
@@ -195,27 +242,32 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
       if not index.IsOrdered then 
         invalidOp "Floating window aggregation and chunking is only supported on ordered indices."
       let builder = (builder :> IIndexBuilder)
-      let ranges =
-        // Get windows based on the key sequence
-        let windows = 
-          match aggregation with
-          | WindowWhile cond -> Seq.windowedWhile cond index.Keys |> Seq.map (fun vs -> DataSegment(Complete, vs))
-          | ChunkWhile cond -> Seq.chunkedWhile cond index.Keys |> Seq.map (fun vs -> DataSegment(Complete, vs))
-          | WindowSize(size, bounds) -> Seq.windowedWithBounds size bounds index.Keys 
-          | ChunkSize(size, bounds) -> Seq.chunkedWithBounds size bounds index.Keys
-        // For each window, get a VectorConstruction that represents it
-        windows |> Seq.map (fun win -> 
-          let index, cmd = 
-            builder.GetRange
-              ( index, Some(win.Data.[0], BoundaryBehavior.Inclusive), 
-                Some(win.Data.[win.Data.Length - 1], BoundaryBehavior.Inclusive), vector)
-          win.Kind, (index, cmd) ) |> Array.ofSeq
+      
+      // Calculate locatons (addresses) of the chunks or windows
+      // For ChunkSize and WindowSize, this can be done faster, because we can just calculate
+      // the locations of chunks/windows based on the number of the keys. For chunking/windowing
+      // based on conditions, we actually need to iterate over all the keys...
+      let locations = 
+        match aggregation with 
+        | ChunkSize(size, boundary) -> Seq.chunkRangesWithBounds (int64 size) boundary index.KeyCount
+        | WindowSize(size, boundary) -> Seq.windowRangesWithBounds (int64 size) boundary index.KeyCount
+        | ChunkWhile cond -> Seq.chunkRangesWhile cond index.Keys |> Seq.map (fun (s, e) -> DataSegmentKind.Complete, s, e)
+        | WindowWhile cond -> Seq.windowRangesWhile cond index.Keys |> Seq.map (fun (s, e) -> DataSegmentKind.Complete, s, e)
 
-      /// Build a new index & vector by applying key/value selectors
-      let keyValues = ranges |> Array.map selector
-      let newIndex = builder.Create(Seq.map fst keyValues, None)
-      let vect = vectorBuilder.CreateMissing(Array.map snd keyValues)
+      // Turn each location into vector construction using LinearRangeIndex
+      let vectorConstructions =
+        locations |> Array.ofSeq |> Array.map (fun (kind, lo, hi) ->
+          let cmd = Vectors.GetRange(vector, (lo, hi)) 
+          let index = LinearRangeIndex(index, lo, hi)
+          kind, (index :> IIndex<_>, cmd) )
+
+      // Run the specified selector function
+      let keyValuePairs = vectorConstructions |> Array.map selector
+      // Build & return the resulting series
+      let newIndex = builder.Create(Seq.map fst keyValuePairs, None)
+      let vect = vectorBuilder.CreateMissing(Array.map snd keyValuePairs)
       newIndex, vect
+
 
     member builder.GroupBy<'K, 'TNewKey when 'K : equality and 'TNewKey : equality>
         (index:IIndex<'K>,  keySel:'K -> OptionalValue<'TNewKey>, vector) =

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -362,7 +362,7 @@ and
     Series(Index.ofKeys newIndex, vectorBuilder.CreateMissing(newVector), vectorBuilder, indexBuilder)
 
   /// [category:Projection and filtering]
-  member x.ScanValues(foldFunc:System.Func<'a,'V,'a>, init) =   
+  member x.ScanValues(foldFunc:System.Func<'S,'V,'S>, init) =   
     let newVector = [| 
       let accum = ref init
       for v in vector.DataSequence ->
@@ -375,7 +375,7 @@ and
     Series(index, vectorBuilder.CreateMissing(newVector), vectorBuilder, indexBuilder)
 
   /// [category:Projection and filtering]
-  member x.ScanAllValues(foldFunc:System.Func<OptionalValue<'a>,OptionalValue<'V>,OptionalValue<'a>>, init) =   
+  member x.ScanAllValues(foldFunc:System.Func<OptionalValue<'S>,OptionalValue<'V>,OptionalValue<'S>>, init) =   
     let newVector = vector.DataSequence |> Seq.scan (fun x y -> foldFunc.Invoke(x, y)) init |> Seq.skip 1 |> Seq.toArray
     Series(index, vectorBuilder.CreateMissing(newVector), vectorBuilder, indexBuilder)
 
@@ -885,15 +885,27 @@ and
       |> String.concat "; "
       |> sprintf "series [ %s]" 
 
+  /// Shows the series content in a human-readable format. The resulting string
+  /// shows a limited number of values from the series.
   member series.Format() =
     series.Format(Formatting.StartItemCount, Formatting.EndItemCount)
 
+  /// Shows the series content in a human-readable format. The resulting string
+  /// shows a limited number of values from the series.
+  ///
+  /// ## Parameters
+  ///  - `itemCount` - The total number of items to show. The result will show
+  ///    at most `itemCount/2` items at the beginning and ending of the series.
   member series.Format(itemCount) =
     let half = itemCount / 2
     series.Format(half, half)
 
   /// Shows the series content in a human-readable format. The resulting string
-  /// shows a limited number of rows.
+  /// shows a limited number of values from the series.
+  ///
+  /// ## Parameters
+  ///  - `startCount` - The number of elements to show at the beginning of the series
+  ///  - `endCount` - The number of elements to show at the end of the series
   member series.Format(startCount, endCount) = 
     let getLevel ordered previous reset maxLevel level (key:'K) = 
       let levelKey = 

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -188,7 +188,7 @@ and
   ///
   /// [category:Accessors and slicing]
   member series.GetItems(keys, lookup) =    
-    let newIndex = indexBuilder.Create<_>(keys, None)
+    let newIndex = indexBuilder.Create<_>((keys:seq<_>), None)
     let newVector = vectorBuilder.Build(indexBuilder.Reindex(index, newIndex, lookup, Vectors.Return 0, fun addr -> series.Vector.GetValue(addr).HasValue), [| vector |])
     Series(newIndex, newVector, vectorBuilder, indexBuilder)
 
@@ -705,7 +705,7 @@ and
     Series<int, _>(newIndex, vector, vectorBuilder, indexBuilder)
 
   /// [category:Indexing]
-  member x.IndexWith(keys) = 
+  member x.IndexWith(keys:seq<_>) = 
     let newIndex = indexBuilder.Create(keys, None)
     Series<'TNewKey, _>(newIndex, vector, vectorBuilder, indexBuilder)
 

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -472,9 +472,8 @@ and
         ( x.Index, keys, direction, Vectors.Return 0, 
           (fun (key, (index, cmd)) -> 
               let window = Series<_, _>(index, vectorBuilder.Build(cmd, [| vector |]), vectorBuilder, indexBuilder)
-              OptionalValue(valueSelector.Invoke(key, window))),
-          (fun (key, (index, cmd)) -> 
-              keySelector.Invoke(key, fun () -> Series<_, _>(index, vectorBuilder.Build(cmd, [| vector |]), vectorBuilder, indexBuilder))) )
+              let newKey = keySelector.Invoke(key, window)
+              newKey, OptionalValue(valueSelector.Invoke(newKey, window))) )
     Series<'TNewKey, 'R>(newIndex, newVector, vectorBuilder, indexBuilder)
 
   /// Resample the series based on a provided collection of keys. The values of the series

--- a/src/Deedle/SeriesExtensions.fs
+++ b/src/Deedle/SeriesExtensions.fs
@@ -689,18 +689,8 @@ type SeriesExtensions =
   ///
   /// [category:Data structure manipulation]
   [<Extension>]
-  static member OrderByKey(series:Series<'K, 'T>) = 
-    Series.orderByKey series
-
-  /// Returns a new series whose entries are reordered according to index order
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be used
-  ///
-  /// [category:Data structure manipulation]
-  [<Extension>]
   static member SortByKey(series:Series<'K, 'T>) = 
-    Series.orderByKey series
+    Series.sortByKey series
 
   // ----------------------------------------------------------------------------------------------
   // Lookup, resampling and scaling
@@ -969,3 +959,12 @@ type SeriesExtensions =
   [<Extension>]
   static member SampleInto<'V>(series:Series<DateTimeOffset, 'V>, interval:TimeSpan, dir, aggregate:Func<_, _>) =
     series |> Series.Implementation.sampleTimeIntoInternal (+) None interval dir aggregate.Invoke
+
+
+  // ----------------------------------------------------------------------------------------------
+  // Obsolete - kept for temporary compatibility
+  // ----------------------------------------------------------------------------------------------
+
+  [<Extension; Obsolete("Use SortByKeys instead. This function will be removed in futrue versions.")>]
+  static member OrderByKey(series:Series<'K, 'T>) = Series.sortByKey series
+

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -1337,19 +1337,10 @@ module Series =
   ///  - `series` - An input series to be used
   ///
   /// [category:Data structure manipulation]
-  let orderByKey (series:Series<'K, 'T>) =
+  let sortByKey (series:Series<'K, 'T>) =
     let newRowIndex, rowCmd = series.IndexBuilder.OrderIndex(series.Index, Vectors.Return 0)
     let newData = series.VectorBuilder.Build(rowCmd, [| series.Vector |])
     Series(newRowIndex, newData, series.VectorBuilder, series.IndexBuilder)
-
-  /// Returns a new series whose entries are reordered according to index order
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be used
-  ///
-  /// [category:Data structure manipulation]
-  let sortByKey series =
-    series |> orderByKey
 
   // ----------------------------------------------------------------------------------------------
   // Resampling and similar stuff
@@ -1737,3 +1728,10 @@ module Series =
   /// [category:Appending, joining and zipping]
   let unionUsing behavior (series1:Series<'K, 'V>) (series2:Series<'K, 'V>) = 
     series1.Union(series2, behavior)
+
+  // ----------------------------------------------------------------------------------------------
+  // Obsolete - kept here for temporary compatibility
+  // ----------------------------------------------------------------------------------------------
+
+  [<Obsolete("Use sortByKeys instead. This function will be removed in futrue versions.")>]
+  let orderByKey series = sortByKey series 

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -566,8 +566,8 @@ module Series =
   let windowSizeInto bounds f (series:Series<'K, 'T>) : Series<'K, 'R> =
     let dir = if snd bounds = Boundary.AtEnding then Direction.Forward else Direction.Backward
     let keySel = System.Func<DataSegment<Series<_, _>>, _>(fun data -> 
-      if dir = Direction.Backward then data.Data.Index.Keys |> Seq.last
-      else data.Data.Index.Keys |> Seq.head )
+      if dir = Direction.Backward then data.Data.Index.KeyRange |> snd
+      else data.Data.Index.KeyRange |> fst )
     series.Aggregate(WindowSize(bounds), keySel, (fun ds -> OptionalValue(f ds)))
 
   /// Creates a sliding window using the specified size and boundary behavior and returns

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -70,18 +70,28 @@ let testOne() =
   //let d1 = Array.init 1000000 float
   //let d2 = Array.init 1000000 float
 
-  let s = series [ for k in 0 .. 100000 -> k => float k ]
+//  let s = series [ for k in 0 .. 100000 -> k => float k ]
+
+  let genRandomNumbers count =
+    let rnd = System.Random()
+    List.init count (fun _ -> (float <| rnd.Next()) / (float Int32.MaxValue))
+  let r = genRandomNumbers 1000000
+  let n = Series.ofValues(r)
+  let f = Frame.ofColumns ["n" => n]
 
 //  s |> Series.chunkInto 100 Series.mean |> ignore
 //  s |> Series.chunkWhileInto (fun k1 k2 -> k2 - k1 < 100) Series.mean |> ignore
 //  s |> Series.windowWhileInto (fun k1 k2 -> k2 - k1 < 100) Series.mean |> ignore
 
   //let titanic = Frame.ReadCsv(__SOURCE_DIRECTORY__ + @"\..\..\docs\content\data\Titanic.csv")
-  for i in 1 .. 5 do
+  let rows = ResizeArray<_>()
+  for i in 1 .. 10 do
     timed(fun () ->
        //let nada = s |> Series.windowInto 100 Series.mean
 
-       let nada = s |> Series.windowInto 100 Series.mean |> ignore
+       //let nada = s |> Series.windowInto 100 Series.mean |> ignore
+
+       rows.Add(f.RowsDense)
 
        ///let nada2 = s |> Series.windowSizeInto (5, Boundary.Skip) (DataSegment.data >> Series.mean)
        ()

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -70,10 +70,22 @@ let testOne() =
   //let d1 = Array.init 1000000 float
   //let d2 = Array.init 1000000 float
 
-  let titanic = Frame.ReadCsv(__SOURCE_DIRECTORY__ + @"\..\..\docs\content\data\Titanic.csv")
-  for i in 1 .. 20 do
+  let s = series [ for k in 0 .. 100000 -> k => float k ]
+
+//  s |> Series.chunkInto 100 Series.mean |> ignore
+//  s |> Series.chunkWhileInto (fun k1 k2 -> k2 - k1 < 100) Series.mean |> ignore
+//  s |> Series.windowWhileInto (fun k1 k2 -> k2 - k1 < 100) Series.mean |> ignore
+
+  //let titanic = Frame.ReadCsv(__SOURCE_DIRECTORY__ + @"\..\..\docs\content\data\Titanic.csv")
+  for i in 1 .. 5 do
     timed(fun () ->
-   
+       //let nada = s |> Series.windowInto 100 Series.mean
+
+       let nada = s |> Series.windowInto 100 Series.mean |> ignore
+
+       ///let nada2 = s |> Series.windowSizeInto (5, Boundary.Skip) (DataSegment.data >> Series.mean)
+       ()
+       (*
         let bySex = titanic |> Frame.groupRowsByString "Sex"
         let survivedBySex = bySex.Columns.["Survived"].As<bool>()
         let survivals = 
@@ -88,8 +100,7 @@ let testOne() =
         let summary = 
               [ "Survived (%)" => survivals?Survived / survivals?Total * 100.0
                 "Died (%)" => survivals?Died/ survivals?Total * 100.0 ] |> frame
-
-        ()
+                *)
       //CSharp.Tests.DynamicFrameTests.CanAddSeriesDynamically()
       //CSharp.Tests.DynamicFrameTests.CanGetSeriesDynamically()
 //      Tests.Frame.``Can group 10x5k data frame by row of type string and nest it (in less than a few seconds)``()

--- a/tests/Deedle.Tests/Common.fs
+++ b/tests/Deedle.Tests/Common.fs
@@ -213,30 +213,3 @@ let ``Seq.alignWithoutOrdering works on sample input`` () =
   Seq.alignWithoutOrdering [ ("b", 0); ("c", 1); ("d", 2) ] [ ("b", 1); ("c", 2); ("a", 0); ] 
   |> List.ofSeq |> set |> shouldEqual
       (set [("b", Some 0, Some 1); ("c", Some 1, Some 2); ("d", Some 2, None); ("a", None, Some 0)])
-
-[<Test>]
-let ``Seq.chunkedUsing works in forward direction on sample input`` () =
-  let actual = Seq.chunkedUsing Comparer<int>.Default Direction.Forward [2;4;7] [1 .. 10] |> Array.ofSeq 
-  let expected = [| (2, [1; 2; 3]); (4, [4; 5; 6]); (7, [7; 8; 9; 10]) |]
-  actual |> shouldEqual expected
-  
-[<Test>]
-let ``Seq.chunkedUsing works in backward direction on sample input`` () =
-  let actual = Seq.chunkedUsing Comparer<int>.Default Direction.Backward [2;4;7] [1 .. 10] |> Array.ofSeq 
-  let expected = [|(2, [1;2]); (4, [3;4]); (7, [5; 6; 7; 8; 9; 10]) |]
-  actual |> shouldEqual expected
-
-[<Test>]
-let ``Seq.chunkedUsing returns empty lists when keys are denser than values`` () =
-  let actual = [1;3;4;5] |> Seq.chunkedUsing Comparer<int>.Default Direction.Forward [1;2;3;5;6] |> List.ofSeq
-  let expected = [ (1,[1]); (2,[]); (3,[3;4]); (5,[5]); (6,[]) ]
-  actual |> shouldEqual expected
-
-[<Test>]
-let ``Seq.chunkedUsing works for 500k keys`` () =
-  let input = [for m in 1 .. 12 -> DateTime.Today.AddMonths(m) ] 
-  let keys = [for m in 0.0 .. 500000.0 -> DateTime.Today.AddMinutes(m) ]
-  let actual = input |> Seq.chunkedUsing Comparer<DateTime>.Default Direction.Forward keys
-  actual |> Seq.length |> shouldEqual 500001
-  let actual = input |> Seq.chunkedUsing Comparer<DateTime>.Default Direction.Backward keys
-  actual |> Seq.length |> shouldEqual 500001

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -341,6 +341,17 @@ let ``Accessing row via missing row key with lookup works`` () =
   let actual = rowSample().GetRow<int>("f", Lookup.NearestSmaller)
   actual |> shouldEqual <| series [ "X" => 3; "Y" => 6 ]
 
+[<Test>]
+let ``Accessing row observation via missing row key with lookup works`` () =
+  let actual = rowSample().TryGetRowObservation<int>("f", Lookup.NearestSmaller)
+  actual.Value.Key |> shouldEqual "e"
+  actual.Value.Value |> shouldEqual <| series [ "X" => 3; "Y" => 6 ]
+
+[<Test>]
+let ``Accessing row observation via missing row key returns missing`` () =
+  let actual = rowSample().TryGetRowObservation<int>("f", Lookup.Exact)
+  actual.HasValue |> shouldEqual false
+
 // ------------------------------------------------------------------------------------------------
 // Stack & unstack
 // ------------------------------------------------------------------------------------------------
@@ -422,7 +433,7 @@ let ``Can perform numerical operation with a series on data frames`` () =
   
 [<Test>]
 let ``Can perform pointwise numerical operations on two frames`` () =
-  let df1 = msft() |> Frame.orderRows
+  let df1 = msft() |> Frame.sortRowsByKey
   let df2 = df1 |> Frame.shift 1
   let opens1 = df1?Open
   let opens2 = df2?Open
@@ -529,7 +540,7 @@ let ``Can zip and subtract numerical values in MSFT data set``() =
 
 [<Test>]
 let ``Can zip and subtract numerical values in MSFT data set; with some rows dropped``() = 
-  let df1 = (msft() |> Frame.orderRows).Rows.[DateTime(2000, 1, 1) ..]
+  let df1 = (msft() |> Frame.sortRowsByKey).Rows.[DateTime(2000, 1, 1) ..]
   let df2 = msft()
   let values = df1.Zip(df2, fun a b -> a - b).GetAllValues<int>()
   values |> Seq.length |> shouldEqual (6 * (df1 |> Frame.countRows))


### PR DESCRIPTION
As usual, the detailed comments are included in the individual commit messages. The main changes are:
- Optimize `frame.Rows` (from ~2600ms to ~600ms for 1M rows on my machine). This mainly reduces the number of allocated objects (fixes #165).
- Optimize windowing and chunking functions - the idea is to create `LinearRangeIndex` representing a range inside an index. When returning window/chunk, we only create this virtual index for the specified range. The full index is only needed for complex processing, but not e.g. for `Series.mean`. (Related to #161)
- Similar optimization for the resampling functions (which work by finding range based on the provided keys and then running aggregation based on the keys).
- I also did some tweaks to the naming of ordering/sorting functions - the idea is to use the name `sort` for all the functions (and make `order` legacy). So, `orderRows` becomes `sortByRowKeys` which is perhaps longer, but more meaningful (and easy to find with the other sorting functions). I left the old ones and marked them as obsolete to avoid breaking changes.
