### PR TITLE
Change 'frame (op) series' behaviour to use outer join (#208)

### DIFF
--- a/docs/content/frame.fsx
+++ b/docs/content/frame.fsx
@@ -44,12 +44,22 @@ let msft =
 // Specify column separator
 let air = Frame.ReadCsv(root + "AirQuality.csv", separators=";")
 (**
+In the second example, we call `indexRowsDate` to use the "Date" column as a row index
+of the resulting data frame. This is a very common scenario and so Deedle provides an
+easier option using a generic overload of the `ReadCsv` method:
+*)
+let msftSimpler = 
+  Frame.ReadCsv<DateTime>(root + "stocks/msft.csv", indexCol="Date") 
+  |> Frame.sortRowsByKey
+(**
 The `ReadCsv` method has a number of optional arguments that you can use to control 
 the loading. It supports both CSV files, TSV files and other formats. If the file name
 ends with `tsv`, the Tab is used automatically, but you can set `separator` explicitly.
 The following parameters can be used:
 
  * `path` - Specifies a file name or an web location of the resource.
+ * `indexCol` - Specifies the column that should be used as an index in the 
+   resulting frame. The type is specified via a type parameter.
  * `inferTypes` - Specifies whether the method should attempt to infer types
    of columns automatically (set this to `false` if you want to specify schema)
  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -7,11 +7,11 @@
     <meta name="description" content="@Description">
     <meta name="author" content="@Properties["project-author"]">
 
-    <script src="http://code.jquery.com/jquery-1.8.0.js"></script>
-    <script src="http://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.8.0.js"></script>
+    <script src="https://code.jquery.com/ui/1.8.23/jquery-ui.js"></script>
+    <script src="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
+    <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/css/bootstrap-combined.min.css" rel="stylesheet">
 
     <link type="text/css" rel="stylesheet" href="@Root/content/style.css" />
     <link type="text/css" rel="stylesheet" href="@Root/content/deedle.css" />
@@ -26,9 +26,10 @@
       <div class="masthead">
         <ul class="nav nav-pills pull-right">
           <li><a href="http://fsharp.org">fsharp.org</a></li>
-          <li><a href="http://fsharp.github.io/FSharp.Data"><img height="16" width="16" src="http://fsharp.org/images/thumbs/FSharp.Data.png" /> F# Data</a></li>
           <li><a href="http://bluemountaincapital.github.io/FSharpRProvider"><img height=" 16" width="16" src="http://fsharp.org/images/thumbs/FSharpRProvider.png" /> R Provider</a></li>
           <li><a href="http://fsharp.github.io/FSharp.Charting/"><img height="16" width="16" src="http://fsharp.org/images/thumbs/FSharp.Charting.png" /> F# Charting</a></li>
+          <li><a href="http://fsharp.github.io/FSharp.Data"><img height="16" width="16" src="http://fsharp.org/images/thumbs/FSharp.Data.png" /> F# Data</a></li>
+          <li><a href="http://fsprojects.github.io/FSharp.Data.Toolbox"><img height="16" width="16" src="http://fsharp.org/images/thumbs/FSharp.Data.Toolbox.png" /> F# Data Toolbox</a></li>
         </ul>
         <h3 class="muted"><a href="@Root/index.html">@Properties["project-name"]</a></h3>
       </div>

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -339,6 +339,34 @@ module FSharpFrameExtensions =
     /// ## Parameters
     ///
     ///  * `path` - Specifies a file name or an web location of the resource.
+    ///  * `indexCol` - Specifies the column that should be used as an index in the 
+    ///     resulting frame. The type is specified via a type parameter, e.g. use
+    ///     `Frame.ReadCsv<int>("file.csv", indexCol="Day")`.
+    ///  * `hasHeaders` - Specifies whether the input CSV file has header row
+    ///  * `inferTypes` - Specifies whether the method should attempt to infer types
+    ///    of columns automatically (set this to `false` if you want to specify schema)
+    ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
+    ///    rows to use for type inference. The default value is 0, meaninig all rows.
+    ///  * `schema` - A string that specifies CSV schema. See the documentation for 
+    ///    information about the schema format.
+    ///  * `separators` - A string that specifies one or more (single character) separators
+    ///    that are used to separate columns in the CSV file. Use for example `";"` to 
+    ///    parse semicolon separated files.
+    ///  * `culture` - Specifies the name of the culture that is used when parsing 
+    ///    values in the CSV file (such as `"en-US"`). The default is invariant culture. 
+    static member ReadCsv<'R when 'R : equality>(path:string, indexCol, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators, ?culture, ?maxRows) : Frame<'R, _> =
+      use reader = new StreamReader(path)
+      FrameUtils.readCsv reader hasHeaders inferTypes inferRows schema TextConversions.DefaultMissingValues separators culture maxRows
+      |> Frame.indexRows indexCol
+
+    /// Load data frame from a CSV file. The operation automatically reads column names from the 
+    /// CSV file (if they are present) and infers the type of values for each column. Columns
+    /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
+    /// types (such as dates) are not converted automatically.
+    ///
+    /// ## Parameters
+    ///
+    ///  * `path` - Specifies a file name or an web location of the resource.
     ///  * `hasHeaders` - Specifies whether the input CSV file has header row
     ///  * `inferTypes` - Specifies whether the method should attempt to infer types
     ///    of columns automatically (set this to `false` if you want to specify schema)
@@ -414,6 +442,11 @@ module FSharpFrameExtensions =
     /// over the specified type parameter `'T` and turns its properties to columns.
     static member ofRecords (values:seq<'T>) =
       Reflection.convertRecordSequence<'T>(values)    
+
+    /// Creates a data frame from a sequence of any .NET objects. The method uses reflection
+    /// over the specified type parameter `'T` and turns its properties to columns.
+    static member ofRecords<'R when 'R : equality> (values:System.Collections.IEnumerable, indexCol:string) =
+      Reflection.convertRecordSequenceUntyped(values).IndexRows<'R>(indexCol)
 
     /// Create data frame from a 2D array of values. The first dimension of the array
     /// is used as rows and the second dimension is treated as columns. Rows and columns

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -87,9 +87,10 @@
 /// ordinal numbers using `indexRowsOrdinally`.
 ///
 /// The function `indexRows` uses the specified column of the original frame as the 
-/// index. This function infers the type of row keys from the context, so it is usually
-/// more convenient to use `indexRows[Date|String|Int|...]` functions. Finally, if 
-/// you want to calculate the index value based on multiple columns of the row, you
+/// index. It removes the column from the resulting frame (to avoid this, use overloaded
+/// `IndexRows` method). This function infers the type of row keys from the context, so it 
+/// is usually more convenient to use `indexRows[Date|String|Int|...]` functions. Finally, 
+/// if you want to calculate the index value based on multiple columns of the row, you
 /// can use `indexRowsUsing`.
 ///
 /// ### Sorting frame rows
@@ -640,7 +641,8 @@ module Frame =
 
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. The generic type parameter is specifies the type of the values in the required 
-  /// index column (and usually needs to be specified using a type annotation).
+  /// index column (and usually needs to be specified using a type annotation). The specified
+  /// column is removed from the resulting frame.
   ///
   /// ## Parameters
   ///  - `frame` - Source data frame whose row index is to be replaced.
@@ -654,6 +656,7 @@ module Frame =
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `obj`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
+  /// The specified column is removed from the resulting frame.
   ///
   /// ## Parameters
   ///  - `frame` - Source data frame whose row index is to be replaced.
@@ -667,6 +670,7 @@ module Frame =
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `int`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
+  /// The specified column is removed from the resulting frame.
   ///
   /// ## Parameters
   ///  - `frame` - Source data frame whose row index is to be replaced.
@@ -680,6 +684,7 @@ module Frame =
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `DateTime`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
+  /// The specified column is removed from the resulting frame.
   ///
   /// ## Parameters
   ///  - `frame` - Source data frame whose row index is to be replaced.
@@ -693,6 +698,7 @@ module Frame =
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `DateTimeOffset`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
+  /// The specified column is removed from the resulting frame.
   ///
   /// ## Parameters
   ///  - `frame` - Source data frame whose row index is to be replaced.
@@ -706,6 +712,7 @@ module Frame =
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `string`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
+  /// The specified column is removed from the resulting frame.
   ///
   /// ## Parameters
   ///  - `frame` - Source data frame whose row index is to be replaced.
@@ -718,6 +725,7 @@ module Frame =
 
   /// Replace the column index of the frame with the provided sequence of column keys.
   /// The columns of the frame are assigned keys according to the provided order.
+  /// The specified column is removed from the resulting frame.
   ///
   /// ## Parameters
   ///  - `frame` - Source data frame whose column index are to be replaced.

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -1062,17 +1062,13 @@ type ObjectSeries<'K when 'K : equality> internal(index:IIndex<_>, vector, vecto
   static member (?) (series:ObjectSeries<_>, name:string) = 
     series.GetAs<float>(name, nan)
 
-  member x.TryAs<'R>(strict) =
-    match unboxVector vector with
-    | :? IVector<'R> as vec -> 
-        let newIndex = indexBuilder.Project(index)
-        OptionalValue(Series(newIndex, vec, vectorBuilder, indexBuilder))
-    | _ -> 
-        ( if strict then VectorHelpers.tryCastType vector
-          else VectorHelpers.tryChangeType vector )
-        |> OptionalValue.map (fun vec -> 
-          let newIndex = indexBuilder.Project(index)
-          Series(newIndex, vec, vectorBuilder, indexBuilder))
+  member x.TryAs<'R>(strict) : OptionalValue<Series<_, 'R>> =
+    let typed = 
+      if strict then VectorHelpers.tryCastType vector
+      else VectorHelpers.tryChangeType vector
+    typed |> OptionalValue.map (fun vec -> 
+      let newIndex = indexBuilder.Project(index)
+      Series(newIndex, vec, vectorBuilder, indexBuilder))
 
   member x.TryAs<'R>() =
     x.TryAs<'R>(false)

--- a/tests/Deedle.Tests.Console/Program.fs
+++ b/tests/Deedle.Tests.Console/Program.fs
@@ -75,18 +75,27 @@ open Deedle
 
 let rnd = System.Random(0)
 
-//let s0 = series <| Array.init 1000 (fun i -> i => rnd.NextDouble())
-let s1 = series <| Array.init 1000000 (fun i -> i => rnd.NextDouble())
+let s0 = series <| Array.init 10000 (fun i -> i => rnd.NextDouble())
+let f0 = frame [ for i in 0 .. 10 -> i => s0 ]
+let f1 = frame [ for i in 0 .. 100 -> i => s0 ]
+
+//let s1 = series <| Array.init 1000000 (fun i -> i => rnd.NextDouble())
 //let s2 = series <| Array.init 10000000 (fun i -> i => rnd.NextDouble())
 
 let testOne() =      
-  timed 1 (fun () ->
+  timed 5 (fun () ->
+
+    // 75 ms ~> 40 ms
+    //f0 + s0 |> ignore
+
+    // 750 ms ~> 360 ms
+    f1 + s0 |> ignore
 
     // 315ms
     //for i in 0 .. 1000 do (s0 |> Stats.movingMin 100 |> ignore)
 
     // 310ms
-    s1 |> Stats.movingMin 100 |> ignore
+    //s1 |> Stats.movingMin 100 |> ignore
 
     // 190ms
     //s1 |> Stats.expandingMin |> ignore

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -91,8 +91,8 @@ let ``Can save MSFT data as CSV file and read it afterwards (with default args)`
   let file = System.IO.Path.GetTempFileName()
   let expected = msft()
   expected.SaveCsv(file)
-  let actual = Frame.ReadCsv(file) |> Frame.indexRowsDate "Date"
-  actual |> shouldEqual expected
+  let actual = Frame.ReadCsv(file) 
+  actual |> shouldEqual (Frame.indexRowsOrdinally expected)
 
 [<Test>]
 let ``Saving dates uses consistently invariant cultrue by default`` () =
@@ -115,13 +115,11 @@ let ``Can save MSFT data as CSV file and read it afterwards (with custom format)
   let file = System.IO.Path.GetTempFileName()
   let cz = System.Globalization.CultureInfo.GetCultureInfo("cs-CZ")
   let expected = msft()
-  expected.DropColumn("Date")
   expected.SaveCsv(file, keyNames=["Date"], separator=';', culture=cz)
   let actual = 
     Frame.ReadCsv(file, separators=";", culture="cs-CZ")
     |> Frame.indexRowsString "Date" 
     |> Frame.mapRowKeys (fun s -> DateTime.Parse(s, cz) )
-    |> Frame.dropCol "Date"
   actual |> shouldEqual expected
 
 [<Test>]


### PR DESCRIPTION
The previous behaviour was using inner join, which means that applying numerical operation
to a frame and series could return a frame with fewer column keys than the original frame
(although this did not happen when there were non-numerical columns in the frame).

This changes the behaviour to use outer join and so the returned frame will contain the
union of the keys from the frame and the series. (As an alternative, we could preserve the
keys of the frame and do left/right join, but this seems counter-intuitive when you have
a series on the left e.g. "s + f" would be a frame with the keys of "f").

I also did some performance improvements (perform the join just once, which makes it
about 2x faster) and refactorings (the `unboxVector` check is now done in `tryCast`
and `tryChangeType` functions, so you do not have to worry about this when writing
code that changes types of vectors).
