### PR TITLE
Speedup df.AppendN (and rename appending functions on frame to merging)

### DIFF
--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -316,6 +316,9 @@ module OptionalValue =
   /// available, throws an exception. (This is equivalent to the `Value` property)
   let inline get (optional:'T opt) = optional.Value
     
+  /// Returns the value `def` when the argument is missing, otherwise returns its value
+  let inline defaultArg def (optional:'T opt) = 
+    if optional.HasValue then optional.Value else def
 
 
 // --------------------------------------------------------------------------------------

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -896,8 +896,8 @@ type FrameExtensions =
     frame.Columns.SelectKeys(projection) |> Frame.ofColumns
 
   [<Extension>]
-  static member Append(frame:Frame<'TRowKey, 'TColumnKey>, rowKey, row) = 
-    frame.Append(Frame.ofRows [ rowKey => row ])
+  static member Merge(frame:Frame<'TRowKey, 'TColumnKey>, rowKey, row) = 
+    frame.Merge(Frame.ofRows [ rowKey => row ])
 
   /// Returns a frame with columns shifted by the specified offset. When the offset is 
   /// positive, the values are shifted forward and first `offset` keys are dropped. When the

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1059,13 +1059,13 @@ module Frame =
   ///  - `frames` - The seq of frames to be appended (combined) 
   ///
   /// [category:Joining, zipping and appending]
-  [<CompiledName("AppendN")>]
-  let appendN (frames:Frame<'R, 'C> seq) =
+  [<CompiledName("MergeAll")>]
+  let mergeAll (frames:Frame<'R, 'C> seq) =
     if frames |> Seq.isEmpty then 
       Frame([], [])
     else 
       let head = frames |> Seq.head 
-      head.AppendN(frames |> Seq.skip 1)
+      head.Merge(frames |> Seq.skip 1)
 
   /// Append two data frames with non-overlapping values. The operation takes the union of columns
   /// and rows of the source data frames and then unions the values. An exception is thrown when 
@@ -1080,8 +1080,8 @@ module Frame =
   ///  - `otherFrame` - The other frame to be appended (combined) with the current instance
   ///
   /// [category:Joining, zipping and appending]
-  [<CompiledName("Append")>]
-  let append (frame1:Frame<'R, 'C>) frame2 = appendN [frame1; frame2]
+  [<CompiledName("Merge")>]
+  let merge (frame1:Frame<'R, 'C>) frame2 = mergeAll [frame1; frame2]
 
   /// Aligns two data frames using both column index and row index and apply the specified operation
   /// on values of a specified type that are available in both data frames. The parameters `columnKind`,
@@ -1150,7 +1150,7 @@ module Frame =
       |> Seq.map (fun k2 -> (k1, k2)) 
       |> (fun ix -> indexRowsWith ix df))
     |> Series.values
-    |> appendN
+    |> mergeAll
 
   /// Implements R-like 'stack' (returns frame whose 
   /// columns are named Row/Column/Value)

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -430,6 +430,10 @@ and
     Series(newIndex, newVector, vectorBuilder, indexBuilder)
 
   /// [category:Merging, joining and zipping]
+  member series.Merge(otherSeries:seq<Series<'K, 'V>>) =
+    series.Merge(Array.ofSeq otherSeries)
+
+  /// [category:Merging, joining and zipping]
   member series.Merge([<ParamArray>] otherSeries:Series<'K, 'V>[]) =
     // Append the row indices and get transformation that combines two column vectors
     // (LeftOrRight - specifies that when column exist in both data frames then fail)

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -1,7 +1,9 @@
-﻿module Main
-#if INTERACTIVE
-#I "..\\bin"
-#load "DataFrame.fsx"
+﻿#if INTERACTIVE
+#time
+#I "../../bin"
+#load "Deedle.fsx"
+#else
+module Main
 #endif
 
 open System
@@ -70,236 +72,39 @@ let testAll () =
 open Deedle
 
 let testOne() =
-  //let d1 = Array.init 1000000 float
-  //let d2 = Array.init 1000000 float
-
-//  let s = series [ for k in 0 .. 100000 -> k => float k ]
-(*
-  let genRandomNumbers count =
-    let rnd = System.Random()
-    List.init count (fun _ -> (float <| rnd.Next()) / (float Int32.MaxValue))
-  let r = genRandomNumbers 1000000
-  let n = Series.ofValues(r)
-  let f = Frame.ofColumns ["n" => n]
-  *)
-
-  let s1 = series [ for i in 0000001 .. 0100000 -> i => float i ]
-  let s3 = series [ for i in 1000001 .. 1100000 -> i => float i ]
-  let s4 = series [ for i in 2000001 .. 2100000 -> i => float i ]
-  let s2 = series [ for i in 3000001 .. 3100000 -> i => float i ]
-
-  //Deedle.Internal.Seq.useBinomial <- true
-
-  // 570, 270
-  printfn "Append few"
-  timed 5 (fun _ -> 
-    s1.Merge(s2, s3, s4) |> ignore
-  )
-
-  printfn "Append lots"
-  timed 5 (fun _ -> 
-      let mkSeries objId = Series([for j in 1..60 -> (objId, j)], [1..60])
-      let h::tl = [1..1000] |> List.map mkSeries  
-      h.Merge(tl |> Array.ofSeq) |> ignore
-  )
-//  s |> Series.chunkInto 100 Series.mean |> ignore
-//  s |> Series.chunkWhileInto (fun k1 k2 -> k2 - k1 < 100) Series.mean |> ignore
-//  s |> Series.windowWhileInto (fun k1 k2 -> k2 - k1 < 100) Series.mean |> ignore
-
-  //let titanic = Frame.ReadCsv(__SOURCE_DIRECTORY__ + @"\..\..\docs\content\data\Titanic.csv")
-  //let msft = Frame.ReadCsv(__SOURCE_DIRECTORY__ + @"\..\..\docs\content\data\stocks\msft.csv")
-  //let rows = ResizeArray<_>()
-  //let df = msft |> Frame.sortRowsByKey
-
-  //let df = frame [ for c in ["A";"B";"C";"D";"E"] -> c => series [ for i in 0 .. 500000 -> i => float i  ]]
+  let ordFrames =
+    [| for i in 0 .. 500 ->
+        [ for col in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" ->
+            col => series [  for j in 0 .. 100 -> (i, j) => 1.0 ] ] |> frame |]
   
-  (*
-  let size = 1000000
-  let rnd = Random()
-
-  for count in 10 .. 30 .. 300 do
-    let ss = Array.init count (fun _ -> ResizeArray<_>())
-    for i in 1 .. size do
-      ss.[rnd.Next(ss.Length)].Add( (i, float i) )
-    let sser = Array.map series ss
-
-    Deedle.Internal.Seq.useBinomial <- false
-    printfn "Normal (%d):" count
-    timed 2 (fun _ ->
-      Series.appendN sser |> ignore )
-
-    Deedle.Internal.Seq.useBinomial <- true
-    printfn "Binomial (%d):" count
-    timed 2 (fun _ ->
-      Series.appendN sser |> ignore )
-
-    printfn ""
-    *)
-
-
-  //timed 1 (fun () ->
-
-
-       //let nada = s |> Series.windowInto 100 Series.mean
-
-       //let nada = s |> Series.windowInto 100 Series.mean |> ignore
-
-       //rows.Add(f.RowsDense)
-
+  let unordFrames =
+    [| for i in 0 .. 500 ->
+        [ for col in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" ->
+            col => series [  for j in 0 .. 100 -> (i, 100-j) => 1.0 ] ] |> frame |]
       
-      // 37 sec, 41 sec, 42 sec, 42 sec ~~~> sub 1sec
-      //let mkSeries objId = Series([for j in 1..60 -> (objId, j)], [1..60])
-      //let h::tl = [1..2000] |> List.map mkSeries  
-      //h.Append(tl |> Array.ofSeq) |> ignore
+  timed 1 (fun () ->
+    
+    // 0.32
+    ordFrames.[0 .. 20] |> Frame.mergeAll |> ignore
+    // 1.75
+    ordFrames.[0 .. 50] |> Frame.mergeAll |> ignore
 
-      // 520ms // 1 sec
-      //s1.Append(s2, s3) |> ignore
+    // 0.32
+    unordFrames.[0 .. 20] |> Frame.mergeAll |> ignore
+    // 2.0
+    unordFrames.[0 .. 50] |> Frame.mergeAll |> ignore
 
-      // 926ms
-      //s1.Append(s2, s3, s4, s5) |> ignore
+    // 0.40
+    unordFrames |> Frame.mergeAll |> ignore
 
-      // 1930ms
-      //s1.Append(s2, s3, s4, s5, s6, s7, s8) |> ignore
+    
+    let df1 = frame [ "A" => series [1=>1.0] ]
+    let df2 = frame [ "B" => series [2=>1.0] ]
+    
+    df1.Merge(df2) |> ignore
+    ()
 
-    //  )
-
-      //df?A |> Series.windowInto 5 (fun _ -> 0.0) |> ignore // 1.2sec ~
-
-      //df |> Frame.shift 1 |> ignore // 3.2s
-      //df |> Frame.diff 1 |> ignore // 3.0s
-
-      // #time 
-
-      // 0.95
-      //s1.Append(s2, s3, s4) |> ignore
-      // 2.44
-      //s1.Append(s2).Append(s3) |> ignore
-      // 4.35
-      //s1.Append(s2).Append(s3).Append(s4) |> ignore
-      // 6.80
-      //s1.Append(s2).Append(s3).Append(s4).Append(s5) |> ignore
-
-      //s1.Append(s2, s3, s4, s5)
-
-
-      ///let nada2 = s |> Series.windowSizeInto (5, Boundary.Skip) (DataSegment.data >> Series.mean)
-  //    () 
-       (*
-        let bySex = titanic |> Frame.groupRowsByString "Sex"
-        let survivedBySex = bySex.Columns.["Survived"].As<bool>()
-        let survivals = 
-            survivedBySex
-            |> Series.applyLevel Pair.get1Of2 (fun sr -> 
-                sr.Values |> Seq.countBy id |> series)
-            |> Frame.ofRows
-            |> Frame.indexColsWith ["Survived"; "Died"]
-        survivals?Total <- 
-            bySex
-            |> Frame.applyLevel Pair.get1Of2 Series.countKeys
-        let summary = 
-              [ "Survived (%)" => survivals?Survived / survivals?Total * 100.0
-                "Died (%)" => survivals?Died/ survivals?Total * 100.0 ] |> frame
-                *)
-      //CSharp.Tests.DynamicFrameTests.CanAddSeriesDynamically()
-      //CSharp.Tests.DynamicFrameTests.CanGetColumnDynamically()
-//      Tests.Frame.``Can group 10x5k data frame by row of type string and nest it (in less than a few seconds)``()
-//      Series(d1, d2).[300000.0 .. 600000.0] |> Series.filter (fun k _ -> true) |> Series.mean
-//      |> ignore
-
-    //)
+  )
 
 //do testAll()
 do testOne()
-
-(*
-
-
-
-let s1 = series [ for i in 0000001 .. 0300000 -> i => float i ]
-let s2 = series [ for i in 1000001 .. 1300000 -> i => float i ]
-let s3 = series [ for i in 2000001 .. 2300000 -> i => float i ]
-let s4 = series [ for i in 3000001 .. 3300000 -> i => float i ]
-let s5 = series [ for i in 4000001 .. 4300000 -> i => float i ]
-let s6 = series [ for i in 5000001 .. 5300000 -> i => float i ]
-let s7 = series [ for i in 6000001 .. 6300000 -> i => float i ]
-let s8 = series [ for i in 7000001 .. 7300000 -> i => float i ]
-
-let ss = 
-  [ for i in 1 .. 64 ->
-      series [ for j in 1000000*i+1 .. 1000000*i+10000 -> j => float j ] ]
-// #time 
-
-// 0.95 ~> 0.38
-s1.Append(s2) |> ignore
-// 2.44 ~> 1.00
-s1.Append(s2).Append(s3) |> ignore
-// 4.35 ~> 1.75
-s1.Append(s2).Append(s3).Append(s4) |> ignore
-// 6.80 ~> 2.69
-s1.Append(s2).Append(s3).Append(s4).Append(s5) |> ignore
-
-s1.Append(s2).Append(s3).Append(s4).Append(s5).Append(s6).Append(s7).Append(s8) |> ignore
-
-// 15s
-s1.Append(Array.ofSeq ss) |> ignore
-// 29s
-ss |> List.fold (fun (s:Series<_, _>) v -> s.Append(v)) s1 |> ignore
-
-// Original in a new context
-//
-// 1.25
-// 3.18
-// 5.62
-// 8.57
-
-// Using sorted dictionary ( / better version with simpler "returnUsingAlignedSequences" )
-//
-// 1.35 / 1.19
-// 3.30 / 3.10
-// 5.95 / 5.60
-// 9.65 / 8.90
-
-// Using fancy general function
-//
-// 1.75
-// 3.95
-// 8.15
-// 13.25
-
-// 0.8 ~> 0.60
-s1.Append(s2, s3) |> ignore
-// 1.2 ~> 0.76
-s1.Append(s2, s3, s4) |> ignore
-// 1.8 ~> 1.0
-s1.Append(s2, s3, s4, s5) |> ignore
-// 3.55 ~> 1.8
-s1.Append(s2, s3, s4, s5, s6, s7, s8) |> ignore
-
-let r1 = series [ for i in 0000001 .. 0300000 -> i => float i ] |> Series.rev
-let r2 = series [ for i in 1000001 .. 1300000 -> i => float i ] |> Series.rev
-let r3 = series [ for i in 2000001 .. 2300000 -> i => float i ] |> Series.rev
-let r4 = series [ for i in 3000001 .. 3300000 -> i => float i ] |> Series.rev 
-let r5 = series [ for i in 4000001 .. 4300000 -> i => float i ] |> Series.rev
-let r6 = series [ for i in 5000001 .. 5300000 -> i => float i ] |> Series.rev
-
-// #time 
-
-// 1.05
-r1.Append(r2) |> ignore
-// 2.62 ~> 2.82
-r1.Append(r2).Append(r3) |> ignore
-// 4.82 ~> 5.15
-r1.Append(r2).Append(r3).Append(r4) |> ignore
-// 7.55 ~> 8.10
-r1.Append(r2).Append(r3).Append(r4).Append(r5) |> ignore
-
-// 1.90
-r1.Append(r2, r3) |> ignore
-// 2.95
-r1.Append(r2, r3, r4) |> ignore
-// 4.10
-r1.Append(r2, r3, r4, r5) |> ignore
-
-
-
-*)

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -513,7 +513,7 @@ let ``Can perform pointwise numerical operations on two frames`` () =
 let ``Can append two frames with disjoint columns`` () = 
   let df1 = Frame.ofColumns [ "A" => series [ for i in 1 .. 5 -> i, i ] ]
   let df2 = Frame.ofColumns [ "B" => series [ for i in 1 .. 5 -> i, i ] ]
-  let actual = df1.Append(df2) 
+  let actual = df1.Merge(df2) 
   actual.Rows.[3].GetAt(0) |> shouldEqual (box 3)
   actual.Rows.[3].GetAt(1) |> shouldEqual (box 3)
 
@@ -521,7 +521,7 @@ let ``Can append two frames with disjoint columns`` () =
 let ``Appending works on overlapping frames with missing values`` () =
   let df1 = Frame.ofColumns [ "A" => series [1 => Double.NaN; 2 => 1.0] ]
   let df2 = Frame.ofColumns [ "A" => series [2 => Double.NaN; 1 => 1.0] ]
-  let actual = df1.Append(df2)
+  let actual = df1.Merge(df2)
   actual.Columns.["A"] |> Series.mapValues (unbox<float>) 
   |> shouldEqual (series [1 => 1.0; 2 => 1.0])
 
@@ -529,7 +529,7 @@ let ``Appending works on overlapping frames with missing values`` () =
 let ``Appending fails on overlapping frames with overlapping values`` () =
   let df1 = Frame.ofColumns [ "A" => series [1 => Double.NaN; 2 => 1.0] ]
   let df2 = Frame.ofColumns [ "A" => series [2 => 1.0] ]
-  (fun () -> df1.Append(df2) |> ignore) |> should throw (typeof<InvalidOperationException>)
+  (fun () -> df1.Merge(df2) |> ignore) |> should throw (typeof<InvalidOperationException>)
 
 [<Test>]
 let ``Can append two frames with partially overlapping columns`` () = 
@@ -537,7 +537,7 @@ let ``Can append two frames with partially overlapping columns`` () =
   let df2 = Frame.ofColumns 
               [ "A" => series [ 6 => 10 ]
                 "B" => series [ for i in 1 .. 5 -> i, i ] ]
-  let actual = df1.Append(df2)
+  let actual = df1.Merge(df2)
   actual.Rows.[3].GetAt(0) |> shouldEqual (box 3)
   actual.Rows.[3].GetAt(1) |> shouldEqual (box 3)
   actual.Rows.[6].GetAt(0) |> shouldEqual (box 10)
@@ -547,14 +547,14 @@ let ``Can append two frames with partially overlapping columns`` () =
 let ``Can append two frames with single rows and keys with comparison that fails at runtime`` () = 
   let df1 = Frame.ofColumns [ "A" => series [ ([| 0 |], 0) => "A" ] ]
   let df2 = Frame.ofColumns [ "A" => series [ ([| 0 |], 1) => "A" ] ]
-  df1.Append(df2).RowKeys |> Seq.length |> shouldEqual 2
+  df1.Merge(df2).RowKeys |> Seq.length |> shouldEqual 2
  
 [<Test>]
 let ``Can append multiple frames`` () =
   let df1 = Frame.ofColumns [ "A" => series [ for i in 1 .. 5 -> i, i ] ]
   let df2 = Frame.ofColumns [ "B" => series [ for i in 1 .. 5 -> i, i ] ]
   let df3 = Frame.ofColumns [ "B" => series [ for i in 6 .. 9 -> i, i ] ]
-  let actual = Frame.appendN [df1;df2;df3]
+  let actual = Frame.mergeAll [df1;df2;df3]
   actual.Rows.[3].GetAt(0) |> shouldEqual (box 3)
   actual.Rows.[3].GetAt(1) |> shouldEqual (box 3)
   actual.Rows.[8].GetAt(1) |> shouldEqual (box 8)

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -199,8 +199,8 @@ let ``Basic level statistics works on sample input`` () =
 [<Test>]
 let ``Advanced level statistics works on sample input`` () = 
   let s1 = series [(1,0) => 1.0; (1,1) => 2.0; (1,2) => 3.0; (1,4) => 4.0; (2,0) => 3.0; (2,1) => 4.0 ]  
-  s1 |> Stats.levelKurt fst |> shouldEqual <| series [ 1 => -1.2; 2 => nan ]
-  s1 |> Stats.levelSkew fst |> shouldEqual <| series [ 1 => 0.0; 2 => nan ]
+  s1 |> Stats.levelKurt fst |> Stats.sum |> should beWithin (-1.2 +/- 1e-9)
+  s1 |> Stats.levelSkew fst |> Stats.sum |> should beWithin (0.0 +/- 1e-9)
 
 // ------------------------------------------------------------------------------------------------
 // Comparing results with Math.NET


### PR DESCRIPTION
There was a failing statistics test, but this was due to floating point
precision issue, so I updated the test.

The last failing test is the one comparing our skewness with Math.NET
but that is a Math.NET issue (#199)

I have not yet renamed Combine/CombineN in vector construction. I would
like to get rid of Combine and have just a single Merge, but I want to
see if this has any performance implications for two-element mergings
(which is probably the common case).
