### PR TITLE
Allow Read CSV to work over HTTP (and other non-seekable) streams

### DIFF
--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -389,7 +389,7 @@ module internal FrameUtils =
   let readCsv (reader:TextReader) hasHeaders inferTypes inferRows schema (missingValues:string[]) separators culture maxRows =
     let schema = defaultArg schema ""
     let schema = if schema = null then "" else schema
-    let inferRows = defaultArg inferRows 0
+    let inferRows = defaultArg inferRows 100
     let safeMode = false // Irrelevant - all DF values can be missing
     let preferOptionals = true // Ignored
     let culture = defaultArg culture ""
@@ -406,19 +406,21 @@ module internal FrameUtils =
       else Vector.ofValues data :> IVector
 
     // If 'inferTypes' is specified (or by default), use the CSV type inference
-    // to load information about types in the CSV file. By default, use the entire
-    // content (but inferRows can be set to smaller number). Otherwise we just
+    // to load information about types in the CSV file. By default, use the first
+    // 100 rows (but inferRows can be set to another value). Otherwise we just
     // "infer" all columns as string.
-    let data = CsvFile.Load(reader, ?separators=separators, ?hasHeaders=hasHeaders)
-    let inferedProperties = 
-      if not (inferTypes = Some false) then
-        data.InferColumnTypes(inferRows, missingValues, cultureInfo, schema, safeMode, preferOptionals)
-      else 
-        let headers = 
-          match data.Headers with 
-          | None -> [| for i in 1 .. data.NumberOfColumns -> sprintf "Column%d" i |]
-          | Some headers -> headers
-        [ for c in headers -> PrimitiveInferedProperty.Create(c, typeof<string>, true, None) ]
+    let readDataFromCsv() = CsvFile.Load(reader, ?separators=separators, ?hasHeaders=hasHeaders)
+    let data = readDataFromCsv()
+    let inferredProperties =
+        match inferTypes with
+        | Some true | None ->
+            readDataFromCsv().InferColumnTypes(inferRows, missingValues, cultureInfo, schema, safeMode, preferOptionals)
+        | Some false ->
+            let headers = 
+                match data.Headers with 
+                | None -> [| for i in 1 .. data.NumberOfColumns -> sprintf "Column%d" i |]
+                | Some headers -> headers
+            [ for c in headers -> PrimitiveInferedProperty.Create(c, typeof<string>, true, None) ]
 
     // Load the data and convert the values to the appropriate type
     let data = 
@@ -427,9 +429,9 @@ module internal FrameUtils =
       | None -> data.Cache()
 
     // Generate columns using the inferred properties 
-    let columnIndex = Index.ofKeys [ for p in inferedProperties -> p.Name ]
+    let columnIndex = Index.ofKeys [ for p in inferredProperties -> p.Name ]
     let columns = 
-      inferedProperties |> Seq.mapi (fun i prop ->
+      inferredProperties |> Seq.mapi (fun i prop ->
         [| for row in data.Rows -> row.Columns.[i] |]
         |> createVector prop.RuntimeType )
     let rowIndex = Index.ofKeys [ 0 .. (Seq.length data.Rows) - 1 ]


### PR DESCRIPTION
This is done by forcing a re-read of the stream when infering schema as opposed to loading data into the frame. If / when FSharp.Data allows caching of data on typed CsvFiles, this re-reading of the stream will no longer be necessary.
