### PR TITLE
Fix a bug in Stats.minBy.

### DIFF
--- a/src/Deedle/Stats.fs
+++ b/src/Deedle/Stats.fs
@@ -606,7 +606,7 @@ type Stats =
   /// [category:Series statistics]
   static member inline minBy f (series:Series<'K, 'T>) = 
     if series.ValueCount = 0 then None
-    else Some(series |> Series.observations |> Seq.maxBy (snd >> f))
+    else Some(series |> Series.observations |> Seq.minBy (snd >> f))
 
   /// Returns the median of the elements of the series.
   ///

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -210,11 +210,11 @@ let ``Moving minimum works with nan values`` () =
 [<Test>]
 let ``maxBy and minBy work`` () =
   let s = series [ 0 => 1.0; 1 => nan; 2 => 5.0 ]
-  s |> Stats.maxBy id |> shouldEqual (Some 5.0)
-  s |> Stats.minBy id |> shouldEqual (Some 1.0)
+  s |> Stats.maxBy id |> shouldEqual (Some (2, 5.0))
+  s |> Stats.minBy id |> shouldEqual (Some (0, 1.0))
 
-  s |> Stats.maxBy (fun x -> -x) |> shouldEqual (Some -1.0)
-  s |> Stats.minBy (fun x -> -x) |> shouldEqual (Some -5.0)
+  s |> Stats.maxBy (fun x -> -x) |> shouldEqual (Some (0, 1.0))
+  s |> Stats.minBy (fun x -> -x) |> shouldEqual (Some (2, 5.0))
 
 // ------------------------------------------------------------------------------------------------
 // Statistics on frames

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -231,10 +231,6 @@ let ``Can calulate minimum and maximum of numeric series in a frame`` () =
   let df = sampleFrame()
   df |> Stats.min |> shouldEqual <| series [ "A" => 1.0; "B" => nan; "C" => 3.3 ]
   df |> Stats.max |> shouldEqual <| series [ "A" => 3.0; "B" => nan; "C" => 6.6 ]
-  
-  // minBy and maxBy
-  df |> Stats.minBy id |> shouldEqual <| series [ "A" => 1.0; "B" => nam; "C" => 3.3 ]
-  df |> Stats.maxBy id |> shouldEqual <| series [ "A" => 3.0; "B" => nan; "C" => 6.6 ]
 
 // ------------------------------------------------------------------------------------------------
 // Some FsCheck tests

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -207,6 +207,15 @@ let ``Moving minimum works with nan values`` () =
   let s1 = series [ 0 => 1.0; 1 => nan ]
   Stats.movingMin 1 s1 |> shouldEqual <| series [ 0 => 1.0; 1 => nan ]
 
+[<Test>]
+let ``maxBy and minBy work`` () =
+  let s = series [ 0 => 1.0; 1 => nan; 2 => 5.0 ]
+  s |> Stats.maxBy id |> shouldEqual (Some 5.0)
+  s |> Stats.minBy id |> shouldEqual (Some 1.0)
+
+  s |> Stats.maxBy (fun x -> -x) |> shouldEqual (Some -1.0)
+  s |> Stats.minBy (fun x -> -x) |> shouldEqual (Some -5.0)
+
 // ------------------------------------------------------------------------------------------------
 // Statistics on frames
 // ------------------------------------------------------------------------------------------------

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -222,6 +222,10 @@ let ``Can calulate minimum and maximum of numeric series in a frame`` () =
   let df = sampleFrame()
   df |> Stats.min |> shouldEqual <| series [ "A" => 1.0; "B" => nan; "C" => 3.3 ]
   df |> Stats.max |> shouldEqual <| series [ "A" => 3.0; "B" => nan; "C" => 6.6 ]
+  
+  // minBy and maxBy
+  df |> Stats.minBy id |> shouldEqual <| series [ "A" => 1.0; "B" => nam; "C" => 3.3 ]
+  df |> Stats.maxBy id |> shouldEqual <| series [ "A" => 3.0; "B" => nan; "C" => 6.6 ]
 
 // ------------------------------------------------------------------------------------------------
 // Some FsCheck tests


### PR DESCRIPTION
The implementation should use Seq.minBy instead of Seq.maxBy. This PR fixes it.
