### PR TITLE
Revisit type conversions, fix documentation and filling bug

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,3 +52,5 @@
 ### 1.0.2
  * Operations GetAs, TryAs (ObjectSeries), GetColumns, GetRows, GetAllValues, ColumnApply (Frame)
    and filling of missing values uses "safe" conversion (allows conversion to bigger numeric type)
+ * Avoid boxing when filling missing values (#222)
+ * Fix documentation bugs (#221, #226) and update formatters from FsLab

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,54 @@
-* 0.9.0-beta - Initial release
-* 0.9.1-beta - First beta version on NuGet
-* 0.9.2-beta - Update paths in NuGet package
-* 0.9.3-beta - Saving CSV, fix series alignment
-* 0.9.4-beta - Rename and various fixes and additions
-* 0.9.5-beta - Update documentation and tools, adding functionality
-* 0.9.6-beta - Load script automatically references F# data (for CSV reading)
-* 0.9.7-beta - Fix series formatting
-* 0.9.8-beta - Add reflection-based frame expansion
-* 0.9.9-beta - Performance improvements, API additions, experimental R plugin
-* 0.9.10-beta - Support time series in the R plugin
-* 0.9.11-beta - Fix bug when creating empty data frame
-* 0.9.12 - Improved C# compatibility, added C# documentation
-* 1.0.0-alpha1 - API redesign, performance improvements and new features
-* 1.0.0-alpha2 - Update to a new pre-release of RProvider
-* 1.0.0 - Performance and API design improvements
-* 1.0.1 - Update RProvider references
+### 0.9.0-beta
+ * Initial release
+
+### 0.9.1-beta
+ * First beta version on NuGet
+
+### 0.9.2-beta
+ * Update paths in NuGet package
+
+### 0.9.3-beta
+ * Saving CSV, fix series alignment
+
+### 0.9.4-beta
+ * Rename and various fixes and additions
+
+### 0.9.5-beta
+ * Update documentation and tools, adding functionality
+
+### 0.9.6-beta
+ * Load script automatically references F# data (for CSV reading)
+
+### 0.9.7-beta
+ * Fix series formatting
+
+### 0.9.8-beta
+ * Add reflection-based frame expansion
+
+### 0.9.9-beta
+ * Performance improvements, API additions, experimental R plugin
+
+### 0.9.10-beta
+ * Support time series in the R plugin
+
+### 0.9.11-beta
+ * Fix bug when creating empty data frame
+
+### 0.9.12
+ * Improved C# compatibility, added C# documentation
+
+### 1.0.0-alpha1
+ * API redesign, performance improvements and new features
+
+### 1.0.0-alpha2
+ * Update to a new pre-release of RProvider
+
+### 1.0.0 
+ * Performance and API design improvements
+
+### 1.0.1 
+ * Update RProvider references
+
+### 1.0.2
+ * Operations GetAs, TryAs (ObjectSeries), GetColumns, GetRows, GetAllValues, ColumnApply (Frame)
+   and filling of missing values uses "safe" conversion (allows conversion to bigger numeric type)

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -84,7 +84,7 @@ Samples & documentation
 -----------------------
 
 The library comes with comprehensible documentation. The tutorials and articles are 
-automatically generated from `*.fsx` files in [the samples folder][samples]. The API
+automatically generated from `*.fsx` files in [the docs folder][docs]. The API
 reference is automatically generated from Markdown comments in the library implementation.
 
  * [Quick start tutorial](tutorial.html) shows how to use the most important 
@@ -97,7 +97,7 @@ reference is automatically generated from Markdown comments in the library imple
    relevant when working with time series data (such as stock prices). This includes sliding
    windows, chunking, sampling and statistics.
 
- * [Calculating frame ans series statistics](stats.fsx) shows how to calculate statistical
+ * [Calculating frame and series statistics](stats.html) shows how to calculate statistical
    indicators such as mean, variance, skweness and other. The tutorial also covers moving
    window and expanding window statistics.
 
@@ -135,10 +135,11 @@ redistribution for both commercial and non-commercial purposes. For more informa
 [License file][license] in the GitHub repository. 
 
 
-  [samples]: https://github.com/blueMountainCapital/Deedle/tree/master/samples
-  [gh]: https://github.com/blueMountainCapital/Deedle
-  [issues]: https://github.com/blueMountainCapital/Deedle/issues
-  [readme]: https://github.com/blueMountainCapital/Deedle/blob/master/README.md
-  [license]: https://github.com/blueMountainCapital/Deedle/blob/master/LICENSE.md
+  [docs]: https://github.com/BlueMountainCapital/Deedle/tree/master/docs/content
+  [samples]: https://github.com/BlueMountainCapital/Deedle/tree/master/docs/content/samples
+  [gh]: https://github.com/BlueMountainCapital/Deedle
+  [issues]: https://github.com/BlueMountainCapital/Deedle/issues
+  [readme]: https://github.com/BlueMountainCapital/Deedle/blob/master/README.md
+  [license]: https://github.com/BlueMountainCapital/Deedle/blob/master/LICENSE.md
   [fsharp-dwg]: http://fsharp.org/technical-groups/
 *)

--- a/docs/content/series.fsx
+++ b/docs/content/series.fsx
@@ -1,7 +1,7 @@
 ﻿(*** hide ***)
 #I "../../bin"
 #load "Deedle.fsx"
-#I "../../packages/MathNet.Numerics.3.0.0-beta01/lib/net40"
+#I "../../packages/MathNet.Numerics.3.0.0/lib/net40"
 #load "../../packages/FSharp.Charting.0.90.6/FSharp.Charting.fsx"
 open System
 open FSharp.Data

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -21,7 +21,7 @@ let info =
 // --------------------------------------------------------------------------------------
 
 #I "../../packages/FSharp.Compiler.Service.0.0.44/lib/net40"
-#I "../../packages/FSharp.Formatting.2.4.8/lib/net40"
+#I "../../packages/FSharp.Formatting.2.4.11/lib/net40"
 #I "../../packages/RazorEngine.3.3.0/lib/net40/"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
@@ -51,7 +51,7 @@ let content    = __SOURCE_DIRECTORY__ @@ "../content"
 let output     = __SOURCE_DIRECTORY__ @@ "../output"
 let files      = __SOURCE_DIRECTORY__ @@ "../files"
 let templates  = __SOURCE_DIRECTORY__ @@ "templates"
-let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.4.8/"
+let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.4.11/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
@@ -89,4 +89,4 @@ let buildDocumentation () =
 // Generate
 copyFiles()
 buildDocumentation()
-buildReference()
+//buildReference()

--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="FSharp.Charting" version="0.90.6" targetFramework="net40" />
   <package id="FSharp.Data" version="2.0.8" targetFramework="net40" />
-  <package id="FSharp.Formatting" version="2.4.8" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.4.11" targetFramework="net45" />
   <package id="FSharp.Compiler.Service" version="0.0.44" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
-  <package id="MathNet.Numerics" version="3.0.0-beta01" targetFramework="net45" />
+  <package id="MathNet.Numerics" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/src/Deedle.RProvider.Plugin/Convertors.fs
+++ b/src/Deedle.RProvider.Plugin/Convertors.fs
@@ -47,7 +47,7 @@ let (|NumericIndex|StringIndex|) (items:string[]) =
 let convertIndex (names:string[]) : option<IIndex<'R>> =
   try 
     names 
-    |> Array.map (Convert.changeType<'R>)
+    |> Array.map (Convert.convertType<'R> ConversionKind.Flexible)
     |> Index.ofKeys |> Some
   with _ -> None
 
@@ -65,7 +65,7 @@ let convertVector (vector:IVector) : obj =
         // If there are missing values and we do not have filler, try converting to float
         let hasMissing = col.DataSequence |> Seq.exists (fun v -> not v.HasValue)
         if hasMissing && missingVal.IsNone then
-          let colNum = VectorHelpers.tryChangeType<float> col
+          let colNum = VectorHelpers.tryConvertType<float> ConversionKind.Flexible col
           if colNum.HasValue then
             box [| for v in colNum.Value.DataSequence -> if v.HasValue then v.Value else nan  |]
           else

--- a/src/Deedle/Common/AssemblyInfo.fs
+++ b/src/Deedle/Common/AssemblyInfo.fs
@@ -4,9 +4,9 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Deedle")>]
 [<assembly: AssemblyProductAttribute("Deedle")>]
 [<assembly: AssemblyDescriptionAttribute("Easy to use .NET library for data manipulation and scientific programming")>]
-[<assembly: AssemblyVersionAttribute("1.0.1")>]
-[<assembly: AssemblyFileVersionAttribute("1.0.1")>]
+[<assembly: AssemblyVersionAttribute("1.0.2")>]
+[<assembly: AssemblyFileVersionAttribute("1.0.2")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.0.1"
+    let [<Literal>] Version = "1.0.2"

--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -4,6 +4,21 @@ namespace Deedle
 open System
 open System.Runtime.CompilerServices
 
+/// Represents different kinds of type conversions that can be used by Deedle internally.
+/// This is used, for example, when converting `ObjectSeries<'K>` to `Series<'K, 'T>` - 
+/// The conversion kind can be specified as an argument to allow certain conversions.
+type ConversionKind = 
+  /// Specifies that the type has to match exactly and no conversions are performed.
+  | Exact = 0
+  /// Allows conversions that widen numeric types, but nothing else. This includes
+  /// conversions on decimals `decimal -> float32 -> float` and also from integers 
+  /// to floating points (`int -> decimal` etc.)
+  | Safe = 1
+  /// Allows the use of arbitrary .NET conversions. This uses `Convert.ChangeType`, which
+  /// performs numerical conversions, parsing of strings, uses `IConvertable` and more.
+  | Flexible = 2
+
+
 /// Thrown when a value at the specified index does not exist in the data frame or series.
 /// This exception is thrown only when the key is defined, but the value is not available,
 /// in other situations `KeyNotFoundException` is thrown
@@ -1185,16 +1200,84 @@ module Formatting =
 
 /// [omit]
 module Convert =
-  let nullableType = typedefof<System.Nullable<_>>
+  let private nullableType = typedefof<System.Nullable<_>>
 
-  /// Helper function that converts value to a specified type
-  /// (this aims to be as flexible as possible)
-  let changeType<'T> (value:obj) =
-    // Check if we can cast first - one would think that System.Convert
-    // should handle this, but it fails to convert nullables (e.g. bool to bool?)
-    if value :? 'T then value :?> 'T
-    else System.Convert.ChangeType(value, typeof<'T>) :?> 'T
-    
+  /// Conversions that are "safe" as a list of "source -> target" types
+  let private safeConversions =
+    [ // Conversions from smaller integers to larger integers
+      typeof<uint8>, typeof<int16>
+      typeof<int8>, typeof<int16>
+      typeof<uint16>, typeof<int32>
+      typeof<int16>, typeof<int32>
+      typeof<uint32>, typeof<int64>
+      typeof<int32>, typeof<int64>
+      // Conversions from u/int64 to decimal are legal too
+      typeof<int64>, typeof<decimal>
+      typeof<uint64>, typeof<decimal>
+      // Conversions decimal -> float32 -> float are allowed
+      typeof<decimal>, typeof<float32>
+      typeof<float32>, typeof<float> ]
+
+  /// Dictionary that maps target type (e.g. 'float32') to all the source types that can be
+  /// safely converted to it (e.g. 'decimal,int64,unit64,int32,uint32,int16,uint16,int8,uint8')
+  let private sourcesByTarget =
+    let lookupFromTarget =        
+      safeConversions    
+      |> Seq.groupBy snd
+      |> Seq.map (fun (k, s) -> k, [ for f, _ in s -> f ])
+      |> dict
+
+    // For each target type, find all the allowed sources (recursively)
+    let rec allSourcesFor typ = seq {
+      match lookupFromTarget.TryGetValue(typ) with
+      | false, _ -> ()
+      | true, sources ->
+          yield! sources
+          for sourceTyp in sources do
+            yield! allSourcesFor sourceTyp }
+
+    [ for _, target in safeConversions ->
+        target, dict [ for s in allSourcesFor target -> s, true] ] |> dict
+
+  /// Helper function that converts value to a specified type. The conversion
+  /// is done using the specified conversion kind, which specifies the level
+  /// of flexibility (Exact - cast, Safe - according to 'sourcesByTarget', 
+  /// Flexible - anything that System.Convert allows)
+  let convertType<'T> conversionKind (value:obj) =
+    match conversionKind with
+    | ConversionKind.Flexible ->
+        // Check if we can cast first (one would think that System.Convert
+        // should handle this, but it fails to convert nullables e.g. bool to bool?)
+        if value :? 'T then value :?> 'T
+        else System.Convert.ChangeType(value, typeof<'T>) :?> 'T
+    | ConversionKind.Safe ->
+        if value :? 'T then value :?> 'T
+        elif value <> null then
+          match sourcesByTarget.TryGetValue(typeof<'T>) with
+          | true, sources when sources.ContainsKey(value.GetType()) ->
+              System.Convert.ChangeType(value, typeof<'T>) :?> 'T
+          | _ -> raise <| InvalidCastException(sprintf "Cannot safely convert %s to %s" (value.GetType().Name) (typeof<'T>.Name))
+        else raise <| InvalidCastException(sprintf "Cannot safely convert null to %s" (typeof<'T>.Name))
+    | ConversionKind.Exact -> value :?> 'T
+    | _ -> invalidArg "conversionKind" "Invalid value"
+
+  /// A function that returns `true` when `convertType<'T>` is expected
+  /// to succeed on the specified value (this is approximation - it may
+  /// return 'true' even if the conversion fails, but not the other way round)
+  let canConvertType<'T> conversionKind (value:obj) =
+    match conversionKind with
+    | ConversionKind.Flexible ->
+        value :? 'T || value :? IConvertible
+    | ConversionKind.Safe ->
+        if value :? 'T then true
+        elif value :? IConvertible then
+          match sourcesByTarget.TryGetValue(typeof<'T>) with
+          | true, sources -> sources.ContainsKey(value.GetType())
+          | _ -> false
+        else false
+    | ConversionKind.Exact -> value :? 'T
+    | _ -> invalidArg "conversionKind" "Invalid value"
+
 // --------------------------------------------------------------------------------------
 // Support for C# dynamic
 // --------------------------------------------------------------------------------------

--- a/src/Deedle/Deedle.fsx
+++ b/src/Deedle/Deedle.fsx
@@ -4,9 +4,9 @@
 #I "../bin"
 #I "bin"
 #I "lib"
-#I "../packages/Deedle.1.0.1/lib/net40"
-#I "../../packages/Deedle.1.0.1/lib/net40"
-#I "../../../packages/Deedle.1.0.1/lib/net40"
+#I "../packages/Deedle.1.0.2/lib/net40"
+#I "../../packages/Deedle.1.0.2/lib/net40"
+#I "../../../packages/Deedle.1.0.2/lib/net40"
 // Also reference path with FSharp.Data.DesignTime.dll
 #I "../FSharp.Data.2.0.8/lib/net40/"
 // Reference Deedle

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -966,7 +966,7 @@ type FrameExtensions =
   ///
   [<Extension>]
   static member Diff(frame:Frame<'TRowKey, 'TColumnKey>, offset) = 
-    frame.ColumnApply<float>(false, fun s -> Series.diff offset s :> ISeries<_>)
+    frame |> Frame.diff offset 
 
   [<Extension>]
   static member Reduce(frame:Frame<'TRowKey, 'TColumnKey>, aggregation:Func<'T, 'T, 'T>) = 

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1196,7 +1196,7 @@ module Frame =
   /// [category:Processing frames with exceptions]
   [<CompiledName("FillErrorsWith")>]
   let fillErrorsWith (value:'T) (frame:Frame<'R, 'C>) = 
-    frame.ColumnApply(true, fun (s:Series<_, 'T tryval>) -> 
+    frame.ColumnApply(ConversionKind.Safe, fun (s:Series<_, 'T tryval>) -> 
       (Series.fillErrorsWith value s) :> ISeries<_>)
 
   // ----------------------------------------------------------------------------------------------
@@ -1216,7 +1216,7 @@ module Frame =
   /// [category:Missing values]
   [<CompiledName("FillMissingWith")>]
   let fillMissingWith (value:'T) (frame:Frame<'R, 'C>) =
-    frame.ColumnApply(true, fun (s:Series<_, 'T>) -> Series.fillMissingWith value s :> ISeries<_>)
+    frame.ColumnApply(ConversionKind.Safe, fun (s:Series<_, 'T>) -> Series.fillMissingWith value s :> ISeries<_>)
 
   /// Fill missing values in the data frame with the nearest available value
   /// (using the specified direction). Note that the frame may still contain
@@ -1254,7 +1254,7 @@ module Frame =
   /// [category:Missing values]
   [<CompiledName("FillMissingUsing")>]
   let fillMissingUsing (f:Series<'R, 'T> -> 'R -> 'T) (frame:Frame<'R, 'C>) =
-    frame.ColumnApply(false, fun (s:Series<_, 'T>) -> Series.fillMissingUsing (f s) s :> ISeries<_>)
+    frame.ColumnApply(ConversionKind.Safe, fun (s:Series<_, 'T>) -> Series.fillMissingUsing (f s) s :> ISeries<_>)
 
   /// Creates a new data frame that contains only those rows of the original 
   /// data frame that are _dense_, meaning that they have a value for each column.

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1234,7 +1234,9 @@ module Frame =
   /// [category:Missing values]
   [<CompiledName("FillMissing")>]
   let fillMissing direction (frame:Frame<'R, 'C>) =
-    frame.Columns |> Series.mapValues (fun s -> Series.fillMissing direction s) |> FrameUtils.fromColumns
+    let fillCmd = Vectors.FillMissing(Vectors.Return 0, VectorFillMissing.Direction direction)
+    let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder fillCmd)
+    Frame<_, _>(frame.RowIndex, frame.ColumnIndex, newData)
 
   /// Fill missing values in the frame using the specified function. The specified
   /// function is called with all series and keys for which the frame does not 

--- a/src/Deedle/SeriesExtensions.fs
+++ b/src/Deedle/SeriesExtensions.fs
@@ -172,7 +172,7 @@ type SeriesBuilder<'K, 'V when 'K : equality and 'V : equality>() =
             | (true, v) -> v :> obj
             | (false, _) -> failwithf "%s does not exist" name)
         (fun builder name value ->
-            let converted = Convert.changeType<'V> value
+            let converted = Convert.convertType<'V> ConversionKind.Flexible value
             builder.Add(unbox<'K> name, converted))
 
 /// A simple class that inherits from `SeriesBuilder<'K, obj>` and can be

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -1834,7 +1834,7 @@ module Series =
       | OptionalValue.Present(a, b) -> OptionalValue.ofOption(op (OptionalValue.asOption a) (OptionalValue.asOption b))
       | _ -> OptionalValue.Missing )
 
-  /// Align and zip two series using outer join and exact key matching (use `zipAlignInto`
+  /// Align and zip two series using inner join and exact key matching (use `zipAlignInto`
   /// for more options). The function calls the specified function `op` to combine values 
   /// from the two series
   ///

--- a/tests/Deedle.RPlugin.Tests/RPlugin.fs
+++ b/tests/Deedle.RPlugin.Tests/RPlugin.fs
@@ -112,3 +112,10 @@ let ``Can index rows ordinally and pass the result to R (#146)`` () =
 
   R.assign("df", df2) |> ignore
   R.get("df").GetValue<Frame<int, string>>() |> shouldEqual df2
+
+[<Test>]
+let ``Filling missing values preserves type of columns (and allows R interop)`` () =
+  let df1 = frame [ "A" => series [0 => 0.0; 1 => nan]]
+  let df2 = df1 |> Frame.fillMissing Direction.Forward
+  let df3 = R.as_data_frame(df2).GetValue<Frame<int, string>>()
+  df3 |> shouldEqual df2

--- a/tests/Deedle.RPlugin.Tests/RPlugin.fs
+++ b/tests/Deedle.RPlugin.Tests/RPlugin.fs
@@ -112,4 +112,3 @@ let ``Can index rows ordinally and pass the result to R (#146)`` () =
 
   R.assign("df", df2) |> ignore
   R.get("df").GetValue<Frame<int, string>>() |> shouldEqual df2
-

--- a/tests/Deedle.Tests/Deedle.Tests.fsproj
+++ b/tests/Deedle.Tests/Deedle.Tests.fsproj
@@ -50,7 +50,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MathNet.Numerics">
-      <HintPath>..\..\packages\MathNet.Numerics.3.0.0-beta01\lib\net40\MathNet.Numerics.dll</HintPath>
+      <HintPath>..\..\packages\MathNet.Numerics.3.0.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="nunit.framework">

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -870,6 +870,11 @@ let ``Fill missing values using the specified constant``() =
   filled.Rows.[0].As<float>() |> shouldEqual <| series ["A" => 0.0; "B" => 0.0; "C" => 0.0; "D" => 0.0 ]
   filled.Rows.[10].As<float>() |> shouldEqual <| series ["A" => 10.0; "B" => 0.0; "C" => 10.0; "D" => 10.0 ]
 
+[<Test>]
+let ``Can fill missing values in a frame containing decimals`` () =
+  let df1 = frame [ "A" => Series.ofOptionalObservations [ 1 => None; 2 => Some 0.2M ] ]
+  let df2 = df1 |> Frame.fillMissingWith 0.1
+  df2?A |> shouldEqual <| series [1 => 0.1; 2 => 0.2]
 
 // ------------------------------------------------------------------------------------------------
 // Operations - join & zip (handling missing values)

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -2,7 +2,7 @@
 #load "../../bin/Deedle.fsx"
 #r "../../packages/NUnit.2.6.3/lib/nunit.framework.dll"
 #r "../../packages/FsCheck.0.9.1.0/lib/net40-Client/FsCheck.dll"
-#r "../../packages/MathNet.Numerics.3.0.0-beta01/lib/net40/MathNet.Numerics.dll"
+#r "../../packages/MathNet.Numerics.3.0.0/lib/net40/MathNet.Numerics.dll"
 #load "../Common/FsUnit.fs"
 #else
 module Deedle.Tests.Stats

--- a/tests/Deedle.Tests/packages.config
+++ b/tests/Deedle.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FsCheck" version="0.9.1.0" targetFramework="net45" />
-  <package id="MathNet.Numerics" version="3.0.0-beta01" targetFramework="net45" />
+  <package id="MathNet.Numerics" version="3.0.0" targetFramework="net45" />
   <package id="FSharp.Data" version="2.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="NUnit.Runners" version="2.6.3" targetFramework="net45" />


### PR DESCRIPTION
I added log with changes to `RELEASE_NOTES`:
- Operations GetAs, TryAs (ObjectSeries), GetColumns, GetRows, GetAllValues, ColumnApply (Frame)
  and filling of missing values uses "safe" conversion (allows conversion to bigger numeric type)
- Avoid boxing when filling missing values (#222)
- Fix documentation bugs (#221, #226) and update formatters from FsLab

The three commit messages have all the details. The change with "safe" conversion is the most notable one, so here is the commit message:

> This change was triggered by my surprise that `fillMissingWith 0.0` did not work on frame I loaded from a CSV file (because the values were loaded as `decimal` and 0.0 is `float` - and so they are of different types).
> 
> The checkin implements nicer conversion function that has three modes (exact, safe and flexible), replacing castType (exact) and changeType (flexible). Safe can be used to allow safe widening in numerical conversions (e.g. converting int/float32/decimal to float or byte to int/decimal/float). The checkin uses the new safe mode in a few places, but it lets us be more careful about how hidden conversions are done in the future.
