### PR TITLE
Add more options for the Lookup operation (#201)

### DIFF
--- a/docs/content/csharp/Frame.cs
+++ b/docs/content/csharp/Frame.cs
@@ -103,7 +103,7 @@ namespace CSharp
 
       // This works! Find the value for the nearest smaller key
       // (that is, for the nearest earlier time with value)
-      var joinLeft = fb.Join(msftShift, JoinKind.Left, Lookup.NearestSmaller);
+      var joinLeft = fb.Join(msftShift, JoinKind.Left, Lookup.ExactOrSmaller);
       joinLeft.Print();
       // [/join-lookup]
 
@@ -137,7 +137,7 @@ namespace CSharp
       // Get row for the first available value after
       // the specified key (1 January 2013)
       var firstJan = joinIn.Rows.Get(new DateTime(2013, 1, 1), 
-        Lookup.NearestGreater);
+        Lookup.ExactOrGreater);
 
       // Get value for a specified column & row keys
       var diff = joinIn["MsftDiff", new DateTime(2013, 1, 4)];

--- a/docs/content/csharp/Series.cs
+++ b/docs/content/csharp/Series.cs
@@ -99,11 +99,11 @@ namespace CSharp
 
       // Get value at a key or for the nearest previous date
       var beforeJan1 = msftOpen
-        .Get(new DateTime(2012, 1, 1), Lookup.NearestSmaller);
+        .Get(new DateTime(2012, 1, 1), Lookup.ExactOrSmaller);
 
       // Get value at a key or for the nearest later date
       var afterJan1 = msftOpen
-        .Get(new DateTime(2012, 1, 1), Lookup.NearestGreater);
+        .Get(new DateTime(2012, 1, 1), Lookup.ExactOrGreater);
       // [/lookup-ord]
 
       // [lookup-slice]

--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -492,7 +492,6 @@ module Array =
 
   /// Returns a new array containing only the elements for which the specified function returns `Some`.
   /// The predicate is called with the index in the source array and the element.
-  /// When 'inclusive' is false, the function returns the index of strictry greater value.
   let inline choosei f (array:_[]) = 
     let res = new System.Collections.Generic.List<_>() // ResizeArray
     for i = 0 to array.Length - 1 do 

--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -464,24 +464,35 @@ module Array =
 
   /// Returns the index of 'key' or the index of immediately following value.
   /// If the specified key is greater than all keys in the array, None is returned.
-  let binarySearchNearestGreater key (comparer:System.Collections.Generic.IComparer<'T>) (array:ReadOnlyCollection<'T>) =
+  ///
+  /// When 'inclusive' is false, the function returns the index of strictry greater value.
+  /// Note that the function expects that the array contains distinct values
+  /// (which is fine because LinearIndex does not support duplicate keys)
+  let binarySearchNearestGreater key (comparer:System.Collections.Generic.IComparer<'T>) inclusive (array:ReadOnlyCollection<'T>) =
     if array.Count = 0 then None else
     let loc = binarySearch key comparer array
-    if comparer.Compare(array.[loc], key) >= 0 then Some loc
+    let comp = comparer.Compare(array.[loc], key)
+    if (comp = 0 && inclusive) || comp > 0 then Some loc
     elif loc + 1 < array.Count && comparer.Compare(array.[loc + 1], key) >= 1 then Some (loc + 1)
     else None
 
   /// Returns the index of 'key' or the index of immediately preceeding value.
   /// If the specified key is smaller than all keys in the array, None is returned.
-  let binarySearchNearestSmaller key (comparer:System.Collections.Generic.IComparer<'T>) (array:ReadOnlyCollection<'T>) =
+  ///
+  /// When 'inclusive' is false, the function returns the index of strictry smaller value.
+  /// Note that the function expects that the array contains distinct values
+  /// (which is fine because LinearIndex does not support duplicate keys)
+  let binarySearchNearestSmaller key (comparer:System.Collections.Generic.IComparer<'T>) inclusive (array:ReadOnlyCollection<'T>) =
     if array.Count = 0 then None else
     let loc = binarySearch key comparer array
