### PR TITLE
[WiP] More cleanup and some bug fixes

### DIFF
--- a/docs/content/csharp/Frame.cs
+++ b/docs/content/csharp/Frame.cs
@@ -120,11 +120,11 @@ namespace CSharp
 
       // [series-dropadd]
       // Drop series from a data frame
-      joinIn.DropSeries("MsftAdj Close");
-      joinIn.DropSeries("FbAdj Close");
+      joinIn.DropColumn("MsftAdj Close");
+      joinIn.DropColumn("FbAdj Close");
 
       // Add new series to a frame
-      joinIn.AddSeries("MsftDiff", msDiff);
+      joinIn.AddColumn("MsftDiff", msDiff);
       joinIn.Print();
       // [/series-dropadd]
 

--- a/docs/content/csharp/Frame.cs
+++ b/docs/content/csharp/Frame.cs
@@ -64,8 +64,8 @@ namespace CSharp
       var fb = fbRaw.IndexRows<DateTime>("Date").SortRowsByKey();
       
       // And rename columns to avoid overlap
-      msft.RenameSeries(s => "Msft" + s);
-      fb.RenameSeries(s => "Fb" + s);
+      msft.RenameColumns(s => "Msft" + s);
+      fb.RenameColumns(s => "Fb" + s);
       // [/index-date]
 
       // [index-cols]
@@ -113,8 +113,8 @@ namespace CSharp
 
       // [series-get]
       // Get MSFT and FB opening prices and calculate the difference
-      var msOpen = joinIn.GetSeries<double>("MsftOpen");
-      var msClose = joinIn.GetSeries<double>("MsftClose");
+      var msOpen = joinIn.GetColumn<double>("MsftOpen");
+      var msClose = joinIn.GetColumn<double>("MsftClose");
       var msDiff = msClose - msOpen;
       // [/series-get]
 
@@ -171,7 +171,7 @@ namespace CSharp
       // Transform all numerical series
       // (round the values to 2 fractional digits)
       var round = 
