### PR TITLE
Review and document the Stats module.

### DIFF
--- a/src/Deedle/Stats.fs
+++ b/src/Deedle/Stats.fs
@@ -3,29 +3,74 @@
 open Deedle.Vectors
 open System.Collections.Generic
 
+/// The `Stats` module contains functions for fast calculation of statistics over
+/// and entire series as well as over a moving and an expanding window in a series. 
+/// The three kinds of functions in this module are:
+///
+///  * **Standard** - functions such as `count`, `mean`, `kurt` etc. return the
+///    statistics calculated over all values of a series. The calculation skips
+///    over missing values (or `nan` values), so for example `mean` returns the
+///    average of all _present_ values.
+///
+///  * **Moving window** means that the window has a fixed size and moves over the series.
+///    In this case, the result of the statisitcs is always attached to the last key
+///    of the window. The function names are prefixed with `moving`.
+///
+///  * **Expanding window** means that the window starts as a zero-element sized window
+///    and expands as it moves over the series. In this case, statistics is calculated
+///    for all values preceding the current key. This means that the result is attached
+///    to the key _after_ the end of the window (prefix). The function names are prefixed
+///    with `expanding`.
+///
+/// The resulting series has the same keys as the input series. When the window contains
+/// no values, or contains missing values, different functions behave in different ways.
+/// Statistics (e.g. mean) return missing value when any value is missing, while min/max
+/// functions return the minimal/maximal element (skipping over missing values).
+///
+/// ## Remarks
+///
+/// The windowing functions in the `Stats` module support calculations over a fixed-size
+/// windows specified by the size of the window. If you need more complex windowing 
+/// behavior (such as window based on the distance between keys), different handling
+/// of boundary, or chunking (calculation over adjacent chunks), you can use chunking and
+/// windowing functions from the `Series` module such as `Series.windowSizeInto` or
+/// `Series.chunkSizeInto`.
+///
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]    
 module Stats =
-  // -- Experimental fast sliding window logic 
-  // - TODO: 
-  //    -- still to do, possibly: median, percentile, corr, cov
 