-    if comparer.Compare(array.[loc], key) <= 0 then Some loc
+    let comp = comparer.Compare(array.[loc], key)
+    if (comp = 0 && inclusive) || comp < 0 then Some loc
     elif loc - 1 >= 0 && comparer.Compare(array.[loc - 1], key) <= 0 then Some (loc - 1)
     else None
 
   /// Returns a new array containing only the elements for which the specified function returns `Some`.
   /// The predicate is called with the index in the source array and the element.
+  /// When 'inclusive' is false, the function returns the index of strictry greater value.
   let inline choosei f (array:_[]) = 
     let res = new System.Collections.Generic.List<_>() // ResizeArray
     for i = 0 to array.Length - 1 do 

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -170,6 +170,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `columnKind` - Specifies how to align columns (inner, outer, left or right join)
   ///  - `rowKind` - Specifies how to align rows (inner, outer, left or right join)
   ///  - `lookup` - Specifies how to find matching value for a row (when using left or right join on rows)
+  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
   ///  - `op` - A function that is applied to aligned values. The `Zip` operation is generic
   ///    in the type of this function and the type of function is used to determine which 
   ///    values in the frames are zipped and which are left unchanged.
@@ -244,6 +245,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `lookup` - When `kind` is `Left` or `Right` and the two frames have ordered row index,
   ///    this parameter can be used to specify how to find value for a key when there is no
   ///    exactly matching key or when there are missing values.
+  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
   ///
   /// [category:Joining, zipping and appending]
   member frame.Join(otherFrame:Frame<'TRowKey, 'TColumnKey>, kind, lookup) =    
@@ -302,6 +304,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   ///  - `lookup` - When `kind` is `Left` or `Right` and the two frames have ordered row index,
   ///    this parameter can be used to specify how to find value for a key when there is no
   ///    exactly matching key or when there are missing values.
+  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
   ///
   /// [category:Joining, zipping and appending]
   member frame.Join<'V>(colKey, series:Series<'TRowKey, 'V>, kind, lookup) =    

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -10,22 +10,36 @@
 /// Represents different behaviors of key lookup in series. For unordered series,
 /// the only available option is `Lookup.Exact` which finds the exact key - methods
 /// fail or return missing value if the key is not available in the index. For ordered
-/// series `Lookup.NearestGreater` finds the first greater key (e.g. later date) with
-/// a value. `Lookup.NearestSmaller` searches for the first smaller key.
+/// series `Lookup.Greater` finds the first greater key (e.g. later date) with
+/// a value. `Lookup.Smaller` searches for the first smaller key. The options
+/// `Lookup.ExactOrGreater` and `Lookup.ExactOrSmaller` finds the exact key (if it is
+/// present) and otherwise search for the nearest larger or smaller key, respectively.
+[<System.Flags>]
 type Lookup = 
   /// Lookup a value associated with the exact specified key. 
   /// If the key is not available, then fail or return missing value. 
-  | Exact = 0
+  | Exact = 1
 
   /// Lookup a value associated with the specified key or with the nearest
   /// greater key that has a value available. Fails (or returns missing value)
   /// only when the specified key is greater than all available keys.
-  | NearestGreater = 1
+  | ExactOrGreater = 3
 
   /// Lookup a value associated with the specified key or with the nearest
   /// smaller key that has a value available. Fails (or returns missing value)
   /// only when the specified key is smaller than all available keys.
-  | NearestSmaller = 2
+  | ExactOrSmaller = 5
+
+  /// Lookup a value associated with a key that is greater than the specified one.
+  /// Fails (or returns missing value) when the specified key is greater or equal
+  /// to the greatest available key.
+  | Greater = 2
+
+  /// Lookup a value associated with a key that is smaller than the specified one.
+  /// Fails (or returns missing value) when the specified key is smaller or equal
+  /// to the smallest available key.
+  | Smaller = 4
+
 
 /// Represents a strategy for aggregating data in an ordered series into data segments.
 /// To create a value of this type from C#, use the non-generic `Aggregation` type.

--- a/src/Deedle/JoinHelpers.fs
+++ b/src/Deedle/JoinHelpers.fs
@@ -50,9 +50,10 @@ module internal JoinHelpers =
   /// When using fancy lookup, first fill values in the vector, before doing the join
   let fillMissing vector lookup = 
     match lookup with