-        returns.SeriesApply((Series<DateTime, double> numeric) => 
+        returns.ColumnApply((Series<DateTime, double> numeric) => 
           numeric.Select(kvp => Math.Round(kvp.Value, 2)));
       // [/ops-returns]
       round.Print();

--- a/docs/content/csharp/Series.cs
+++ b/docs/content/csharp/Series.cs
@@ -64,7 +64,7 @@ namespace CSharp
       // [create-csv]
       var frame = Frame.ReadCsv(Path.Combine(root, "../data/stocks/msft.csv"));
       var frameDate = frame.IndexRows<DateTime>("Date").SortRowsByKey();
-      var msftOpen = frameDate.GetSeries<double>("Open");
+      var msftOpen = frameDate.GetColumn<double>("Open");
       msftOpen.Print();
       // [/create-csv]
 

--- a/docs/content/features.fsx
+++ b/docs/content/features.fsx
@@ -108,10 +108,10 @@ let people = peopleList |> Frame.indexRowsString "Name"
 (**
 Note that this does not perform any conversion on the column data. Numerical series
 can be accessed using the `?` operator. For other types, we need to explicitly call
-`GetSeries` with the right type arguments:
+`GetColumn` with the right type arguments:
 *)
 people?Age
-people.GetSeries<string list>("Countries")
+people.GetColumn<string list>("Countries")
 
 (**
 <a name="creating-wb"></a>
@@ -248,7 +248,7 @@ series of series.
 // (the '?' operator converts values automatically)
 people?Age
 // Get the 'Name' column as a series of 'string' values
-people.GetSeries<string>("Name")
+people.GetColumn<string>("Name")
 // Get all frame columns as a series of series
 people.Columns
 
@@ -302,7 +302,7 @@ people.Columns?Name.TryAs<int>()
 The type `ObjectSeries<string>` has a few methods in addition to ordinary `Series<K, V>` type.
 On the lines 18 and 20, we use `As<T>` and `TryAs<T>` that can be used to convert object series
 to a series with statically known type of values. The expression on line 18 is equivalent to
-`people.GetSeries<string>("Name")`, but it is not specific to frame columns - you can use the
+`people.GetColumn<string>("Name")`, but it is not specific to frame columns - you can use the
 same approach to work with frame rows (using `people.Rows`) if your data set has rows of 
 homogeneous types.
 
@@ -504,7 +504,7 @@ using `df.Rows` and `df.Columns`, so the first option is also useful on data fra
 In the following sample, we use the data frame `people` loaded from F# records in 
 [an earlier section](#creating-recd). Let's first get the data:
 *)
-let travels = people.GetSeries<string list>("Countries")
+let travels = people.GetColumn<string list>("Countries")
 // [fsi:val travels : Series<string,string list> =]
 // [fsi:  Joe     -> [UK; US; UK]       ]
 // [fsi:  Tomas   -> [CZ; UK; US; ... ] ]
@@ -650,7 +650,7 @@ byClassAndPort
 |> Frame.meanLevel Pair.get1And2Of3
 
 // Count number of survivors in each group
-byClassAndPort.GetSeries<bool>("Survived")
+byClassAndPort.GetColumn<bool>("Survived")
 |> Series.applyLevel Pair.get1And2Of3 (Series.values >> Seq.countBy id >> series)
 |> Frame.ofRows
 

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -46,7 +46,7 @@ let bySex =
   grouped
   |> Series.map (fun sex df -> 
       // Group by the 'Survived' column & count by Boolean values
-      df.GetSeries<bool>("Survived") |> Series.groupBy (fun k v -> v) 
+      df.GetColumn<bool>("Survived") |> Series.groupBy (fun k v -> v) 
       |> Frame.ofColumns |> Frame.countValues )
   |> Frame.ofRows
   |> Frame.indexColsWith ["Died"; "Survived"]

--- a/docs/content/rinterop.fsx
+++ b/docs/content/rinterop.fsx
@@ -109,7 +109,7 @@ open FSharp.Charting
 mtcars
 |> Frame.groupRowsByInt "gear"
 |> Frame.meanLevel fst
-|> Frame.getSeries "mpg"
+|> Frame.getColumn "mpg"
 |> Series.observations |> Chart.Column
 
 (**

--- a/docs/content/samples/titanic.fsx
+++ b/docs/content/samples/titanic.fsx
@@ -24,7 +24,7 @@ Draw a pie chart displaying the survival rate
 titanic
 |> Frame.groupRowsByBool "Survived"
 |> Frame.countLevel fst
-|> Frame.getSeries "PassengerId"
+|> Frame.getColumn "PassengerId"
 |> Series.indexWith ["Died"; "Survived"]
 |> Series.observations
 |> Chart.Pie

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -20,7 +20,8 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FSharp.Formatting.2.2.12-beta/lib/net40"
+#I "../../packages/FSharp.Compiler.Service.0.0.32/lib/net40"
+#I "../../packages/FSharp.Formatting.2.4.3/lib/net40"
 #I "../../packages/RazorEngine.3.3.0/lib/net40/"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
@@ -48,7 +49,7 @@ let content    = __SOURCE_DIRECTORY__ @@ "../content"
 let output     = __SOURCE_DIRECTORY__ @@ "../output"
 let files      = __SOURCE_DIRECTORY__ @@ "../files"
 let templates  = __SOURCE_DIRECTORY__ @@ "templates"
-let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.2.12-beta/"
+let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.4.3/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
@@ -69,7 +70,9 @@ let buildReference () =
   for lib in referenceBinaries do
     MetadataFormat.Generate
       ( bin @@ lib, output @@ "reference", layoutRoots, 
-        parameters = ("root", root)::info )
+        parameters = ("root", root)::info,
+        sourceRepo = "https://github.com/BlueMountainCapital/Deedle/tree/master/",
+        sourceFolder = __SOURCE_DIRECTORY__.Substring(0, __SOURCE_DIRECTORY__.Length - "\docs\tools".Length ) )
 
 // Build documentation from `fsx` and `md` files in `docs/content`
 let buildDocumentation () =

--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FSharp.Charting" version="0.87" targetFramework="net45" />
   <package id="FSharp.Data" version="1.1.10" targetFramework="net45" />
-  <package id="FSharp.Formatting" version="2.2.12-beta" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.4.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
   <package id="MathNet.Numerics" version="2.6.1" targetFramework="net45" />

--- a/src/Deedle.RProvider.Plugin/Convertors.fs
+++ b/src/Deedle.RProvider.Plugin/Convertors.fs
@@ -83,7 +83,7 @@ let constructFrame (df:DataFrame) rowIndex colIndex =
   // TODO: Do not always create column with objects - pick int/string/something
   let data = Array.init df.ColumnCount (fun colIndex ->
     let colData = rows |> Array.map (fun r -> r.[colIndex])
-    VectorHelpers.createTypedVector Vectors.ArrayVector.ArrayVectorBuilder.Instance colData)
+    VectorHelpers.createInferredTypeVector Vectors.ArrayVector.ArrayVectorBuilder.Instance colData)
   Some(Frame<_,_>(rowIndex, colIndex, Vector.ofValues data))
 
 /// Convert R expression to a data frame and return frame of an

--- a/src/Deedle/Deedle.fsx
+++ b/src/Deedle/Deedle.fsx
@@ -13,8 +13,4 @@
 #r "Deedle.dll"
 
 do fsi.AddPrinter(fun (printer:Deedle.Internal.IFsiFormattable) -> "\n" + (printer.Format()))
-
 open Deedle
-
-let x = frame [ "a" => series [ 0 => 1.0; 1 => 2.0; 2 => 3.0 ]; 
-                "b" => series [ 0 => 5.0; 1 => 6.0; 2 => nan ] ]

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -918,7 +918,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     frame.ColumnApply(false, fun (s:Series<'TRowKey, 'T>) -> (Series.mapValues op s) :> ISeries<_>)
   // Apply operation 'op' to all values in all columns convertible to 'T1 (the operation returns different type!)
   static member inline internal UnaryGenericOperation<'T1, 'T2>(frame:Frame<'TRowKey, 'TColumnKey>, op : 'T1 -> 'T2) =
-    frame.ColumnsApply(false, fun (s:Series<'TRowKey, 'T1>) -> (Series.mapValues op s) :> ISeries<_>)
+    frame.ColumnApply(false, fun (s:Series<'TRowKey, 'T1>) -> (Series.mapValues op s) :> ISeries<_>)
 
   // Unary numerical operators (just minus)
 

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -585,11 +585,16 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
       vopt |> OptionalValue.bind (fun ser -> ser.TryAs<'R>(false)))
 
   /// [category:Fancy accessors]
+  member frame.GetRows<'R>() = 
+    frame.Rows.SelectOptional(fun (KeyValue(k, vopt)) ->
+      vopt |> OptionalValue.bind (fun ser -> ser.TryAs<'R>(false)))
+
+  /// [category:Fancy accessors]
   member frame.GetAllValues<'R>() = frame.GetAllValues<'R>(false)
 
   /// [category:Fancy accessors]
   member frame.GetAllValues<'R>(strict) =
-    seq { for (KeyValue(_, v)) in frame.GetAllSeries<'R>() do yield! v |> Series.values }
+    seq { for (KeyValue(_, v)) in frame.GetAllColumns<'R>() do yield! v |> Series.values }
 
   /// Returns data of the data frame as a 2D array. The method attempts to convert
   /// all values to the specified type 'R. When a value is missing, the specified 
@@ -777,17 +782,16 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     frame.ReplaceSeries(column, data, Lookup.Exact)
 
 
-
   /// [category:Series operations]
   member frame.Item 
-    with get(column:'TColumnKey) = frame.GetSeries<float>(column)
+    with get(column:'TColumnKey) = frame.GetColumn<float>(column)
     and set(column:'TColumnKey) (series:Series<'TRowKey, float>) = frame.ReplaceSeries(column, series)
 
   /// [category:Series operations]
-  member frame.SeriesApply<'T>(f) = frame.SeriesApply<'T>(false, f)
+  member frame.ColumnApply<'T>(f) = frame.ColumnApply<'T>(false, f)
 
   /// [category:Series operations]
-  member frame.SeriesApply<'T>(strict, f:Func<Series<'TRowKey, 'T>, ISeries<_>>) = 
+  member frame.ColumnApply<'T>(strict, f:Func<Series<'TRowKey, 'T>, ISeries<_>>) = 
     frame.Columns |> Series.mapValues (fun os ->
       match os.TryAs<'T>(strict) with
       | OptionalValue.Present s -> f.Invoke s
@@ -795,7 +799,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     |> fromColumnsNonGeneric id
 
   /// [category:Series operations]
-  member frame.GetSeries<'R>(column:'TColumnKey, lookup) : Series<'TRowKey, 'R> = 
+  member frame.GetColumn<'R>(column:'TColumnKey, lookup) : Series<'TRowKey, 'R> = 
     match safeGetColVector(column, lookup, fun _ -> true) with
     | :? IVector<'R> as vec -> 
         Series.Create(rowIndex, vec)
@@ -803,23 +807,23 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
         Series.Create(rowIndex, changeType colVector)
 
   /// [category:Series operations]
-  member frame.GetSeriesAt<'R>(index:int) : Series<'TRowKey, 'R> = 
+  member frame.GetColumnAt<'R>(index:int) : Series<'TRowKey, 'R> = 
     frame.Columns.GetAt(index).As<'R>()
 
   /// [category:Series operations]
-  member frame.GetSeries<'R>(column:'TColumnKey) : Series<'TRowKey, 'R> = 
-    frame.GetSeries(column, Lookup.Exact)
+  member frame.GetColumn<'R>(column:'TColumnKey) : Series<'TRowKey, 'R> = 
+    frame.GetColumn(column, Lookup.Exact)
 
   /// [category:Series operations]
-  member frame.GetAllSeries<'R>() = frame.GetAllSeries<'R>(false)
+  member frame.GetAllColumns<'R>() = frame.GetAllColumns<'R>(false)
 
   /// [category:Series operations]
-  member frame.TryGetSeries<'R>(column:'TColumnKey, lookup) =
+  member frame.TryGetColumn<'R>(column:'TColumnKey, lookup) =
     tryGetColVector(column, lookup, fun _ -> true) 
     |> OptionalValue.map (fun v -> Series.Create(rowIndex, changeType<'R> v))
 
   /// [category:Series operations]
-  member frame.TryGetSeriesObservation<'R>(column:'TColumnKey, lookup) =
+  member frame.TryGetColumnObservation<'R>(column:'TColumnKey, lookup) =
     let columnIndex = columnIndex.Lookup(column, lookup, fun _ -> true)
     if not columnIndex.HasValue then 
       OptionalValue.Missing 
@@ -830,25 +834,25 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
         KeyValuePair(fst columnIndex.Value, ser) )
 
   /// [category:Series operations]
-  member frame.GetAllSeries<'R>(strict) =
+  member frame.GetAllColumns<'R>(strict) =
     frame.Columns.Observations |> Seq.choose (fun os -> 
       match os.Value.TryAs<'R>(strict) with
       | OptionalValue.Present s -> Some (KeyValuePair(os.Key, s))
       | _ -> None)
 
   /// [category:Series operations]
-  member frame.RenameSeries(columnKeys) =
+  member frame.RenameColumns(columnKeys) =
     if Seq.length columnIndex.Keys <> Seq.length columnKeys then 
       invalidArg "columnKeys" "The number of new column keys does not match with the number of columns"
     frame.setColumnIndex (Index.ofKeys columnKeys)
 
   /// [category:Series operations]
-  member frame.RenameSeries(oldKey, newKey) =
+  member frame.RenameColumn(oldKey, newKey) =
     let newKeys = columnIndex.Keys |> Seq.map (fun k -> if k = oldKey then newKey else k)
     frame.setColumnIndex (Index.ofKeys newKeys)
 
   /// [category:Series operations]
-  member frame.RenameSeries(mapping:Func<_, _>) =
+  member frame.RenameColumns(mapping:Func<_, _>) =
     frame.setColumnIndex (Index.ofKeys (Seq.map mapping.Invoke columnIndex.Keys))
 
   /// [category:Series operations]
@@ -861,7 +865,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Series operations]
   static member (?) (frame:Frame<_, _>, column) : Series<'T, float> = 
-    frame.GetSeries<float>(column)
+    frame.GetColumn<float>(column)
 
   // ----------------------------------------------------------------------------------------------
   // Some operators
@@ -895,10 +899,10 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     Frame<'TRowKey, 'TColumnKey>.ScalarOperationR<'T>(frame, scalar, fun a b -> op b a)
   // Apply operation 'op' to all values in all columns convertible to 'T
   static member inline internal NullaryOperation<'T>(frame:Frame<'TRowKey, 'TColumnKey>, op : 'T -> 'T) = 
-    frame.SeriesApply(false, fun (s:Series<'TRowKey, 'T>) -> (Series.mapValues op s) :> ISeries<_>)
+    frame.ColumnApply(false, fun (s:Series<'TRowKey, 'T>) -> (Series.mapValues op s) :> ISeries<_>)
   // Apply operation 'op' to all values in all columns convertible to 'T1 (the operation returns different type!)
   static member inline internal NullaryGenericOperation<'T1, 'T2>(frame:Frame<'TRowKey, 'TColumnKey>, op : 'T1 -> 'T2) =
-    frame.SeriesApply(false, fun (s:Series<'TRowKey, 'T1>) -> (Series.mapValues op s) :> ISeries<_>)
+    frame.ColumnApply(false, fun (s:Series<'TRowKey, 'T1>) -> (Series.mapValues op s) :> ISeries<_>)
 
   // Pointwise binary operations applied to two frames
 
@@ -1273,7 +1277,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
             if typeof<'TColumnKey> = typeof<string> then unbox<'TColumnKey> name
             else invalidOp "Dynamic operations are not supported on frames with non-string column key!"
           // In principle, 'retType' could be something else than 'obj', but C# never does this (?)
-          <@@ box ((%%frame : Frame<'TRowKey, 'TColumnKey>).GetSeries<float>(colKey)) @@>)
+          <@@ box ((%%frame : Frame<'TRowKey, 'TColumnKey>).GetColumn<float>(colKey)) @@>)
 
         (fun frame name argTyp argExpr -> 
           // Cast column key to the right type
@@ -1446,7 +1450,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     Series<_, _>(newIndex, Vector.ofValues groups, vectorBuilder, indexBuilder)
 
   member frame.GroupRowsBy<'TGroup when 'TGroup : equality>(colKey) =
-    let col = frame.GetSeries<'TGroup>(colKey)    
+    let col = frame.GetColumn<'TGroup>(colKey)    
     frame.GroupByLabels col.Values frame.RowCount
 
   member frame.GroupRowsByIndex(keySelector:Func<_, _>) =
@@ -1473,7 +1477,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let labels = frame.Rows.Values |> Seq.map (Series.getAll grpKeys >> Series.values >> Array.ofSeq) 
     let nested = frame.NestRowsBy(labels)
     nested
-    |> Series.map (fun _ f -> [for c in aggBy -> (c, aggFunc.Invoke(f.GetSeries<_>(c)) |> box)] )
+    |> Series.map (fun _ f -> [for c in aggBy -> (c, aggFunc.Invoke(f.GetColumn<_>(c)) |> box)] )
     |> Series.map (fun k v -> v |> Seq.append (k |> Seq.zip grpKeys) |> Series.ofObservations)
     |> Series.indexOrdinally
     |> FrameUtils.fromRows
@@ -1488,7 +1492,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///
   /// [category:Indexing]
   member frame.IndexRows<'TNewRowIndex when 'TNewRowIndex : equality>(column) : Frame<'TNewRowIndex, _> = 
-    let columnVec = frame.GetSeries<'TNewRowIndex>(column)
+    let columnVec = frame.GetColumn<'TNewRowIndex>(column)
     let lookup addr = columnVec.Vector.GetValue(addr)
     let newRowIndex, rowCmd = frame.IndexBuilder.WithIndex(frame.RowIndex, lookup, Vectors.Return 0)
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder rowCmd)

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -649,8 +649,8 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `series` - A sequence of values to be added
   ///
   /// [category:Series operations]