-  let internal applySeriesProj (proj: float opt seq -> float seq) (series:Series<'K, float>) : Series<'K, float> =
+  // TODO: still to do, possibly: median, percentile, corr, cov
+
+
+  // ------------------------------------------------------------------------------------
+  // Implementation internals - moving window functionality
+  // ------------------------------------------------------------------------------------  
+
+  /// Apply transformation on series elements. The projection function `proj` always
+  /// returns `float`, but may return `nan` to indicate that the value is not available.
+  /// The resulting sequence should have the same number of values as the input sequence
+  let inline internal applySeriesProj (proj: float opt seq -> float seq) (series:Series<'K, float>) : Series<'K, float> =
     let newData = 
       series.Vector.DataSequence 
       |> proj 
       |> Vector.ofValues
-
+      
     Series(series.Index, newData, series.VectorBuilder, series.IndexBuilder)
 
-  // Helps create a moving window calculation
-  // nb. adopted from Seq.windowed in F# code base
-  //   finit takes the first fully populated window array to an initial state
-  //   fupdate takes the current state, incoming observation, and out-going observation to the next state
-  //   ftransf takes the current state to the current output
-  let internal movingWindowFn winSz finit fupdate ftransf (source: seq<_>) =
+  /// Helper for moving window calculations (adopted from `Seq.windowed` in F# code base)
+  /// When calling `finit`, we do not copy the array - this is fine, because the function
+  /// is internal (and the only use in `applyMovingSumsTransform` is correct)
+  ///
+  /// # Parameters
+  ///   - `winSize` - The size of the window to create
+  ///   - `finit` takes the first fully populated window array to an initial state
+  ///   - `fupdate` takes the current state, incoming observation, 
+  ///      and out-going observation to the next state
+  ///   - `ftransf` takes the current state to the current output
+  let internal movingWindowFn winSize finit fupdate ftransf (source: seq<_>) =
     seq {
-       let arr = Array.zeroCreate winSz 
-       let r = ref (winSz - 1)
+       let arr = Array.zeroCreate winSize 
+       let r = ref (winSize - 1)
        let i = ref 0 
        let isInit = ref false
        let state = ref Unchecked.defaultof<_>
@@ -34,10 +79,10 @@ module Stats =
          let curr = e.Current
          let outg = arr.[!i]
          arr.[!i] <- curr
-         i := (!i+ 1 ) % winSz
+         i := (!i + 1) % winSize
          if !r = 0 then 
            if not !isInit then
-             state := Array.copy arr |> finit
+             state := arr |> finit
              isInit := true
            else 
              state := fupdate !state curr outg
@@ -46,8 +91,13 @@ module Stats =
            r := (!r - 1)
            yield nan }
 
-  type Sums = { nobs: float; sum: float; sump2: float; sump3: float; sump4: float }
+  /// When calculating moments, this record is used to keep track of the 
+  /// count (`nobs`), sum of values (`sum`), sum of squares (`sum2`),
+  /// sum of values to the power of 3 and 3 (`sum3` and `sum4`)
+  type internal Sums = { nobs: float; sum: float; sump2: float; sump3: float; sump4: float }
 
+  /// Given an initial array of values, calculate the initial `Sums` value
+  /// (only required elements of `Sums` are calculated based on `moment`)
   let internal initSumsDense moment (init: float []) = 
     let count = init |> Array.length |> float
     let sum   = if moment < 1 then 0.0 else init |> Array.sum
@@ -56,6 +106,9 @@ module Stats =
     let sump4 = if moment < 4 then 0.0 else init |> Array.sumBy (fun x -> pown x 4)
     { nobs = count; sum = sum; sump2 = sump2; sump3 = sump3; sump4 = sump4 }
   
+  /// Given an existing `state` of type `Sums`, new incoming element and
+  /// an old outgoing element, update the sums value
+  /// (only required elements of `Sums` are calculated based on `moment`)
   let internal updateSumsDense moment state curr outg =
     let sum   = if moment < 1 then 0.0 else state.sum + curr - outg
     let sump2 = if moment < 2 then 0.0 else state.sump2 + (pown curr 2) - (pown outg 2)
@@ -63,13 +116,15 @@ module Stats =
     let sump4 = if moment < 4 then 0.0 else state.sump4 + (pown curr 4) - (pown outg 4)
     { state with sum = sum; sump2 = sump2; sump3 = sump3; sump4 = sump4 }
 
+  /// Pick only available values from the input array and call `initSumsDense`
+  /// (no need to handle `nan` values, because those are returned as Missing by Deedle)
   let internal initSumsSparse moment (init: float opt []) =
     init 
-    |> Seq.filter (function OptionalValue.Present _ -> true | OptionalValue.Missing -> false )
-    |> Seq.map OptionalValue.get
-    |> Seq.toArray 
+    |> Array.choose OptionalValue.asOption
     |> initSumsDense moment
 
+  /// Update `Sums` value using `updateSumsDense`, but handle the case
+  /// when removing/adding value that is missing (`OptionalValue.Missing`)
   let internal updateSumsSparse moment state curr outg = 
     match curr, outg with
     | OptionalValue.Present x, OptionalValue.Present y -> updateSumsDense moment state x y
@@ -77,16 +132,21 @@ module Stats =
     | OptionalValue.Missing,   OptionalValue.Present y -> { updateSumsDense moment state 0.0 y with nobs = state.nobs - 1.0 }
     | OptionalValue.Missing,   OptionalValue.Missing   -> state
 
-  let internal applyMovingSumsTransform moment winSz (proj: Sums -> float) series =
-    if winSz <= 0 then invalidArg "windowSize" "Window must be non-negative"
-    let calcSparse = movingWindowFn winSz (initSumsSparse moment) (updateSumsSparse moment) proj
+  /// Apply moving window transformation based on `Sums` calculation. The `proj` function
+  /// calculates the statistics from `Sums` value and the `moment` specifies which of the
+  /// `Sums` properties are calculated during the processing.
+  let internal applyMovingSumsTransform moment winSize (proj: Sums -> float) series =
+    if winSize <= 0 then invalidArg "windowSize" "Window must be positive"
+    let calcSparse = movingWindowFn winSize (initSumsSparse moment) (updateSumsSparse moment) proj
     applySeriesProj calcSparse series
 
-  let internal variance s =
+  /// Calculate variance from `Sums`; requires `moment=2`
+  let internal varianceSums s =
     let v = (s.nobs * s.sump2 - s.sum * s.sum) / (s.nobs * s.nobs - s.nobs) 
     if v < 0.0 then nan else v
 
-  let internal skew s =
+  /// Calculate skewness from `Sums`; requires `moment=3`
+  let internal skewSums s =
     let a = s.sum / s.nobs
     let b = s.sump2 / s.nobs - a * a
     let c = s.sump3 / s.nobs - a * a * a - 3.0 * a * b
@@ -94,7 +154,8 @@ module Stats =
     if b = 0.0 || s.nobs < 3.0 then nan 
     else (sqrt (s.nobs * (s.nobs - 1.0)) * c) / ((s.nobs - 2.0) * pown r 3)
   
-  let internal kurt s =
+  /// Calculate kurtsis from `Sums`; requires `moment=4`
+  let internal kurtSums s =
     let a = s.sum / s.nobs
     let r = a * a
     let b = s.sump2 / s.nobs - r
@@ -106,14 +167,24 @@ module Stats =
     else 
       let k = (s.nobs * s.nobs - 1.0) * d / (b * b) - 3.0 * (pown (s.nobs - 1.0) 2)
       k / ((s.nobs - 2.0) * (s.nobs - 3.0))
+
+  // ------------------------------------------------------------------------------------
+  // Implementation internals - moving minimum and maximum
+  // ------------------------------------------------------------------------------------
       
-  // O(n) moving min/max calculator
-  let internal movingMinMaxHelper winSz cmp s = 
+  /// O(n) moving min/max calculator
+  ///
+  /// Keeps double-ended queue of values sorted acording to the specified order,
+  /// such that the front is the min/max value. During the iteration, new value is
+  /// added to the end (and all values that are greater/smaller than the new value
+  /// are removed before it is appended).
+  let internal movingMinMaxHelper winSize cmp s = 
     seq {
       let i = ref 0
       let q = Deque()
       for v in s ->
         // invariant: all values in deque are strictly ascending (min) or descending (max)
+        // invariant: all values in deque are in the current window (fst q.[i] > !i)
         i := !i + 1        
         match v with
         | OptionalValue.Present x -> 
@@ -122,55 +193,115 @@ module Stats =
           // remove from back any values >= (min) or <= (max) compared to current obs
           while q.Count > 0 && (cmp (snd q.[q.Count - 1]) x) do q.RemoveBack() |> ignore
           // append new obs to back
-          q.AddBack( (!i + winSz, x) )
+          q.AddBack( (!i + winSize, x) )
           // return min/max value at front
           snd q.[0]
         | OptionalValue.Missing -> 
           if q.IsEmpty then nan else snd q.[0] }
 
-  // moving window functions
+  // ------------------------------------------------------------------------------------
+  // Public - moving window functions
+  // ------------------------------------------------------------------------------------
 
-  let movingCount winSz (series:Series<'K, float>) : Series<'K, float> =
-    applyMovingSumsTransform 0 winSz (fun s -> s.nobs) series
+  /// Returns a series that contains counts over a moving window of the specified size.
+  /// The first `size-1` elements of the returned series are always missing; if the 
+  /// entire window contains missing values, the result is 0.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingCount")>]
+  let movingCount size (series:Series<'K, float>) : Series<'K, float> =
+    applyMovingSumsTransform 0 size (fun s -> s.nobs) series
 
-  let movingSum winSz (series:Series<'K, float>) : Series<'K, float> =
-    applyMovingSumsTransform 1 winSz (fun s -> s.sum) series
+  /// Returns a series that contains sums over a moving window of the specified size.
+  /// The first `size-1` elements of the returned series are always missing; if the 
+  /// entire window contains missing values, the result is 0.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingSum")>]
+  let movingSum size (series:Series<'K, float>) : Series<'K, float> =
+    applyMovingSumsTransform 1 size (fun s -> s.sum) series
 
-  let movingMean winSz (series:Series<'K, float>) : Series<'K, float> =
-    applyMovingSumsTransform 1 winSz (fun s -> s.sum / s.nobs) series
+  /// Returns a series that contains means over a moving window of the specified size.
+  /// The first `size-1` elements of the returned series are always missing; if the 
+  /// entire window contains missing values, the result is also missing.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingMean")>]
+  let movingMean size (series:Series<'K, float>) : Series<'K, float> =
+    applyMovingSumsTransform 1 size (fun s -> s.sum / s.nobs) series
 
-  let movingVariance winSz (series:Series<'K, float>) : Series<'K, float> =
-    applyMovingSumsTransform 2 winSz variance series
+  /// Returns a series that contains variance over a moving window of the specified size.
+  /// The first `size-1` elements of the returned series are always missing; if the 
+  /// entire window contains missing values, the result is also missing.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingVariance")>]
+  let movingVariance size (series:Series<'K, float>) : Series<'K, float> =
+    applyMovingSumsTransform 2 size varianceSums series
 
-  let movingStdDev winSz (series:Series<'K, float>) : Series<'K, float> =
-    applyMovingSumsTransform 2 winSz (variance >> sqrt) series
+  /// Returns a series that contains standard deviations over a moving window of the specified size.
+  /// The first `size-1` elements of the returned series are always missing; if the 
+  /// entire window contains missing values, the result is also missing.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingStandardDeviation")>]
+  let movingStdDev size (series:Series<'K, float>) : Series<'K, float> =
+    applyMovingSumsTransform 2 size (varianceSums >> sqrt) series
 
-  let movingSkew winSz (series:Series<'K, float>) : Series<'K, float> =
-    applyMovingSumsTransform 3 winSz skew series
+  /// Returns a series that contains skewness over a moving window of the specified size.
+  /// The first `size-1` elements of the returned series are always missing; if the 
+  /// entire window contains missing values, the result is also missing.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingSkewness")>]
+  let movingSkew size (series:Series<'K, float>) : Series<'K, float> =
+    applyMovingSumsTransform 3 size skewSums series
 
-  let movingKurt winSz (series:Series<'K, float>) : Series<'K, float> =
-    applyMovingSumsTransform 4 winSz kurt series 
+  /// Returns a series that contains kurtosis over a moving window of the specified size.
+  /// The first `size-1` elements of the returned series are always missing; if the 
+  /// entire window contains missing values, the result is also missing.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingKurtosis")>]
+  let movingKurt size (series:Series<'K, float>) : Series<'K, float> =
+    applyMovingSumsTransform 4 size kurtSums series 
 
-  let movingMin winSz (series:Series<'K, float>) : Series<'K, float> =
-    applySeriesProj (movingMinMaxHelper winSz (>=)) series
+  /// Returns a series that contains minimum over a moving window of the specified size.
+  /// The first `size-1` elements are calculated using smaller windows spanning over `1 .. size-1` 
+  /// values. If the entire window contains missing values, the result is missing.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingMinimum")>]
+  let movingMin size (series:Series<'K, float>) : Series<'K, float> =
+    applySeriesProj (movingMinMaxHelper size (>=)) series
 
-  let movingMax winSz (series:Series<'K, float>) : Series<'K, float> =
-    applySeriesProj (movingMinMaxHelper winSz (<=)) series
+  /// Returns a series that contains maximum over a moving window of the specified size.
+  /// The first `size-1` elements are calculated using smaller windows spanning over `1 .. size-1` 
+  /// values. If the entire window contains missing values, the result is missing.
+  ///
+  /// [category:Moving windows]
+  [<CompiledName("MovingMaximum")>]
+  let movingMax size (series:Series<'K, float>) : Series<'K, float> =
+    applySeriesProj (movingMinMaxHelper size (<=)) series
 
-  // end moving window functions
+  // ------------------------------------------------------------------------------------
+  // Implementation internals - expanding windows
+  // ------------------------------------------------------------------------------------
 
-  // Helps create an expanding window calculation
-  //   winSz is the minimum window size
-  //   fupdate takes the current state and incoming observation to the next state
-  //   ftransf takes the current state to the current output
-  let internal expandingWindowFn initState fupdate ftransf (source: seq<_>) =
+  /// Helper for expanding window calculations
+  ///
+  /// ## Parameters
+  ///  - `initState` is the initial state of the computation
+  //   - `fupdate` takes the current state and incoming observation to the next state
+  //   - `ftransf` takes the current state to the current output
+  let inline internal expandingWindowFn initState fupdate ftransf (source: seq<_>) =
     source 
     |> Seq.scan fupdate initState 
     |> Seq.map ftransf 
 
-  // Knuth/Welford algorithm for online stats updating
-  // see: http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#On-line_algorithm            
-  type Moments = { 
+  /// Represents the moments as calculated during online processing
+  /// (`nobs` is the count, `sum` is the sum, `M1` to `M4` are moments)
+  type internal Moments = { 
     nobs : float 
     sum  : float 
     M1   : float
@@ -179,6 +310,8 @@ module Stats =
     M4   : float 
   }
 
+  /// Updates the moments using the Knuth/Welford algorithm for online stats updating
+  /// (See: http://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm)
   let internal updateMoments state x =
     let { nobs = nobs; sum = sum; M1 = M1; M2 = M2; M3 = M3; M4 = M4 } = state
     let n1 = nobs
@@ -194,16 +327,20 @@ module Stats =
     let s = sum + x 
     { nobs = n; sum = s; M1 = M1; M2 = M2; M3 = M3; M4 = M4 }   
 
+  /// Updates the moments using `updateMoments`, but skips over missing values
   let internal updateMomentsSparse state curr =     
     match curr with
     | OptionalValue.Present x -> updateMoments state x
     | OptionalValue.Missing   -> state
 
+  /// Given a series, calculates expanding moments (using online `updateMoments`)
+  /// The specified `proj` function is used to calculate the resulting value
   let internal applyExpandingMomentsTransform (proj: Moments -> float) series =
     let initMoments = {nobs = 0.0; sum = 0.0; M1 = 0.0; M2 = 0.0; M3 = 0.0; M4 = 0.0 }
     let calcSparse = expandingWindowFn initMoments updateMomentsSparse proj
     applySeriesProj calcSparse series
 
+  /// Calculates minimum or maximum over an expanding window
   let internal expandingMinMaxHelper cmp s =
     seq {
       let m = ref nan
@@ -214,25 +351,66 @@ module Stats =
           if System.Double.IsNaN(mv) || cmp mv x then m := x; x else mv
         | None -> !m }  
 
-  // expanding window functions
+  // ------------------------------------------------------------------------------------
+  // Public - expanding window functions
+  // ------------------------------------------------------------------------------------
 
+  /// Returns a series that contains counts over expanding windows (the value for
+  /// a given key is calculated from all elements with smaller keys).
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingCount")>]
   let expandingCount (series:Series<'K, float>) : Series<'K, float> =
     applyExpandingMomentsTransform (fun w -> w.nobs) series
 
+  /// Returns a series that contains sums over expanding windows (the value for
+  /// a given key is calculated from all elements with smaller keys); If the 
+  /// entire window contains no values, the result is 0.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingSum")>]
   let expandingSum (series:Series<'K, float>) : Series<'K, float> =
     applyExpandingMomentsTransform (fun w -> w.sum) series
 
+  /// Returns a series that contains means over expanding windows (the value for
+  /// a given key is calculated from all elements with smaller keys); If the 
+  /// entire window contains no values, the result is missing.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingMean")>]
   let expandingMean (series:Series<'K, float>) : Series<'K, float> =
     applyExpandingMomentsTransform (fun w -> w.M1) series
 
+  /// Returns a series that contains variance over expanding windows (the value for
+  /// a given key is calculated from all elements with smaller keys); If the 
+  /// entire window contains fewer than 2 values, the result is missing.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingVariance")>]
   let expandingVariance (series:Series<'K, float>) : Series<'K, float> =
-    let toVar w = w.M2 / (w.nobs - 1.0)
+    let toVar w = 
+      if w.nobs < 2.0 then nan
+      else w.M2 / (w.nobs - 1.0)
     applyExpandingMomentsTransform toVar series
 
+  /// Returns a series that contains standard deviation over expanding windows (the 
+  /// value for a given key is calculated from all elements with smaller keys); If the 
+  /// entire window contains fewer than 2 values, the result is missing.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingStandardDeviation")>]
   let expandingStdDev (series:Series<'K, float>) : Series<'K, float> =
-    let toStdDev w = w.M2 / (w.nobs - 1.0) |> sqrt
+    let toStdDev w = 
+      if w.nobs < 2.0 then nan
+      else w.M2 / (w.nobs - 1.0) |> sqrt
     applyExpandingMomentsTransform toStdDev series
 
+  /// Returns a series that contains skewness over expanding windows (the value for
+  /// a given key is calculated from all elements with smaller keys); If the 
+  /// entire window contains fewer than 3 values, the result is missing.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingSkewness")>]
   let expandingSkew (series:Series<'K, float>) : Series<'K, float> =
     // population -> sample estimate    
     let toEstSkew w = 
@@ -241,6 +419,12 @@ module Stats =
         adjust * (sqrt w.nobs) * w.M3 / (w.M2 ** 1.5) 
     applyExpandingMomentsTransform toEstSkew series
 
+  /// Returns a series that contains kurtosis over expanding windows (the value for
+  /// a given key is calculated from all elements with smaller keys); If the 
+  /// entire window contains fewer than 4 values, the result is missing.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingKurtosis")>]
   let expandingKurt (series:Series<'K, float>) : Series<'K, float> =
     // population -> sample estimate
     let toEstKurt w = 
@@ -249,6 +433,12 @@ module Stats =
         adjust ((w.nobs * w.M4) / (w.M2 * w.M2) - 3.0)
     applyExpandingMomentsTransform toEstKurt series
 
+  /// Returns a series that contains minimum over an expanding window. The value
+  /// for a key _k_ in the returned series is the minimum from all elements with
+  /// smaller keys.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingMinimum")>]
   let expandingMin (series:Series<'K, float>) : Series<'K, float> =
     let minFn s v =
       match v with
@@ -256,6 +446,12 @@ module Stats =
       | OptionalValue.Missing   -> s
     applySeriesProj (Seq.scan minFn nan) series
 
+  /// Returns a series that contains maximum over an expanding window. The value
+  /// for a key _k_ in the returned series is the maximum from all elements with
+  /// smaller keys.
+  ///
+  /// [category:Expanding windows]
+  [<CompiledName("ExpandingMaximum")>]
   let expandingMax (series:Series<'K, float>) : Series<'K, float> =
     let maxFn s v =
       match v with
@@ -263,5 +459,91 @@ module Stats =
       | OptionalValue.Missing   -> s
     applySeriesProj (Seq.scan maxFn nan) series
 
-  // end expanding window functions
+  // ------------------------------------------------------------------------------------
+  // Statistics calculated over the entire series
+  // ------------------------------------------------------------------------------------
 
+  /// Returns all values of a series as an array of `OptionalValue`s
+  let internal valuesAllOpt (series:Series<_, _>) =
+    series.Vector.DataSequence |> Array.ofSeq
+
+  /// Calculates minimum or maximum using the specified function 'f'
+  /// Returns None when there are no values or Some.
+  let inline internal trySeriesExtreme f (series:Series<'K, 'V>) =
+    let mutable res = Unchecked.defaultof<_>
+    let mutable initialized = false
+    for v in series.Vector.DataSequence do
+      if v.HasValue then 
+        res <- if initialized then f res v.Value else v.Value
+        initialized <- true
+    if initialized then Some res else None
+
+
+  /// Returns the number of the values in a series. This excludes missing values
+  /// and values created from `Double.NaN` etc.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Count")>]
+  let inline count (series:Series<'K, 'V>) = series.ValueCount
+
+  /// Returns the sum of the values in a series. The function skips over missing values
+  /// and `NaN` values. When there are no available values, the result is 0.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Sum")>]
+  let inline sum (series:Series<'K, 'V>) : 'V = Seq.sum series.Values
+
+  /// Returns the mean of the values in a series. The function skips over missing values
+  /// and `NaN` values. When there are no available values, the result is NaN.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Mean")>]
+  let mean (series:Series<'K, float>) =
+    let sums = initSumsSparse 1 (valuesAllOpt series)
+    sums.sum / sums.nobs
+
+  /// Returns the variance of the values in a series. The function skips over missing values
+  /// and `NaN` values. When there are less than 2 values, the result is NaN.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Variance")>]
+  let variance (series:Series<'K, float>) =
+    varianceSums (initSumsSparse 2 (valuesAllOpt series))
+
+  /// Returns the standard deviation of the values in a series. The function skips over 
+  /// missing values and `NaN` values. When there are less than 2 values, the result is NaN.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("StandardDeviation")>]
+  let stdDev (series:Series<'K, float>) =
+    sqrt (varianceSums (initSumsSparse 2 (valuesAllOpt series)))
+
+  /// Returns the skewness of the values in a series. The function skips over missing 
+  /// values and `NaN` values. When there are less than 3 values, the result is NaN.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Skewness")>]
+  let skew (series:Series<'K, float>) =
+    skewSums (initSumsSparse 3 (valuesAllOpt series))
+
+  /// Returns the kurtosis of the values in a series. The function skips over missing 
+  /// values and `NaN` values. When there are less than 4 values, the result is NaN.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Kurtosis")>]
+  let kurt (series:Series<'K, float>) =
+    kurtSums (initSumsSparse 4 (valuesAllOpt series))
+
+  /// Returns the minimum of the values in a series. The result is option value.
+  /// When the series contains no values, the result is `None`.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Minimum")>]
+  let inline min (series:Series<'K, 'V>) = trySeriesExtreme min series
+
+  /// Returns the maximum of the values in a series. The result is option value.
+  /// When the series contains no values, the result is `None`.
+  ///
+  /// [category:Standard statistics]
+  [<CompiledName("Maximum")>]
+  let inline max (series:Series<'K, float>) = trySeriesExtreme max series

--- a/tests/Common/FsUnit.fs
+++ b/tests/Common/FsUnit.fs
@@ -90,5 +90,11 @@ module Extensions =
   let shouldEqual (x: 'a) (y: 'a) = Assert.AreEqual(x, y, sprintf "Expected: %A\nActual: %A" x y)
   let notEqual x = new NotConstraint(new EqualConstraint(x))
 
+  type Range = Within of float * float
+  let (+/-) (a:float) b = Within(a, b)
+
+  let beWithin (Within(x, within)) =
+    (new NUnit.Framework.Constraints.EqualConstraint(x)).Within(within)
+
   let inline spy1 (recorder:Recorder<'T>) f = fun p -> recorder.Record(p); f p
   let inline spy2 (recorder:Recorder<'T1 * 'T2>) f = fun p1 p2 -> recorder.Record( (p1, p2) ); f p1 p2 

--- a/tests/Deedle.Tests/Deedle.Tests.fsproj
+++ b/tests/Deedle.Tests/Deedle.Tests.fsproj
@@ -54,7 +54,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MathNet.Numerics">
-      <HintPath>..\..\packages\MathNet.Numerics.2.6.1\lib\net40\MathNet.Numerics.dll</HintPath>
+      <HintPath>..\..\packages\MathNet.Numerics.3.0.0-alpha8\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="nunit.framework">

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -2,6 +2,7 @@
 #load "../../bin/Deedle.fsx"
 #r "../../packages/NUnit.2.6.3/lib/nunit.framework.dll"
 #r "../../packages/FsCheck.0.9.1.0/lib/net40-Client/FsCheck.dll"
+#r "../../packages/MathNet.Numerics.3.0.0-alpha8/lib/net40/MathNet.Numerics.dll"
 #load "../Common/FsUnit.fs"
 #else
 module Deedle.Tests.Stats
@@ -24,17 +25,6 @@ open Deedle
 // to avoid floating point comparison gotchas, we use checksums to within a threshold
 // we use pandas as an oracle to get proper values
 
-type Range = Within of float * float
-let (+/-) (a:float) b = Within(a, b)
-
-let equal x = 
-  match box x with 
-  | :? Range as r ->
-      let (Within(x, within)) = r
-      (new NUnit.Framework.Constraints.EqualConstraint(x)).Within(within)
-  | _ ->
-    new NUnit.Framework.Constraints.EqualConstraint(x)
-
 [<Test>]
 let ``Moving count works`` () =
   let s1 = Series.ofValues [ 0.0; 1.0; Double.NaN; 3.0; 4.0 ]
@@ -43,8 +33,8 @@ let ``Moving count works`` () =
   let e1 = 6.0
   let e2 = 8.0
 
-  s1 |> Stats.movingCount 2 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingCount 2 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingCount 2 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingCount 2 |> Series.sum |> should beWithin (e2 +/- 1e-9)
  
 [<Test>]
 let ``Moving sum works`` () =
@@ -54,8 +44,8 @@ let ``Moving sum works`` () =
   let e1 = 12.0
   let e2 = 16.0
 
-  s1 |> Stats.movingSum 2 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingSum 2 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingSum 2 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingSum 2 |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Moving mean works`` () =
@@ -66,8 +56,8 @@ let ``Moving mean works`` () =
   let e1 = 8.0
   let e2 = 8.0
 
-  s1 |> Stats.movingMean 2 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingMean 2 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingMean 2 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingMean 2 |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Moving stddev works`` () =
@@ -78,8 +68,8 @@ let ``Moving stddev works`` () =
   let e1 = 1.4142135623730951
   let e2 = 2.8284271247461903
 
-  s1 |> Stats.movingStdDev 2 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingStdDev 2 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingStdDev 2 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingStdDev 2 |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Moving skew works`` () =
@@ -90,8 +80,8 @@ let ``Moving skew works`` () =
   let e1 = -2.7081486342972996
   let e2 = -4.6963310471597577
 
-  s1 |> Stats.movingSkew 3 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingSkew 3 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingSkew 3 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingSkew 3 |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Moving min works`` () =
@@ -102,8 +92,8 @@ let ``Moving min works`` () =
   let e1 = -18.0
   let e2 = -18.0
 
-  s1 |> Stats.movingMin 3 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingMin 3 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingMin 3 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingMin 3 |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Moving max works`` () =
@@ -114,8 +104,8 @@ let ``Moving max works`` () =
   let e1 = 18.0
   let e2 = 20.0
 
-  s1 |> Stats.movingMax 3 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingMax 3 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingMax 3 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingMax 3 |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Moving kurt works`` () =
@@ -126,8 +116,8 @@ let ``Moving kurt works`` () =
   let e1 = 1.9686908218659251
   let e2 = 1.3147969613040118
 
-  s1 |> Stats.movingKurt 4 |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.movingKurt 4 |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.movingKurt 4 |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.movingKurt 4 |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Expanding mean works`` () =
@@ -138,8 +128,8 @@ let ``Expanding mean works`` () =
   let e1 = 4.333333333333333
   let e2 = 5.0
 
-  s1 |> Stats.expandingMean |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.expandingMean |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.expandingMean |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.expandingMean |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Expanding stddev works`` () =
@@ -150,8 +140,8 @@ let ``Expanding stddev works`` () =
   let e1 = 4.7674806523755962
   let e2 = 4.5792400600065433
 
-  s1 |> Stats.expandingStdDev |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.expandingStdDev |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.expandingStdDev |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.expandingStdDev |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Expanding skew works`` () =
@@ -162,8 +152,8 @@ let ``Expanding skew works`` () =
   let e1 =  0.25348662300133284
   let e2 = -0.99638293603701233
 
-  s1 |> Stats.expandingSkew |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.expandingSkew |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.expandingSkew |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.expandingSkew |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Expanding kurt works`` () =
@@ -174,8 +164,8 @@ let ``Expanding kurt works`` () =
   let e1 = 0.90493406707689539
   let e2 = -1.4288501854055262
 
-  s1 |> Stats.expandingKurt |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.expandingKurt |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.expandingKurt |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.expandingKurt |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Expanding min works`` () =
@@ -185,8 +175,8 @@ let ``Expanding min works`` () =
   let e1 = -18.0
   let e2 = -18.0
 
-  s1 |> Stats.expandingMin |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.expandingMin |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.expandingMin |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.expandingMin |> Series.sum |> should beWithin (e2 +/- 1e-9)
 
 [<Test>]
 let ``Expanding max works`` () =
@@ -196,5 +186,55 @@ let ``Expanding max works`` () =
   let e1 = 18.0
   let e2 = 20.0
 
-  s1 |> Stats.expandingMax |> Series.sum |> should equal (e1 +/- 1e-9)
-  s2 |> Stats.expandingMax |> Series.sum |> should equal (e2 +/- 1e-9)
+  s1 |> Stats.expandingMax |> Series.sum |> should beWithin (e1 +/- 1e-9)
+  s2 |> Stats.expandingMax |> Series.sum |> should beWithin (e2 +/- 1e-9)
+
+// ------------------------------------------------------------------------------------------------
+// Statistics
+// ------------------------------------------------------------------------------------------------
+
+open FsCheck
+open MathNet.Numerics.Statistics
+
+[<Test>]
+let ``Mean is the same as in Math.NET``() =
+  Check.QuickThrowOnFailure(fun (input:int[]) -> 
+    let d = DescriptiveStatistics(Array.map float input) 
+    let s = Series.ofValues (Array.map float input)
+    if s.ValueCount < 1 then 
+      Double.IsNaN(Stats.mean s) |> shouldEqual true
+    else 
+      Stats.mean s |> should beWithin (d.Mean +/- 1e-9) )
+
+[<Test>]
+let ``StdDev and Variance is the same as in Math.NET``() =
+  Check.QuickThrowOnFailure(fun (input:int[]) -> 
+    let d = DescriptiveStatistics(Array.map float input) 
+    let s = Series.ofValues (Array.map float input)
+    if s.ValueCount < 2 then 
+      Double.IsNaN(Stats.variance s) |> shouldEqual true
+      Double.IsNaN(Stats.stdDev s) |> shouldEqual true
+    else 
+      Stats.variance s |> should beWithin (d.Variance +/- 1e-9) 
+      Stats.stdDev s |> should beWithin (d.StandardDeviation +/- 1e-9) )
+
+[<Test>]
+let ``Skewness is the same as in Math.NET``() =
+  Check.QuickThrowOnFailure(fun (input:int[]) -> 
+    let d = DescriptiveStatistics(Array.map float input) 
+    let s = Series.ofValues (Array.map float input)
+    if s.ValueCount < 3 then 
+      Double.IsNaN(Stats.skew s) |> shouldEqual true
+    else 
+      Stats.skew s |> should beWithin (d.Skewness +/- 1e-9) )
+
+[<Test>]
+let ``Kurtosis is the same as in Math.NET``() =
+  Check.QuickThrowOnFailure(fun (input:int[]) -> 
+    let d = DescriptiveStatistics(Array.map float input) 
+    let s = Series.ofValues (Array.map float input)
+    if s.ValueCount < 4 then 
+      Double.IsNaN(Stats.kurt s) |> shouldEqual true
+    else 
+      Stats.kurt s |> should beWithin (d.Kurtosis +/- 1e-9) )
+

--- a/tests/Deedle.Tests/packages.config
+++ b/tests/Deedle.Tests/packages.config
@@ -4,4 +4,5 @@
   <package id="FSharp.Data" version="1.1.10" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="NUnit.Runners" version="2.6.3" targetFramework="net45" />
+  <package id="MathNet.Numerics" version="3.0.0-alpha8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I have not done any major changes in the implementation, so this checkin mainly just adds documentation to the functions etc. (I will add separate documentation page in an upcoming commit).

The notable changes are:
- I removed `Array.copy` from `movingWindowFn`. This function is internal and none of our uses mutates the array, so this is safe (it speeds things up only a little though). I also made some functions `inline`, but this also does not add that much.
- In `initSumsSparse`, I replaces `Seq.filter` and `Seq.map` with single  `Array.choose`. This actually makes things a bit faster
- When calculating expanding variance and standard deviation, I changed  the code to return `nan` when there are less than 2 elements (before, this  returned 0 for no elements and `nan` for 1 elements, which, I think, does not make sense).
- I added "normal" versions of all the functions so that you can use e.g. `Stat.mean` to get mean of a series. I think we should move all statistics into the `Stat` module (for consistency and to cleanup the namespaces).
- I also added a couple of tests comparing our statistics with those reported  by Math.NET. Curiously, [Wolfram Alpha returns some of the numbers differently](https://twitter.com/tomaspetricek/status/447466666814107648) but Deedle matches Math.NET, so this must be some oddity.