-    | Lookup.NearestSmaller -> Vectors.FillMissing(vector, VectorFillMissing.Direction Direction.Forward)
-    | Lookup.NearestGreater -> Vectors.FillMissing(vector, VectorFillMissing.Direction Direction.Backward)
-    | Lookup.Exact | _ -> vector
+    | Lookup.ExactOrSmaller -> Vectors.FillMissing(vector, VectorFillMissing.Direction Direction.Forward)
+    | Lookup.ExactOrGreater -> Vectors.FillMissing(vector, VectorFillMissing.Direction Direction.Backward)
+    | Lookup.Exact -> vector
+    | _ -> invalidOp "Lookup.Smaller and Lookup.Greater are not supported when joining"
 
   /// Create transformation on indices/vectors representing the join operation
   let createJoinTransformation 

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -718,8 +718,8 @@ and
     let newObs = 
       seq {
         for k in keys do
-          let smaller = x.TryGetObservation(k, Lookup.NearestSmaller)
-          let bigger  = x.TryGetObservation(k, Lookup.NearestGreater)
+          let smaller = x.TryGetObservation(k, Lookup.ExactOrSmaller)
+          let bigger  = x.TryGetObservation(k, Lookup.ExactOrGreater)
           yield f.Invoke(k, smaller, bigger) }
       |> Seq.toArray
 

--- a/src/Deedle/SeriesExtensions.fs
+++ b/src/Deedle/SeriesExtensions.fs
@@ -523,7 +523,7 @@ type SeriesExtensions =
   /// [category:Lookup, resampling and scaling]
   [<Extension>]
   static member ResampleUniform(series:Series<'K, 'V>, keyProj:Func<_, _>, nextKey:Func<_, _>) =
-    Series.resampleUniformInto Lookup.NearestSmaller keyProj.Invoke nextKey.Invoke Series.lastValue series
+    Series.resampleUniformInto Lookup.ExactOrSmaller keyProj.Invoke nextKey.Invoke Series.lastValue series
 
   /// Resample the series based on equivalence class on the keys and also generate values 
   /// for all keys of the target space that are between the minimal and maximal key of the
@@ -572,7 +572,7 @@ type SeriesExtensions =
   /// [category:Lookup, resampling and scaling]
   [<Extension>]
   static member Sample<'V>(series:Series<DateTime, 'V>, start:DateTime, interval:TimeSpan, dir) =
-    series |> Series.Implementation.lookupTimeInternal (+) (Some start) interval dir Lookup.NearestSmaller
+    series |> Series.Implementation.lookupTimeInternal (+) (Some start) interval dir Lookup.ExactOrSmaller
 
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting at the specified `start` time, using the specified `interval`
@@ -594,7 +594,7 @@ type SeriesExtensions =
   /// [category:Lookup, resampling and scaling]
   [<Extension>]
   static member Sample<'V>(series:Series<DateTimeOffset, 'V>, start:DateTimeOffset, interval:TimeSpan, dir) =
-    series |> Series.Implementation.lookupTimeInternal (+) (Some start) interval dir Lookup.NearestSmaller
+    series |> Series.Implementation.lookupTimeInternal (+) (Some start) interval dir Lookup.ExactOrSmaller
 
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`
@@ -615,7 +615,7 @@ type SeriesExtensions =
   /// [category:Lookup, resampling and scaling]
   [<Extension>]
   static member Sample<'V>(series:Series<DateTime, 'V>, interval:TimeSpan, dir) =
-    series |> Series.Implementation.lookupTimeInternal (+) None interval dir Lookup.NearestSmaller
+    series |> Series.Implementation.lookupTimeInternal (+) None interval dir Lookup.ExactOrSmaller
 
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`
@@ -637,7 +637,7 @@ type SeriesExtensions =
   /// [category:Lookup, resampling and scaling]
   [<Extension>]
   static member Sample<'V>(series:Series<DateTimeOffset, 'V>, interval:TimeSpan, dir) =