-  member frame.AddSeries(column:'TColumnKey, series:seq<_>) = 
-    frame.AddSeries(column, series, Lookup.Exact)
+  member frame.AddColumn(column:'TColumnKey, series:seq<_>) = 
+    frame.AddColumn(column, series, Lookup.Exact)
 
   /// Mutates the data frame by adding an additional data series
   /// as a new column with the specified column key. The operation 
@@ -661,8 +661,8 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `column` - A key (or name) for the newly added column
   ///
   /// [category:Series operations]
-  member frame.AddSeries(column:'TColumnKey, series:ISeries<_>) = 
-    frame.AddSeries(column, series, Lookup.Exact)
+  member frame.AddColumn(column:'TColumnKey, series:ISeries<_>) = 
+    frame.AddColumn(column, series, Lookup.Exact)
 
   /// Mutates the data frame by adding an additional data series
   /// as a new column with the specified column key. The sequence is
@@ -678,11 +678,11 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///    nearest available value with the smaller/greater key).
   ///
   /// [category:Series operations]
-  member frame.AddSeries(column:'TColumnKey, series:seq<'V>, lookup) = 
+  member frame.AddColumn(column:'TColumnKey, series:seq<'V>, lookup) = 
     if isEmpty then
       if typeof<'TRowKey> = typeof<int> then
         let series = unbox<Series<'TRowKey, 'V>> (Series.ofValues series)
-        frame.AddSeries(column, series, lookup)
+        frame.AddColumn(column, series, lookup)
       else
         invalidOp "Adding data sequence to an empty frame with non-integer columns is not supported."
     else
@@ -697,7 +697,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
           Vector.ofOptionalValues (Seq.append (Seq.map Some series) nulls)
 
       let series = Series(frame.RowIndex, vector, vectorBuilder, indexBuilder)
-      frame.AddSeries(column, series, lookup)
+      frame.AddColumn(column, series, lookup)
 
   /// Mutates the data frame by adding an additional data series
   /// as a new column with the specified column key. The operation 
@@ -713,7 +713,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///    nearest available value with the smaller/greater key).
   ///
   /// [category:Series operations]
-  member frame.AddSeries<'V>(column:'TColumnKey, series:ISeries<'TRowKey>, lookup) = 
+  member frame.AddColumn<'V>(column:'TColumnKey, series:ISeries<'TRowKey>, lookup) = 
     if isEmpty then
       // If the frame was empty, then initialize both indices
       rowIndex <- series.Index
@@ -734,7 +734,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `frame` - Source data frame (which is not mutated by the operation)
   ///
   /// [category:Series operations]
-  member frame.DropSeries(column:'TColumnKey) = 
+  member frame.DropColumn(column:'TColumnKey) = 
     let newColumnIndex, colCmd = indexBuilder.DropItem( (columnIndex, Vectors.Return 0), column)
     data <- vectorBuilder.Build(colCmd, [| data |])
     frame.setColumnIndex newColumnIndex
@@ -751,10 +751,10 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///    nearest available value with the smaller/greater key).
   ///
   /// [category:Series operations]
-  member frame.ReplaceSeries(column:'TColumnKey, series:ISeries<_>, lookup) = 
+  member frame.ReplaceColumn(column:'TColumnKey, series:ISeries<_>, lookup) = 
     if columnIndex.Lookup(column, Lookup.Exact, fun _ -> true).HasValue then
-      frame.DropSeries(column)
-    frame.AddSeries(column, series, lookup)
+      frame.DropColumn(column)
+    frame.AddColumn(column, series, lookup)
 
   /// Mutates the data frame by replacing the specified series with
   /// a new data sequence. (If the series does not exist, only the new series is added.) 
@@ -769,9 +769,9 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///    nearest available value with the smaller/greater key).
   ///
   /// [category:Series operations]
-  member frame.ReplaceSeries(column, data:seq<'V>, lookup) = 
+  member frame.ReplaceColumn(column, data:seq<'V>, lookup) = 
     let newSeries = Series(frame.RowIndex, Vector.ofValues data, vectorBuilder, indexBuilder)
-    frame.ReplaceSeries(column, newSeries, lookup)
+    frame.ReplaceColumn(column, newSeries, lookup)
 
   /// Mutates the data frame by replacing the specified series with
   /// a new series. (If the series does not exist, only the new
@@ -782,8 +782,8 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `series` - A data series to be used (the row key type has to match)
   ///
   /// [category:Series operations]
-  member frame.ReplaceSeries(column:'TColumnKey, series:ISeries<_>) = 
-    frame.ReplaceSeries(column, series, Lookup.Exact)
+  member frame.ReplaceColumn(column:'TColumnKey, series:ISeries<_>) = 
+    frame.ReplaceColumn(column, series, Lookup.Exact)
 
   /// Mutates the data frame by replacing the specified series with
   /// a new data sequence . (If the series does not exist, only the new
@@ -794,14 +794,14 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `series` - A sequence of values to be added
   ///
   /// [category:Series operations]
-  member frame.ReplaceSeries(column, data:seq<'V>) = 
-    frame.ReplaceSeries(column, data, Lookup.Exact)
+  member frame.ReplaceColumn(column, data:seq<'V>) = 
+    frame.ReplaceColumn(column, data, Lookup.Exact)
 
 
   /// [category:Series operations]
   member frame.Item 
     with get(column:'TColumnKey) = frame.GetColumn<float>(column)
-    and set(column:'TColumnKey) (series:Series<'TRowKey, float>) = frame.ReplaceSeries(column, series)
+    and set(column:'TColumnKey) (series:Series<'TRowKey, float>) = frame.ReplaceColumn(column, series)
 
   /// [category:Series operations]
   member frame.ColumnApply<'T>(f) = frame.ColumnApply<'T>(false, f)
@@ -873,11 +873,11 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Series operations]
   static member (?<-) (frame:Frame<_, _>, column, series:Series<'T, 'V>) =
-    frame.ReplaceSeries(column, series)
+    frame.ReplaceColumn(column, series)
 
   /// [category:Series operations]
   static member (?<-) (frame:Frame<_, _>, column, data:seq<'V>) =
-    frame.ReplaceSeries(column, data)
+    frame.ReplaceColumn(column, data)
 
   /// [category:Series operations]
   static member (?) (frame:Frame<_, _>, column) : Series<'T, float> = 
@@ -1305,9 +1305,9 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
           let colKey =
             if typeof<'TColumnKey> = typeof<string> then unbox<'TColumnKey> name
             else invalidOp "Dynamic operations are not supported on frames with non-string column key!"
-          // If it is a series, then we can just call ReplaceSeries using quotation
+          // If it is a series, then we can just call ReplaceColumn using quotation
           if typeof<ISeries<'TRowKey>>.IsAssignableFrom argTyp then
-            <@@ (%%frame : Frame<'TRowKey, 'TColumnKey>).ReplaceSeries(colKey, (%%(Expr.Coerce(argExpr, typeof<ISeries<'TRowKey>>)) : ISeries<'TRowKey>)) @@>
+            <@@ (%%frame : Frame<'TRowKey, 'TColumnKey>).ReplaceColumn(colKey, (%%(Expr.Coerce(argExpr, typeof<ISeries<'TRowKey>>)) : ISeries<'TRowKey>)) @@>
           else 
             // Try to find seq<'T> implementation
             let elemTy = 
@@ -1318,15 +1318,15 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
             match elemTy with
             | None -> invalidOp (sprintf "Cannot add value of type %s as a series!" argTyp.Name)
             | Some elemTy ->
-                // Find the ReplaceSeries method taking seq<'T>
-                let addSeriesSeq = 
+                // Find the ReplaceColumn method taking seq<'T>
+                let AddColumnSeq = 
                   typeof<Frame<'TRowKey, 'TColumnKey>>.GetMethods() |> Seq.find (fun mi -> 
-                    mi.Name = "ReplaceSeries" && 
+                    mi.Name = "ReplaceColumn" && 
                       ( let pars = mi.GetParameters()
                         pars.Length = 2 && pars.[1].ParameterType.GetGenericTypeDefinition() = typedefof<seq<_>> ))
                 // Generate call for the right generic specialization
                 let seqTyp = typedefof<seq<_>>.MakeGenericType(elemTy)
-                Expr.Call(frame, addSeriesSeq.MakeGenericMethod(elemTy), [Expr.Value name; Expr.Coerce(argExpr, seqTyp)] ) )
+                Expr.Call(frame, AddColumnSeq.MakeGenericMethod(elemTy), [Expr.Value name; Expr.Coerce(argExpr, seqTyp)] ) )
 
 
 

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -933,7 +933,7 @@ type FrameExtensions =
   ///
   [<Extension>]
   static member Diff(frame:Frame<'TRowKey, 'TColumnKey>, offset) = 
-    frame.SeriesApply<float>(false, fun s -> Series.diff offset s :> ISeries<_>)
+    frame.ColumnApply<float>(false, fun s -> Series.diff offset s :> ISeries<_>)
 
   [<Extension>]
   static member Reduce(frame:Frame<'TRowKey, 'TColumnKey>, aggregation:Func<'T, 'T, 'T>) = 

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -905,7 +905,7 @@ type FrameExtensions =
 
   [<Extension>]
   static member Diff(frame:Frame<'TRowKey, 'TColumnKey>, offset) = 
-    frame.SeriesApply<float>(false, fun s -> Series.diff offset s :> ISeries<_>)
+    frame.ColumnApply<float>(false, fun s -> Series.diff offset s :> ISeries<_>)
 
   [<Extension>]
   static member Reduce(frame:Frame<'TRowKey, 'TColumnKey>, aggregation:Func<'T, 'T, 'T>) = 

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -834,10 +834,10 @@ module Frame =
     frame.Columns |> Series.map (fun _ -> Series.countValues)
 
   let inline maxRowBy column (frame:Frame<'R, 'C>) = 
-    frame.Rows |> Series.maxBy (fun row -> row.GetAs<float>(column))
+    frame.Rows |> Stats.maxBy (fun row -> row.GetAs<float>(column))
 
   let inline minRowBy column (frame:Frame<'R, 'C>) = 
-    frame.Rows |> Series.minBy (fun row -> row.GetAs<float>(column))
+    frame.Rows |> Stats.minBy (fun row -> row.GetAs<float>(column))
 
   // ----------------------------------------------------------------------------------------------
   // Hierarchical aggregation
@@ -1204,21 +1204,3 @@ module Frame =
   /// Returns data of the data frame as a 2D array containing data as `float` values.
   /// Missing data are represented as `Double.NaN` in the returned array.
   let toArray2D (frame:Frame<'R, 'C>) = frame.ToArray2D<float>()
-
-  // ----------------------------------------------------------------------------------------------
-  // Obsolete - kept for temporary compatibility
-  // ----------------------------------------------------------------------------------------------
-
-  [<Obsolete("Use sortRowsByKey instead. This function will be removed in future versions.")>]
-  let orderRows (frame:Frame<'R, 'C>) = sortRowsByKey frame
-  [<Obsolete("Use sortColsByKey instead. This function will be removed in future versions.")>]
-  let orderCols (frame:Frame<'R, 'C>) = sortColsByKey frame
-  [<Obsolete("Use Stats.colMean instead. This function will be removed in future versions.")>]
-  let mean (frame:Frame<'R, 'C>) = frame.GetColumns<float>() |> Series.map (fun _ -> Stats.mean)
-  [<Obsolete("Use Stats.colSum instead. This function will be removed in future versions.")>]
-  let sum (frame:Frame<'R, 'C>) = frame.GetColumns<float>() |> Series.map (fun _ -> Stats.sum)
-  [<Obsolete("Use Stats.colStdDev instead. This function will be removed in future versions.")>]
-  let sdv (frame:Frame<'R, 'C>) = frame.GetColumns<float>() |> Series.map (fun _ -> Stats.stdDev)
-  [<Obsolete("Use Stats.colMedian instead. This function will be removed in future versions.")>]
-  let median (frame:Frame<'R, 'C>) = frame.GetColumns<float>() |> Series.map (fun _ -> Stats.median)
-

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -63,11 +63,20 @@ module Frame =
   let columns (frame:Frame<'R, 'C>) = frame.Columns
 
   /// Returns a series of columns of the data frame indexed by the column keys, 
-  /// which contains those series whose values are convertible to 'T, and with 
+  /// which contains those series whose values are convertible to `'T`, and with 
   /// missing values where the conversion fails.
   ///
+  /// If you want to get numeric columns, you can use a simpler `numericCols` function
+  /// instead. Note that this function typically requires a type annotation. This can
+  /// be specified in various ways, for example by annotating the result value:
+  ///
+  ///     let (res:Series<_, Series<_, string>>) = frame |> typedCols
+  ///
+  /// Here, the annotation on the values of the nested series specifies that we want
+  /// to get columns containing `string` values.
+  ///
   /// [category:Accessing frame data and lookup]
-  [<CompiledName("TypedCols")>]
+  [<CompiledName("TypedColumns")>]
   let typedCols (frame:Frame<'R,'C>) : Series<'C,Series<'R,'T>> =
     frame.Columns 
     |> Series.map(fun _ v -> v.TryAs<'T>() |> OptionalValue.asOption) 

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -61,14 +61,23 @@ module Frame =
   /// [category:Accessing frame data and lookup]
   [<CompiledName("Columns")>]
   let columns (frame:Frame<'R, 'C>) = frame.Columns
+  
+  /// Returns a specified column from a data frame. This function uses exact matching 
+  /// semantics on the key. Use `lookupSeries` if you want to use inexact 
+  /// matching (e.g. on dates)
+  ///
+  /// [category:Accessing frame data and lookup]
+  [<CompiledName("GetColumn")>]
+  let getColumn column (frame:Frame<'R, 'C>) : Series<'R, 'V> = 
+    frame.GetColumn(column)
 
   /// Returns a series of columns of the data frame indexed by the column keys, 
   /// which contains those series whose values are convertible to 'T, and with 
   /// missing values where the conversion fails.
   ///
   /// [category:Accessing frame data and lookup]
-  [<CompiledName("TypedCols")>]
-  let typedCols (frame:Frame<'R,'C>) : Series<'C,Series<'R,'T>> =
+  [<CompiledName("GetColumns")>]
+  let getColumns (frame:Frame<'R,'C>) : Series<'C,Series<'R,'T>> =
     frame.Columns 
     |> Series.map(fun _ v -> v.TryAs<'T>() |> OptionalValue.asOption) 
     |> Series.flatten
@@ -78,9 +87,9 @@ module Frame =
   /// missing values where the conversion fails.
   ///
   /// [category:Accessing frame data and lookup]
-  [<CompiledName("NumericCols")>]
-  let numericCols (frame:Frame<'R,'C>) : Series<'C,Series<'R,float>> =
-    frame |> typedCols
+  [<CompiledName("GetNumericColumns")>]
+  let getNumericColumns (frame:Frame<'R,'C>) : Series<'C,Series<'R,float>> =
+    frame |> getColumns
 
   /// Returns the rows of the data frame as a series (indexed by 
   /// the row keys of the source frame) containing untyped series representing
@@ -90,15 +99,6 @@ module Frame =
   [<CompiledName("Rows")>]
   let rows (frame:Frame<'R, 'C>) = frame.Rows
 
-  /// Returns a specified column from a data frame. This function uses exact matching 
-  /// semantics on the key. Use `lookupSeries` if you want to use inexact 
-  /// matching (e.g. on dates)
-  ///
-  /// [category:Accessing frame data and lookup]
-  [<CompiledName("GetSeries")>]
-  let getSeries column (frame:Frame<'R, 'C>) : Series<'R, 'V> = 
-    frame.GetSeries(column)
-
   /// Returns a specified row from a data frame. This function uses exact matching 
   /// semantics on the key. Use `lookupRow` if you want to use inexact matching 
   /// (e.g. on dates)
@@ -107,13 +107,24 @@ module Frame =
   [<CompiledName("GetRow")>]
   let getRow row (frame:Frame<'R, 'C>) = frame.GetRow(row)
 
+  /// Returns a series of rows of the data frame indexed by the row keys, 
+  /// which contains those rows whose values are convertible to 'T, and with 
+  /// missing values where the conversion fails.
+  ///
+  /// [category:Accessing frame data and lookup]
+  [<CompiledName("GetRows")>]
+  let getRows (frame:Frame<'R,'C>) : Series<'R,Series<'C,'T>> =
+    frame.Rows 
+    |> Series.map(fun _ v -> v.TryAs<'T>() |> OptionalValue.asOption) 
+    |> Series.flatten
+
   /// Returns a specified series (column) from a data frame. If the data frame has 
   /// ordered column index, the lookup semantics can be used to get series
   /// with nearest greater/smaller key. For exact semantics, you can use `getCol`.
   ///
   /// [category:Accessing frame data and lookup]
   [<CompiledName("LookupColumn")>]
-  let lookupCol column lookup (frame:Frame<'R, 'C>) = frame.GetSeries(column, lookup)
+  let lookupCol column lookup (frame:Frame<'R, 'C>) = frame.GetColumn(column, lookup)
 
   /// Returns a specified series (column) from a data frame, or missing value if 
   /// column doesn't exist.
@@ -121,7 +132,7 @@ module Frame =
   /// [category:Accessing frame data and lookup]
   [<CompiledName("TryLookupColumn")>]
   let tryLookupCol column lookup (frame:Frame<'R, 'C>) = 
-    frame.TryGetSeries(column, lookup) |> OptionalValue.asOption
+    frame.TryGetColumn(column, lookup) |> OptionalValue.asOption
 
   /// Returns a specified key and series (column) from a data frame, or missing value if 
   /// doesn't exist.
@@ -129,7 +140,7 @@ module Frame =
   /// [category:Accessing frame data and lookup]
   [<CompiledName("TryLookupColObservation")>]
   let tryLookupColObservation column lookup (frame:Frame<'R, 'C>) = 
-    frame.TryGetSeriesObservation(column, lookup) 
+    frame.TryGetColumnObservation(column, lookup) 
     |> OptionalValue.asOption 
     |> Option.map (fun kvp -> kvp.Key, kvp.Value)
 
@@ -161,16 +172,16 @@ module Frame =
   /// data frame. The function uses exact key matching semantics.
   ///
   /// [category:Accessing frame data and lookup]
-  [<CompiledName("GetColumns")>]
-  let getCols (columns:seq<_>) (frame:Frame<'R, 'C>) = 
+  [<CompiledName("SliceCols")>]
+  let sliceCols (columns:seq<_>) (frame:Frame<'R, 'C>) = 
     frame.Columns.[columns]
 
   /// Returns a frame consisting of the specified rows from the original
   /// data frame. The function uses exact key matching semantics.
   ///
   /// [category:Accessing frame data and lookup]
-  [<CompiledName("GetRows")>]
-  let getRows (rows:seq<_>) (frame:Frame<'R, 'C>) = 
+  [<CompiledName("SliceRows")>]
+  let sliceRows (rows:seq<_>) (frame:Frame<'R, 'C>) = 
     frame.Rows.[rows]
 
   // ----------------------------------------------------------------------------------------------
@@ -513,7 +524,7 @@ module Frame =
   /// [category:Data structure manipulation]
   [<CompiledName("SortRows")>]
   let sortRows colKey (frame:Frame<'R,'C>) =
-    let newRowIndex, rowCmd = frame.GetSeries(colKey) |> Series.sortWithCommand compare
+    let newRowIndex, rowCmd = frame.GetColumn(colKey) |> Series.sortWithCommand compare
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder rowCmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData)
 
@@ -526,7 +537,7 @@ module Frame =
   /// [category:Data structure manipulation]
   [<CompiledName("SortRowsWith")>]
   let sortRowsWith colKey compareFunc (frame:Frame<'R,'C>) =
-    let newRowIndex, rowCmd = frame.GetSeries(colKey) |> Series.sortWithCommand compareFunc
+    let newRowIndex, rowCmd = frame.GetColumn(colKey) |> Series.sortWithCommand compareFunc
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder rowCmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData)
 
@@ -539,7 +550,7 @@ module Frame =
   /// [category:Data structure manipulation]
   [<CompiledName("SortRowBy")>]
   let sortRowsBy colKey (f:'T -> 'V) (frame:Frame<'R,'C>) =
-    let newRowIndex, rowCmd = frame.GetSeries(colKey) |> Series.sortByCommand f
+    let newRowIndex, rowCmd = frame.GetColumn(colKey) |> Series.sortByCommand f
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder rowCmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData)
 
@@ -755,7 +766,7 @@ module Frame =
       raise (new AggregateException(exceptions))
 
   let fillErrorsWith (value:'T) (frame:Frame<'R, 'C>) = 
-    frame.SeriesApply(true, fun (s:Series<_, 'T tryval>) -> 
+    frame.ColumnApply(true, fun (s:Series<_, 'T tryval>) -> 
       (Series.fillErrorsWith value s) :> ISeries<_>)
 
   let reduce (op:'T -> 'T -> 'T) (frame:Frame<'R, 'C>) = 
@@ -786,7 +797,7 @@ module Frame =
     frame |> mapColValues (Series.shift offset)
 
   let diff offset (frame:Frame<'R, 'C>) = 
-    frame.SeriesApply<float>(false, fun s -> Series.diff offset s :> ISeries<_>)
+    frame.ColumnApply<float>(false, fun s -> Series.diff offset s :> ISeries<_>)
 
   // ----------------------------------------------------------------------------------------------
   // Missing values
@@ -805,7 +816,7 @@ module Frame =
   /// [category:Missing values]
   [<CompiledName("FillMissingWith")>]
   let fillMissingWith (value:'T) (frame:Frame<'R, 'C>) =
-    frame.SeriesApply(true, fun (s:Series<_, 'T>) -> Series.fillMissingWith value s :> ISeries<_>)
+    frame.ColumnApply(true, fun (s:Series<_, 'T>) -> Series.fillMissingWith value s :> ISeries<_>)
 
   /// Fill missing values in the data frame with the nearest available value
   /// (using the specified direction). Note that the frame may still contain
@@ -843,7 +854,7 @@ module Frame =
   /// [category:Missing values]
   [<CompiledName("FillMissingUsing")>]
   let fillMissingUsing (f:Series<'R, 'T> -> 'R -> 'T) (frame:Frame<'R, 'C>) =
-    frame.SeriesApply(false, fun (s:Series<_, 'T>) -> Series.fillMissingUsing (f s) s :> ISeries<_>)
+    frame.ColumnApply(false, fun (s:Series<_, 'T>) -> Series.fillMissingUsing (f s) s :> ISeries<_>)
 
   /// Creates a new data frame that contains only those rows of the original 
   /// data frame that are _dense_, meaning that they have a value for each column.

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -60,15 +60,15 @@ module Frame =
   ///
   /// [category:Accessing frame data and lookup]
   [<CompiledName("Columns")>]
-  let columns (frame:Frame<'R, 'C>) = frame.Columns
+  let cols (frame:Frame<'R, 'C>) = frame.Columns
   
   /// Returns a specified column from a data frame. This function uses exact matching 
-  /// semantics on the key. Use `lookupSeries` if you want to use inexact 
+  /// semantics on the key. Use `lookupCol` if you want to use inexact 
   /// matching (e.g. on dates)
   ///
   /// [category:Accessing frame data and lookup]
   [<CompiledName("GetColumn")>]
-  let getColumn column (frame:Frame<'R, 'C>) : Series<'R, 'V> = 
+  let getCol column (frame:Frame<'R, 'C>) : Series<'R, 'V> = 
     frame.GetColumn(column)
 
   /// Returns a series of columns of the data frame indexed by the column keys, 
@@ -86,7 +86,7 @@ module Frame =
   ///
   /// [category:Accessing frame data and lookup]
   [<CompiledName("GetColumns")>]
-  let getColumns (frame:Frame<'R,'C>) : Series<'C,Series<'R,'T>> =
+  let getCols (frame:Frame<'R,'C>) : Series<'C,Series<'R,'T>> =
     frame.Columns 
     |> Series.map(fun _ v -> v.TryAs<'T>() |> OptionalValue.asOption) 
     |> Series.flatten
@@ -98,7 +98,7 @@ module Frame =
   /// [category:Accessing frame data and lookup]
   [<CompiledName("GetNumericColumns")>]
   let getNumericColumns (frame:Frame<'R,'C>) : Series<'C,Series<'R,float>> =
-    frame |> getColumns
+    frame |> getCols
 
   /// Returns the rows of the data frame as a series (indexed by 
   /// the row keys of the source frame) containing untyped series representing
@@ -133,14 +133,14 @@ module Frame =
   ///
   /// [category:Accessing frame data and lookup]
   [<CompiledName("LookupColumn")>]
-  let lookupCol column lookup (frame:Frame<'R, 'C>) = frame.GetColumn(column, lookup)
+  let lookupCol column lookup (frame:Frame<'R, 'C>) : Series<'R, 'V> = frame.GetColumn(column, lookup)
 
   /// Returns a specified series (column) from a data frame, or missing value if 
   /// column doesn't exist.
   ///
   /// [category:Accessing frame data and lookup]
   [<CompiledName("TryLookupColumn")>]
-  let tryLookupCol column lookup (frame:Frame<'R, 'C>) = 
+  let tryLookupCol column lookup (frame:Frame<'R, 'C>) : option<Series<'R, 'V>> = 
     frame.TryGetColumn(column, lookup) |> OptionalValue.asOption
 
   /// Returns a specified key and series (column) from a data frame, or missing value if 
@@ -208,9 +208,9 @@ module Frame =
   ///  - `frame` - Source data frame (which is not mutated by the operation)
   ///
   /// [category:Series operations]
-  [<CompiledName("AddSeries")>]
-  let addSeries column (series:Series<_, 'V>) (frame:Frame<'R, 'C>) = 
-    let f = frame.Clone() in f.AddSeries(column, series); f
+  [<CompiledName("AddColumn")>]
+  let addCol column (series:Series<_, 'V>) (frame:Frame<'R, 'C>) = 
+    let f = frame.Clone() in f.AddColumn(column, series); f
 
   /// Creates a new data frame that contains all data from the original
   /// data frame without the specified series (column). The operation throws
@@ -221,9 +221,9 @@ module Frame =
   ///  - `frame` - Source data frame (which is not mutated by the operation)
   ///
   /// [category:Series operations]
-  [<CompiledName("DropSeries")>]
-  let dropSeries column (frame:Frame<'R, 'C>) = 
-    let f = frame.Clone() in f.DropSeries(column); f
+  [<CompiledName("DropColumn")>]
+  let dropCol column (frame:Frame<'R, 'C>) = 
+    let f = frame.Clone() in f.DropColumn(column); f
 
   /// Creates a new data frame where the specified column is replaced
   /// with a new series. (If the series does not exist, only the new
@@ -236,8 +236,8 @@ module Frame =
   ///
   /// [category:Series operations]
   [<CompiledName("ReplaceColumn")>]
-  let replaceSeries column series (frame:Frame<'R, 'C>) = 
-    let f = frame.Clone() in f.ReplaceSeries(column, series); f
+  let replaceCol column series (frame:Frame<'R, 'C>) = 
+    let f = frame.Clone() in f.ReplaceColumn(column, series); f
 
   // ----------------------------------------------------------------------------------------------
   // Grouping and hierarchical indexing

--- a/src/Deedle/Stats.fs
+++ b/src/Deedle/Stats.fs
@@ -302,10 +302,10 @@ open StatsHelpers
 ///    In this case, the result of the statisitcs is always attached to the last key
 ///    of the window. The function names are prefixed with `moving`.
 ///
-///  * **Expanding window** means that the window starts as a zero-element sized window
+///  * **Expanding window** means that the window starts as a single-element sized window
 ///    and expands as it moves over the series. In this case, statistics is calculated
-///    for all values preceding the current key. This means that the result is attached
-///    to the key _after_ the end of the window (prefix). The function names are prefixed
+///    for all values up to the current key. This means that the result is attached
+///    to the key at the end of the window. The function names are prefixed
 ///    with `expanding`.
 ///
 /// The resulting series has the same keys as the input series. When the window contains

--- a/tests/Deedle.CSharp.Tests/Frame.cs
+++ b/tests/Deedle.CSharp.Tests/Frame.cs
@@ -100,7 +100,7 @@ namespace Deedle.CSharp.Tests
 				}.Frame;
 				dynamic dfd = df;
 				dfd.Test1 = new[] { 1, 2 };
-				dfd.Test2 = df.GetSeries<double>("Test");
+				dfd.Test2 = df.GetColumn<double>("Test");
 				dfd.Test3 = new Dictionary<int, string> { { 1, "A" }, { 2, "B" } };
 				var row = df.Rows[2];
 
@@ -112,7 +112,7 @@ namespace Deedle.CSharp.Tests
 		}
 
 		[Test]
-		public static void CanGetSeriesDynamically()
+		public static void CanGetColumnDynamically()
 		{
 			for (int i = 1; i <= 2; i++) // Run this twice, to check that instance references are right
 			{

--- a/tests/Deedle.CSharp.Tests/Series.cs
+++ b/tests/Deedle.CSharp.Tests/Series.cs
@@ -113,7 +113,7 @@ namespace Deedle.CSharp.Tests
     {
 		var msft = Frame.ReadCsv(@"..\..\..\..\samples\data\msft.csv");
 
-		var s = msft.GetSeries<double>("Open");
+		var s = msft.GetColumn<double>("Open");
 
     IEnumerable<KeyValuePair<int, double>> kvps =
         Enumerable.Range(0, 10).Select(k => new KeyValuePair<int, double>(k, k * k));

--- a/tests/Deedle.RPlugin.Tests/RPlugin.fs
+++ b/tests/Deedle.RPlugin.Tests/RPlugin.fs
@@ -31,6 +31,13 @@ let ``Can roundtrip data frame (mtcars) between Deedle and R`` () =
   cars1 |> shouldEqual cars2
 
 [<Test>]
+let ``Can pass numerical stacked frames to R``() = 
+  let df1 = frame [ 10 => series [ 1 => 1.0 ]; 11 => series [ 2 => 2.0] ] |> Frame.stack
+  R.assign("df", df1) |> ignore
+  let df2 : Frame<int, string> = R.get("df").GetValue()
+  df1 |> shouldEqual df2
+
+[<Test>]
 let ``Can roundtrip data frames with missing values to R`` () =
   //
   // NOTE: R.NET always returns data as floats, so we only test this for floats

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -112,7 +112,7 @@ let testOne() =
                 "Died (%)" => survivals?Died/ survivals?Total * 100.0 ] |> frame
                 *)
       //CSharp.Tests.DynamicFrameTests.CanAddSeriesDynamically()
-      //CSharp.Tests.DynamicFrameTests.CanGetSeriesDynamically()
+      //CSharp.Tests.DynamicFrameTests.CanGetColumnDynamically()
 //      Tests.Frame.``Can group 10x5k data frame by row of type string and nest it (in less than a few seconds)``()
 //      Series(d1, d2).[300000.0 .. 600000.0] |> Series.filter (fun k _ -> true) |> Series.mean
 //      |> ignore

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -201,7 +201,7 @@ let testOne() =
                 "Died (%)" => survivals?Died/ survivals?Total * 100.0 ] |> frame
                 *)
       //CSharp.Tests.DynamicFrameTests.CanAddSeriesDynamically()
-      //CSharp.Tests.DynamicFrameTests.CanGetSeriesDynamically()
+      //CSharp.Tests.DynamicFrameTests.CanGetColumnDynamically()
 //      Tests.Frame.``Can group 10x5k data frame by row of type string and nest it (in less than a few seconds)``()
 //      Series(d1, d2).[300000.0 .. 600000.0] |> Series.filter (fun k _ -> true) |> Series.mean
 //      |> ignore

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -264,9 +264,9 @@ let ``Can retrieve a series according to type parameter`` () =
   let s2 = series [| 1 => ("a",1.0); 2 => ("b",2.0) |]
   let f = frame [ "A" => s1 ]
   f?B <- s2
-  f.GetAllSeries<int*int>() |> shouldEqual ( seq [ KeyValuePair("A", s1) ] )
-  f.GetAllSeries<string*float>() |> shouldEqual ( seq [ KeyValuePair("B", s2) ] )
-  f.GetAllSeries<int*float>() |> shouldEqual Seq.empty
+  f.GetAllColumns<int*int>() |> shouldEqual ( seq [ KeyValuePair("A", s1) ] )
+  f.GetAllColumns<string*float>() |> shouldEqual ( seq [ KeyValuePair("B", s2) ] )
+  f.GetAllColumns<int*float>() |> shouldEqual Seq.empty
 
 [<Test>]
 let ``Can do fuzzy lookup on frame rows and cols`` () =
@@ -442,7 +442,7 @@ let ``Can group 10x5k data frame by row of type string and nest it (in less than
 [<Test>]
 let ``Applying numerical operation to frame does not affect non-numeric series`` () =
   let df = msft() * 2.0
-  let actual = df.GetSeries<DateTime>("Date").GetAt(0).Date 
+  let actual = df.GetColumn<DateTime>("Date").GetAt(0).Date 
   actual |> shouldEqual (DateTime(2012, 1, 27))
   
 [<Test>]

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -255,9 +255,9 @@ let ``Can retrieve a series according to type parameter`` () =
   let s2 = series [| 1 => ("a",1.0); 2 => ("b",2.0) |]
   let f = frame [ "A" => s1 ]
   f?B <- s2
-  f.GetAllSeries<int*int>() |> shouldEqual ( seq [ KeyValuePair("A", s1) ] )
-  f.GetAllSeries<string*float>() |> shouldEqual ( seq [ KeyValuePair("B", s2) ] )
-  f.GetAllSeries<int*float>() |> shouldEqual Seq.empty
+  f.GetAllColumns<int*int>() |> shouldEqual ( seq [ KeyValuePair("A", s1) ] )
+  f.GetAllColumns<string*float>() |> shouldEqual ( seq [ KeyValuePair("B", s2) ] )
+  f.GetAllColumns<int*float>() |> shouldEqual Seq.empty
 
 [<Test>]
 let ``Can do fuzzy lookup on frame rows and cols`` () =
@@ -382,7 +382,7 @@ let ``Can group 10x5k data frame by row of type string and nest it (in less than
 [<Test>]
 let ``Applying numerical operation to frame does not affect non-numeric series`` () =
   let df = msft() * 2.0
-  let actual = df.GetSeries<DateTime>("Date").GetAt(0).Date 
+  let actual = df.GetColumn<DateTime>("Date").GetAt(0).Date 
   actual |> shouldEqual (DateTime(2012, 1, 27))
   
 [<Test>]

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -228,9 +228,10 @@ let ``Union correctly unions series, prefering left or right values``() =
   let input2 = Series.ofObservations [ 'c' => 1; 'd' => 4  ]
   let expectedL = Series.ofObservations [ 'a' => 1; 'b' => 2; 'c' => 3; 'd' => 4 ]
   let expectedR = Series.ofObservations [ 'a' => 1; 'b' => 2; 'c' => 1; 'd' => 4 ]
-  input1.Union(input2) |> shouldEqual expectedL
+  input1.Merge(input2) |> shouldEqual expectedL
   input1.Union(input2, UnionBehavior.PreferRight) |> shouldEqual expectedR
 
+  (series [ 1=>nan; 2=>1.0]).Append(series [1=> 1.0])
 [<Test>] 
 let ``Union throws exception when behavior is exclusive and series overlap``() = 
   let input1 = Series.ofObservations [ 'a' => 1; 'b' => 2; 'c' => 3 ]

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -189,8 +189,21 @@ let ``Expanding max works`` () =
   s1 |> Stats.expandingMax |> Stats.sum |> should beWithin (e1 +/- 1e-9)
   s2 |> Stats.expandingMax |> Stats.sum |> should beWithin (e2 +/- 1e-9)
 
+[<Test>]
+let ``Basic level statistics works on sample input`` () = 
+  let s1 = series [(1,0) => nan; (1,1) => 2.0; (2,0) => 3.0; (2,1) => 4.0 ]  
+  s1 |> Stats.levelCount fst |> shouldEqual <| series [ 1 => 1; 2 => 2 ]
+  s1 |> Stats.levelSum fst |> shouldEqual <| series [ 1 => 2.0; 2 => 7.0 ]
+  s1 |> Stats.levelMean fst |> shouldEqual <| series [ 1 => 2.0; 2 => 3.5 ]
+
+[<Test>]
+let ``Advanced level statistics works on sample input`` () = 
+  let s1 = series [(1,0) => 1.0; (1,1) => 2.0; (1,2) => 3.0; (1,4) => 4.0; (2,0) => 3.0; (2,1) => 4.0 ]  
+  s1 |> Stats.levelKurt fst |> shouldEqual <| series [ 1 => -1.2; 2 => nan ]
+  s1 |> Stats.levelSkew fst |> shouldEqual <| series [ 1 => 0.0; 2 => nan ]
+
 // ------------------------------------------------------------------------------------------------
-// Statistics
+// Comparing results with Math.NET
 // ------------------------------------------------------------------------------------------------
 
 open FsCheck


### PR DESCRIPTION
- This includes various documentation fixes and improvements. I also updated F# Formatting, so that it now generates nicer Reference API docs with links to GitHub. This is quite useful to get nice overview of the function naming. 
- I fixed the bug #192, although not by changing `expandCols`, but by fixing `stack` (which now also works better with R, because it creates correctly typed vector).
- I finished cleanup in the `Stats` module (added back `level` functions and also moved `minBy` and `maxBy` there). This hopefully closes #185
- I did the renaming discussed in #179, so "union" and "append" functions on series are now both called "merge".

There are two TODO things before we can merge this:
- I need to fix and update all unit tests
- I did some more renaming related to "series" and "columns" - I'll post a comment in the discussion for #189 to get more feedback about this.
