### PR TITLE
Upgrade to Math.NET Numerics v3.0.0-beta01

### DIFF
--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -5,5 +5,5 @@
   <package id="FSharp.Formatting" version="2.4.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
-  <package id="MathNet.Numerics" version="2.6.1" targetFramework="net45" />
+  <package id="MathNet.Numerics" version="3.0.0-beta01" targetFramework="net45" />
 </packages>

--- a/tests/Deedle.Tests/Deedle.Tests.fsproj
+++ b/tests/Deedle.Tests/Deedle.Tests.fsproj
@@ -54,7 +54,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MathNet.Numerics">
-      <HintPath>..\..\packages\MathNet.Numerics.3.0.0-alpha8\lib\net40\MathNet.Numerics.dll</HintPath>
+      <HintPath>..\..\packages\MathNet.Numerics.3.0.0-beta01\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="nunit.framework">

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -212,17 +212,17 @@ open MathNet.Numerics.Statistics
 [<Test>]
 let ``Mean is the same as in Math.NET``() =
   Check.QuickThrowOnFailure(fun (input:int[]) -> 
-    let d = DescriptiveStatistics(Array.map float input) 
+    let expected = Statistics.Mean(Array.map float input)
     let s = Series.ofValues (Array.map float input)
     if s.ValueCount < 1 then 
       Double.IsNaN(Stats.mean s) |> shouldEqual true
     else 
-      Stats.mean s |> should beWithin (d.Mean +/- 1e-9) )
+      Stats.mean s |> should beWithin (expected +/- 1e-9) )
 
 [<Test>]
 let ``StdDev and Variance is the same as in Math.NET``() =
   Check.QuickThrowOnFailure(fun (input:int[]) -> 
-    let d = DescriptiveStatistics(Array.map float input) 
+    let d = DescriptiveStatistics(Array.map float input)
     let s = Series.ofValues (Array.map float input)
     if s.ValueCount < 2 then 
       Double.IsNaN(Stats.variance s) |> shouldEqual true
@@ -234,30 +234,27 @@ let ``StdDev and Variance is the same as in Math.NET``() =
 [<Test>]
 let ``Skewness is the same as in Math.NET``() =
   Check.QuickThrowOnFailure(fun (input:int[]) -> 
-    let d = DescriptiveStatistics(Array.map float input) 
+    let expected = Statistics.Skewness(Array.map float input)
     let s = Series.ofValues (Array.map float input)
     if s.ValueCount < 3 then 
       Double.IsNaN(Stats.skew s) |> shouldEqual true
     else 
-      Stats.skew s |> should beWithin (d.Skewness +/- 1e-9) )
+      Stats.skew s |> should beWithin (expected +/- 1e-9) )
 
 [<Test>]
 let ``Kurtosis is the same as in Math.NET``() =
   Check.QuickThrowOnFailure(fun (input:int[]) -> 
-    let d = DescriptiveStatistics(Array.map float input) 
+    let expected = Statistics.Kurtosis(Array.map float input)
     let s = Series.ofValues (Array.map float input)
     if s.ValueCount < 4 then 
       Double.IsNaN(Stats.kurt s) |> shouldEqual true
     else 
-      Stats.kurt s |> should beWithin (d.Kurtosis +/- 1e-9) )
+      Stats.kurt s |> should beWithin (expected +/- 1e-9) )
 
 [<Test>]
 let ``Median is the same as in Math.NET``() =
   Check.QuickThrowOnFailure(fun (input:float[]) -> 
     let input = Array.filter (Double.IsNaN >> not) input
-    let expected = Statistics.Median(input) 
+    let expected = Statistics.Median(input)
     let actual = Series.ofValues input |> Stats.median
-    if input |> Seq.forall (fun v -> not (Double.IsInfinity v)) then
-      // Math.NET returns "nan" if there are infinities, 
-      // while Deedle is happy with that
-      actual |> should beWithin (expected +/- 1e-9) )
+    actual |> should beWithin (expected +/- 1e-9) )

--- a/tests/Deedle.Tests/packages.config
+++ b/tests/Deedle.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FsCheck" version="0.9.1.0" targetFramework="net45" />
   <package id="FSharp.Data" version="1.1.10" targetFramework="net45" />
+  <package id="MathNet.Numerics" version="3.0.0-beta01" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="NUnit.Runners" version="2.6.3" targetFramework="net45" />
-  <package id="MathNet.Numerics" version="3.0.0-alpha8" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In the unit tests to compare Deedle statistics with Math.NET Numerics this fixes the latter to return NaN if not enough data is available for a particular statistic. Also prefers `Statistics` over `DescriptiveStatistics` where appropriate.

See #199