-    series |> Series.Implementation.lookupTimeInternal (+) None interval dir Lookup.NearestSmaller
+    series |> Series.Implementation.lookupTimeInternal (+) None interval dir Lookup.ExactOrSmaller
 
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -1288,9 +1288,10 @@ module Series =
   ///
   /// ## Parameters
   ///  - `series` - An input series to be resampled
-  ///  - `fillMode` - When set to `Lookup.NearestSmaller` or `Lookup.NearestGreater`, 
+  ///  - `fillMode` - When set to `Lookup.ExactOrSmaller` or `Lookup.ExactOrGreater`, 
   ///     the function searches for a nearest available observation in an neighboring chunk.
   ///     Otherwise, the function `f` is called with an empty series as an argument.
+  ///     Values `Lookup.Smaller` and `Lookup.Greater` are not supported.
   ///  - `keyProj` - A function that transforms keys from original space to a new 
   ///    space (which is then used for grouping based on equivalence)
   ///  - `nextKey` - A function that gets the next key in the transformed space
@@ -1304,6 +1305,8 @@ module Series =
   ///
   /// [category:Sampling, resampling and advanced lookup]
   let resampleUniformInto (fillMode:Lookup) (keyProj:'K1 -> 'K2) (nextKey:'K2 -> 'K2) f (series:Series<'K1, 'V>) =
+    if not (fillMode.HasFlag(Lookup.Exact)) then
+      invalidOp "resampleUniformInto: The value of 'fillMode' must include 'Exact'."
     let min, max = series.KeyRange
     
     // Generate keys of the new space that fit in the range of the series
@@ -1322,10 +1325,10 @@ module Series =
     reindexed
     |> fillMissingUsing (fun k ->
         match fillMode with
-        | Lookup.NearestSmaller ->
+        | Lookup.ExactOrSmaller ->
             let res = reindexed.Get(k, fillMode)
             Series([res.KeyRange |> snd], [res.[res.KeyRange |> snd]])
-        | Lookup.NearestGreater ->
+        | Lookup.ExactOrGreater ->
             let res = reindexed.Get(k, fillMode)
             Series([res.KeyRange |> fst], [res.[res.KeyRange |> fst]]) 
         | _ -> Series([], [])  )
@@ -1586,6 +1589,7 @@ module Series =
   ///  - `lookup` specifies how matching keys are found when left or right join is used
   ///    on a sorted series. Use this to find the nearest smaller or nearest greater key
   ///    in the other series.
+  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
   ///  - `series1` - The first (left) series to be aligned
   ///  - `series2` - The second (right) series to be aligned
   ///
@@ -1611,6 +1615,7 @@ module Series =
   ///  - `lookup` specifies how matching keys are found when left or right join is used
   ///    on a sorted series. Use this to find the nearest smaller or nearest greater key
   ///    in the other series.
+  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
   ///  - `op` - A function that combines values from the two series. In case of left, right
   ///    or outer join, some of the values may be missing. The function can also return 
   ///    `None` to indicate a missing result.

--- a/tests/Deedle.RPlugin.Tests/RPlugin.fs
+++ b/tests/Deedle.RPlugin.Tests/RPlugin.fs
@@ -97,4 +97,12 @@ let ``Can pass data frame containing decimals to R (#90)``() =
   let actual = rframe.GetValue<Frame<int, string>>() 
   round (actual * 100.0) |> shouldEqual (round (df * 100.0))
 
+[<Test>]
+let ``Can index rows ordinally and pass the result to R (#146)`` () =
+  let df = Frame.ofRowKeys([0; 1])
+  df?col <- [10.0; 20.0]
+  let df2 = df |> Frame.indexRowsOrdinally 
+
+  R.assign("df", df2) |> ignore
+  R.get("df").GetValue<Frame<int, string>>() |> shouldEqual df2
 

--- a/tests/Deedle.Tests/Common.fs
+++ b/tests/Deedle.Tests/Common.fs
@@ -53,46 +53,88 @@ let ``Array.dropRange drops inclusive range from an array`` () =
   [| 1 .. 10 |] |> Array.dropRange 1 8 |> shouldEqual [| 1; 10 |]    
 
 [<Test>]
-let ``Binary searching for nearest greater value works`` () =
+let ``Binary searching for exact or greater value works`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
   new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
-  |> Array.binarySearchNearestGreater 5 comparer |> shouldEqual (Some 3)
+  |> Array.binarySearchNearestGreater 5 comparer true |> shouldEqual (Some 3)
   new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
-  |> Array.binarySearchNearestGreater 6 comparer |> shouldEqual (Some 3)
+  |> Array.binarySearchNearestGreater 6 comparer true |> shouldEqual (Some 3)
   new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
-  |> Array.binarySearchNearestGreater 7 comparer |> shouldEqual None
+  |> Array.binarySearchNearestGreater 7 comparer true |> shouldEqual None
   new ReadOnlyCollection<_> [| |]
-  |> Array.binarySearchNearestGreater 5 comparer |> shouldEqual None
+  |> Array.binarySearchNearestGreater 5 comparer true |> shouldEqual None
     
 [<Test>]
-let ``Binary searching for nearest smaller value works`` () =
+let ``Binary searching for exact or smaller value works`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
   new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
-  |> Array.binarySearchNearestSmaller 5 comparer |> shouldEqual (Some 2)
+  |> Array.binarySearchNearestSmaller 5 comparer true |> shouldEqual (Some 2)
   new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
-  |> Array.binarySearchNearestSmaller 6 comparer |> shouldEqual (Some 3)
+  |> Array.binarySearchNearestSmaller 6 comparer true |> shouldEqual (Some 3)
   new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
-  |> Array.binarySearchNearestSmaller 0 comparer |> shouldEqual None
+  |> Array.binarySearchNearestSmaller 0 comparer true |> shouldEqual None
   new ReadOnlyCollection<_> [| |]
-  |> Array.binarySearchNearestSmaller 5 comparer |> shouldEqual None
+  |> Array.binarySearchNearestSmaller 5 comparer true |> shouldEqual None
+
+[<Test>]
+let ``Binary searching for greater value works`` () =
+  let comparer = System.Collections.Generic.Comparer<int>.Default
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestGreater 5 comparer false |> shouldEqual (Some 3)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestGreater 2 comparer false |> shouldEqual (Some 2)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestGreater 6 comparer false |> shouldEqual None
+  new ReadOnlyCollection<_> [| |]
+  |> Array.binarySearchNearestGreater 5 comparer false |> shouldEqual None
     
 [<Test>]
-let ``Binary searching for nearest greater value satisfies laws`` () =
+let ``Binary searching for smaller value works`` () =
+  let comparer = System.Collections.Generic.Comparer<int>.Default
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestSmaller 5 comparer false |> shouldEqual (Some 2)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestSmaller 6 comparer false |> shouldEqual (Some 2)
+  new ReadOnlyCollection<_> [| 1; 2; 4; 6 |]
+  |> Array.binarySearchNearestSmaller 0 comparer false |> shouldEqual None
+  new ReadOnlyCollection<_> [| |]
+  |> Array.binarySearchNearestSmaller 5 comparer false |> shouldEqual None
+    
+[<Test>]
+let ``Binary searching for exact or greater value satisfies laws`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
   Check.QuickThrowOnFailure(fun (input:int[]) (key:int) -> 
     let input = new ReadOnlyCollection<_>(Array.sort input)
-    match Array.binarySearchNearestGreater key comparer input with
+    match Array.binarySearchNearestGreater key comparer true input with
     | Some idx -> input.[idx] >= key
     | None -> Seq.forall (fun v -> v < key) input )
 
 [<Test>]
-let ``Binary searching for nearest smaller value satisfies laws`` () =
+let ``Binary searching for exact or smaller value satisfies laws`` () =
   let comparer = System.Collections.Generic.Comparer<int>.Default
   Check.QuickThrowOnFailure(fun (input:int[]) (key:int) -> 
     let input = new ReadOnlyCollection<_>(Array.sort input)
-    match Array.binarySearchNearestSmaller key comparer input with
+    match Array.binarySearchNearestSmaller key comparer true input with
     | Some idx -> input.[idx] <= key
     | None -> Seq.forall (fun v -> v > key) input )
+
+[<Test>]
+let ``Binary searching for greater value satisfies laws`` () =
+  let comparer = System.Collections.Generic.Comparer<int>.Default
+  Check.QuickThrowOnFailure(fun (input:int[]) (key:int) -> 
+    let input = new ReadOnlyCollection<_>(input |> Seq.distinct |> Seq.sort |> Array.ofSeq)
+    match Array.binarySearchNearestGreater key comparer false input with
+    | Some idx -> input.[idx] > key
+    | None -> Seq.forall (fun v -> v <= key) input )
+
+[<Test>]
+let ``Binary searching for smaller value satisfies laws`` () =
+  let comparer = System.Collections.Generic.Comparer<int>.Default
+  Check.QuickThrowOnFailure(fun (input:int[]) (key:int) -> 
+    let input = new ReadOnlyCollection<_>(input |> Seq.distinct |> Seq.sort |> Array.ofSeq)
+    match Array.binarySearchNearestSmaller key comparer false input with
+    | Some idx -> input.[idx] < key
+    | None -> Seq.forall (fun v -> v >= key) input )
 
 [<Test>]
 let ``Seq.lastFew works on empty lists`` () = 

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -55,9 +55,14 @@ let ``Can access elements by address`` () =
   missing.TryGetAt(1).HasValue |> shouldEqual false
 
 [<Test>]  
-let ``Can lookup previous and next elements in ordered series`` () =
-  ordered.Get(4, Lookup.NearestGreater) |> shouldEqual "nazdar"
-  ordered.Get(4, Lookup.NearestSmaller) |> shouldEqual "ciao"
+let ``Can lookup previous and next elements (inclusively) in ordered series`` () =
+  ordered.Get(4, Lookup.ExactOrGreater) |> shouldEqual "nazdar"
+  ordered.Get(4, Lookup.ExactOrSmaller) |> shouldEqual "ciao"
+
+[<Test>]  
+let ``Can lookup previous and next elements (exclusively) in ordered series`` () =
+  ordered.Get(3, Lookup.Greater) |> shouldEqual "nazdar"
+  ordered.Get(3, Lookup.Smaller) |> shouldEqual "bye"
 
 // ------------------------------------------------------------------------------------------------
 // Value conversions
@@ -417,7 +422,7 @@ let ``Sample by keys - get the nearest previous key or <missing> (TestExplicitTi
     [ "12/20/2011" => Double.NaN; "1/5/2012" => 2.0;
       "1/8/2012" => 3.0; "1/19/2012" => 7.0; "1/29/2012" => 10.0 ]
     |> series |> Series.mapKeys parseDateUSA |> Series.mapValues int
-  let actual = input.GetItems(dateSampels, Lookup.NearestSmaller)
+  let actual = input.GetItems(dateSampels, Lookup.ExactOrSmaller)
   actual |> shouldEqual expected
 
 [<Test>]
@@ -601,7 +606,7 @@ let ``ZipInto correctly zips series with missing values and custom operation``()
 
 [<Test>]
 let ``ZipAlignInto correctly left-aligns and zips series with nearest smaller option``() =
-  let res = (a, b) ||> Series.zipAlignInto JoinKind.Left Lookup.NearestSmaller (lift2 (fun l r -> (l**2.0) * r))
+  let res = (a, b) ||> Series.zipAlignInto JoinKind.Left Lookup.ExactOrSmaller (lift2 (fun l r -> (l**2.0) * r))
   res.GetAt(0) |> shouldEqual 8.0
   res.GetAt(1) |> shouldEqual 32.0
   res.GetAt(2) |> shouldEqual 99.0
@@ -610,7 +615,7 @@ let ``ZipAlignInto correctly left-aligns and zips series with nearest smaller op
 
 [<Test>]
 let ``ZipAlignInto correctly left-aligns and zips series with nearest greater option``() =
-  let res = (a, b) ||> Series.zipAlignInto JoinKind.Left Lookup.NearestGreater (lift2 (fun l r -> (l**2.0) * r))
+  let res = (a, b) ||> Series.zipAlignInto JoinKind.Left Lookup.ExactOrGreater (lift2 (fun l r -> (l**2.0) * r))
   res.GetAt(0) |> shouldEqual 11.0
   res.GetAt(1) |> shouldEqual 44.0
   res.GetAt(2) |> shouldEqual 99.0
@@ -619,7 +624,7 @@ let ``ZipAlignInto correctly left-aligns and zips series with nearest greater op
 
 [<Test>]
 let ``ZipAlignInto correctly right-aligns and zips series with nearest smaller option``() =
-  let res = (b, a) ||> Series.zipAlignInto JoinKind.Right Lookup.NearestSmaller (lift2 (fun l r -> (l**2.0) * r)) 
+  let res = (b, a) ||> Series.zipAlignInto JoinKind.Right Lookup.ExactOrSmaller (lift2 (fun l r -> (l**2.0) * r)) 
   res.GetAt(0) |> shouldEqual ((8.0 ** 2.0) * 1.0)
   res.GetAt(1) |> shouldEqual ((8.0 ** 2.0) * 2.0)
   res.GetAt(2) |> shouldEqual ((11.0 ** 2.0) * 3.0)
@@ -628,7 +633,7 @@ let ``ZipAlignInto correctly right-aligns and zips series with nearest smaller o
 
 [<Test>]
 let ``ZipAlignInto correctly right-aligns and zips series with nearest greater option``() =
-  let res = (b, a) ||> Series.zipAlignInto JoinKind.Right Lookup.NearestGreater (lift2 (fun l r -> (l**2.0) * r))
+  let res = (b, a) ||> Series.zipAlignInto JoinKind.Right Lookup.ExactOrGreater (lift2 (fun l r -> (l**2.0) * r))
   res.GetAt(0) |> shouldEqual ((11.0 ** 2.0) * 1.0)
   res.GetAt(1) |> shouldEqual ((11.0 ** 2.0) * 2.0)
   res.GetAt(2) |> shouldEqual ((11.0 ** 2.0) * 3.0)
@@ -641,13 +646,13 @@ let ``Can zip series with lookup and skip over missing values ``() =
   let l = [ 1 => 1.0;  2 => 2.0;        3 => 3.0;        4 => 4.0;  ] |> series
   let r = [ 1 => 10.0; 2 => Double.NaN; 3 => Double.NaN; 4 => 40.0; ] |> series
 
-  let res1 = l.Zip(r, JoinKind.Left, Lookup.NearestSmaller)
+  let res1 = l.Zip(r, JoinKind.Left, Lookup.ExactOrSmaller)
   res1.GetAt(0) |> shouldEqual (OptionalValue 1.0, OptionalValue 10.0)
   res1.GetAt(1) |> shouldEqual (OptionalValue 2.0, OptionalValue 10.0) // second values is missing instead of 10
   res1.GetAt(2) |> shouldEqual (OptionalValue 3.0, OptionalValue 10.0) // second values is missing instead of 10
   res1.GetAt(3) |> shouldEqual (OptionalValue 4.0, OptionalValue 40.0)
 
-  let res2 = l.Zip(r, JoinKind.Left, Lookup.NearestGreater)
+  let res2 = l.Zip(r, JoinKind.Left, Lookup.ExactOrGreater)
   res2.GetAt(0) |> shouldEqual (OptionalValue 1.0, OptionalValue 10.0)
   res2.GetAt(1) |> shouldEqual (OptionalValue 2.0, OptionalValue 40.0) // second values is missing instead of 40
   res2.GetAt(2) |> shouldEqual (OptionalValue 3.0, OptionalValue 40.0) // second values is missing instead of 40


### PR DESCRIPTION
This renames `NearestGreater` and `NearestSmaller` enum values for the `Lookup`
option as discussed in #201 and it adds two additional options. The options are:

```
Exact | ExactOrSmaller | ExactOrGreater | Smaller | Greater
```

The second and third one are renamed `NearestSmaller` and `NearestGreater` respectively.
@hmansell suggested using `AtLeast` and `AtMost` as the name - which is nicer and shorter,
but I like the above because it is more explicit (and I think perhaps easier to
see the difference). However, I would be happy with other naming too - so please send
your comments!

I also used the new lookup features to simplify `GetRange` (as discussed earlier).

As a side-note, the commit adds a test based on #146.
