### PR TITLE
Test case and fix for empty frames using `frame []`

### DIFF
--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1196,7 +1196,7 @@ module Frame =
     let vectorBuilder = VectorBuilder.Instance
     let newRowIndex, vectorR = frame.RowIndex.Builder.Shift((frame.RowIndex, Vectors.Return 0), offset)
     let _, vectorL = frame.RowIndex.Builder.Shift((frame.RowIndex, Vectors.Return 0), -offset)
-    let cmd = Vectors.Combine([vectorL; vectorR], BinaryTransform.Create<float>(OptionalValue.map2 (-)))
+    let cmd = Vectors.Combine(newRowIndex.KeyCount, [vectorL; vectorR], BinaryTransform.Create<float>(OptionalValue.map2 (-)))
     let newData = frame.Data.Select(function
         | AsFloatVector vf -> VectorBuilder.Instance.Build(cmd, [| vf |]) :> IVector
         | vector -> vector)

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -441,7 +441,7 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
         else mergeUnordered()
       let vectors = constructions |> List.map snd
       let newIndex, vectors = makeSeriesConstructions keysAndRelocs vectors ordered
-      newIndex, Vectors.Combine(vectors, transform)
+      newIndex, Vectors.Combine(newIndex.KeyCount, vectors, transform)
 
 
     /// Build a new index by getting a key for each old key using the specified function

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -487,7 +487,7 @@ and
       | UnionBehavior.PreferRight -> BinaryTransform.RightIfAvailable
       | UnionBehavior.Exclusive -> BinaryTransform.AtMostOne
       | _ -> BinaryTransform.LeftIfAvailable
-    let vecCmd = Vectors.Combine([vec1; vec2], transform)
+    let vecCmd = Vectors.Combine(newIndex.KeyCount, [vec1; vec2], transform)
     let newVec = vectorBuilder.Build(vecCmd, [| series.Vector; another.Vector |])
     Series(newIndex, newVec, vectorBuilder, indexBuilder)
 
@@ -520,7 +520,7 @@ and
     let newIndex, lVec, rVec = series.ZipHelper(otherSeries, JoinKind.Inner, Lookup.Exact)
     
     let vecRes = 
-      Vectors.Combine([Vectors.Return 0; Vectors.Return 1], 
+      Vectors.Combine(newIndex.KeyCount, [Vectors.Return 0; Vectors.Return 1], 
         BinaryTransform.CreateLifted<Choice<'V, 'V2, 'V * 'V2>>(fun l r ->
           match l, r with
           | Choice1Of3 l, Choice2Of3 r -> Choice3Of3(l, r)

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -651,7 +651,7 @@ module Series =
     let vectorBuilder = VectorBuilder.Instance
     let newIndex, vectorR = series.Index.Builder.Shift((series.Index, Vectors.Return 0), offset)
     let _, vectorL = series.Index.Builder.Shift((series.Index, Vectors.Return 0), -offset)
-    let cmd = Vectors.Combine([vectorL; vectorR], BinaryTransform.Create< ^T >(OptionalValue.map2 (-)))
+    let cmd = Vectors.Combine(newIndex.KeyCount, [vectorL; vectorR], BinaryTransform.Create< ^T >(OptionalValue.map2 (-)))
     let newVector = vectorBuilder.Build(cmd, [| series.Vector |])
     Series(newIndex, newVector, vectorBuilder, series.Index.Builder)
 

--- a/src/Deedle/Vectors/ArrayVector.fs
+++ b/src/Deedle/Vectors/ArrayVector.fs
@@ -254,7 +254,9 @@ type ArrayVectorBuilder() =
             vectors 
             |> List.map (fun v -> vectorBuilder.Build(v, arguments) :> IVector)
             |> Array.ofSeq
-          let length = data |> Seq.map (fun d -> d.Length) |> Seq.max
+          let length = 
+            if data.Length = 0 then 0L
+            else data |> Seq.map (fun d -> d.Length) |> Seq.max
 
           // Using `createObjRowReader` to get a row reader for a specified address
           let frameData = vectorBuilder.Create data

--- a/src/Deedle/Vectors/ArrayVector.fs
+++ b/src/Deedle/Vectors/ArrayVector.fs
@@ -189,7 +189,7 @@ type ArrayVectorBuilder() =
               VectorOptional(Array.append first second) |> av
 
 
-      | CombinedRelocations(relocs, op) ->
+      | CombinedRelocations(count, relocs, op) ->
           // OPTIMIZATION: Matches when we want to combine N vectors (as below) but
           // each vector is specified by a Relocate construction. In that case, we do
           // not need to build intermediate relocated vectors, but can directly build
@@ -201,7 +201,6 @@ type ArrayVectorBuilder() =
           let data = relocs |> List.map (fun (v, _, r) -> 
             (|AsVectorOptional|) (builder.buildArrayVector v arguments), r)
           let merge = op.GetFunction<'T>()
-          let count = relocs |> List.map (fun (_, l, _) -> l) |> List.max
           let filled : OptionalValue<_>[] = Array.create (int count) OptionalValue.Missing
 
           if op.IsMissingUnit then
@@ -243,7 +242,7 @@ type ArrayVectorBuilder() =
           filled |> vectorBuilder.CreateMissing
 
 
-      | Combine(vectors, VectorListTransform.Nary (:? IRowReaderTransform)) ->
+      | Combine(length, vectors, VectorListTransform.Nary (:? IRowReaderTransform)) ->
           // OPTIMIZATION: The `IRowReaderTransform` interface is a marker telling us that 
           // we are creating `IVector<obj`> where `obj` is a boxed `IVector<obj>` 
           // representing the row formed by all of the specified vectors combined.
@@ -254,9 +253,6 @@ type ArrayVectorBuilder() =
             vectors 
             |> List.map (fun v -> vectorBuilder.Build(v, arguments) :> IVector)
             |> Array.ofSeq
-          let length = 
-            if data.Length = 0 then 0L
-            else data |> Seq.map (fun d -> d.Length) |> Seq.max
 
           // Using `createObjRowReader` to get a row reader for a specified address
           let frameData = vectorBuilder.Create data
@@ -270,17 +266,15 @@ type ArrayVectorBuilder() =
           VectorNonOptional(rows) |> av |> unbox
 
 
-      | Combine(vectors, op) ->
+      | Combine(length, vectors, op) ->
           // Handles all remaining Combine cases - construct the vectors to be combined 
           // recursively and then combine them using a `'T list -> 'T` function (which is
           // either the specified one or `List.reduce` applied to a binary function)
           let merge = op.GetFunction<'T>()
           let data = vectors |> List.map (fun v -> 
             asVectorOptional (builder.buildArrayVector v arguments))
-          let length = 
-            data |> Seq.map Array.length |> Seq.max
           let filled = 
-            Array.init length (fun idx ->
+            Array.init (int length) (fun idx ->
               data 
               |> List.map (fun v -> if idx > v.Length then OptionalValue.Missing else v.[idx]) 
               |> merge)  

--- a/src/Deedle/Vectors/Vector.fs
+++ b/src/Deedle/Vectors/Vector.fs
@@ -230,7 +230,7 @@ type VectorConstruction =
   /// Combine N aligned vectors. The `IVectorValueListTransform` object
   /// specifies how to merge values (in case there is a value at a given address
   /// in more than one of the vectors).
-  | Combine of VectorConstruction list * VectorListTransform
+  | Combine of int64 * VectorConstruction list * VectorListTransform
 
   /// Create a vector that has missing values filled using the specified direction
   /// (forward means that n-th value will contain (n-i)-th value where (n-i) is the

--- a/src/Deedle/Vectors/VectorHelpers.fs
+++ b/src/Deedle/Vectors/VectorHelpers.fs
@@ -491,16 +491,16 @@ let rec substitute ((oldVar, newVar) as subst) = function
   | DropRange(vc, r) -> DropRange(substitute subst vc, r)
   | GetRange(vc, r) -> GetRange(substitute subst vc, r)
   | Append(l, r) -> Append(substitute subst l, substitute subst r)
-  | Combine(lst, c) -> Combine(List.map (substitute subst) lst, c)
+  | Combine(l, lst, c) -> Combine(l, List.map (substitute subst) lst, c)
   | CustomCommand(vcs, f) -> CustomCommand(List.map (substitute subst) vcs, f)
   | AsyncCustomCommand(vcs, f) -> AsyncCustomCommand(List.map (substitute subst) vcs, f)
 
 /// Matches when the vector command represents a combination
 /// of N relocated vectors (that is Combine [Relocate ..; Relocate ..; ...])
 let (|CombinedRelocations|_|) = function
-  | Combine(list, VectorListTransform.Binary op) ->
+  | Combine(l, list, VectorListTransform.Binary op) ->
       if list |> List.forall (function Relocate _ -> true | _ -> false) then
         let parts = list |> List.map (function Relocate(a,b,c) -> (a,b,c) | _ -> failwith "logic error")
-        Some(parts, op)
+        Some(l, parts, op)
       else None
   | _ -> None

--- a/src/Deedle/Vectors/VirtualVector.fs
+++ b/src/Deedle/Vectors/VirtualVector.fs
@@ -279,7 +279,7 @@ type VirtualVectorBuilder() =
           | :? IWrappedVector<'T> as vector -> restrictRange (vector.UnwrapVector())
           | vector -> restrictRange vector 
 
-      | Combine(vectors, ((VectorListTransform.Nary (:? IRowReaderTransform)) as transform)) ->
+      | Combine(count, vectors, ((VectorListTransform.Nary (:? IRowReaderTransform)) as transform)) ->
           // OPTIMIZATION: The `IRowReaderTransform` interface is a marker telling us that 
           // we are creating `IVector<obj`> where `obj` is a boxed `IVector<obj>` 
           // representing the row formed by all of the specified vectors combined.
@@ -334,10 +334,10 @@ type VirtualVectorBuilder() =
             // `obj = IVector<obj>` as the row readers (the caller in Rows then unbox this)
             VirtualVector(VirtualVectorSource.map None (fun _ -> OptionalValue.map box) newSource) |> unbox<IVector<'T>>
           else
-            let cmd = Combine([ for i in 0 .. builtSources.Length-1 -> Return i ], transform)
+            let cmd = Combine(count, [ for i in 0 .. builtSources.Length-1 -> Return i ], transform)
             baseBuilder.Build(cmd, builtSources)
 
-      | Combine(sources, transform) ->
+      | Combine(length, sources, transform) ->
           let builtSources = sources |> List.map (fun source -> VirtualVectorHelpers.unboxVector (build source args)) |> Array.ofSeq
           let allVirtual = builtSources |> Array.forall (fun vec -> vec :? VirtualVector<'T>)
           if allVirtual then
@@ -346,7 +346,7 @@ type VirtualVectorBuilder() =
             let newSource = VirtualVectorSource.combine func sources
             VirtualVector(newSource) :> _
           else
-            let cmd = Combine([ for i in 0 .. builtSources.Length-1 -> Return i ], transform)
+            let cmd = Combine(length, [ for i in 0 .. builtSources.Length-1 -> Return i ], transform)
             baseBuilder.Build(cmd, builtSources)
 
       | Append(first, second) ->

--- a/src/Deedle/Vectors/VirtualVector.fs
+++ b/src/Deedle/Vectors/VirtualVector.fs
@@ -24,7 +24,7 @@ type IVirtualVectorSource<'V> =
   inherit IVirtualVectorSource
   abstract ValueAt : int64 -> OptionalValue<'V>
   abstract GetSubVector : VectorRange -> IVirtualVectorSource<'V>
-  abstract MergeWith : IVirtualVectorSource<'V> list -> IVirtualVectorSource<'V>
+  abstract MergeWith : seq<IVirtualVectorSource<'V>> -> IVirtualVectorSource<'V>
   abstract LookupRange : LookupKind<'V> -> VectorRange
   abstract LookupValue : 'V * Lookup * Func<Addressing.Address, bool> -> OptionalValue<'V * Addressing.Address> 
 
@@ -44,7 +44,7 @@ module VirtualVectorSource =
         member x.GetSubVector(range) = boxSource (source.GetSubVector(range))
         member x.MergeWith(sources) = 
           let sources = 
-            sources |> List.tryChooseBy (function
+            sources |> List.ofSeq |> List.tryChooseBy (function
             | :? IBoxedVectorSource<'T> as src -> Some(src.Source)
             | _ -> None)
           match sources with 
@@ -71,7 +71,7 @@ module VirtualVectorSource =
         member x.MergeWith(sources) = 
           // For every source, we get a list of sources that were used to produce it
           let sources = 
-            (x::sources) |> List.tryChooseBy (function
+            Seq.append [x] sources |> List.ofSeq |> List.tryChooseBy (function
             | :? ICombinedVectorSource<'T> as src -> Some(src.Sources |> Array.ofSeq)
             | _ -> None)
           match sources with 
@@ -105,7 +105,7 @@ module VirtualVectorSource =
     { new IVirtualVectorSource<'TNew> with
         member x.ValueAt(idx) = f (Address.ofInt64 idx) (source.ValueAt(idx)) // TODO: Are we calculating the address correctly here??
         member x.MergeWith(sources) = 
-          let sources = sources |> List.tryChooseBy (function
+          let sources = sources |> List.ofSeq |> List.tryChooseBy (function
               | :? IMappedVectorSource<'V, 'TNew> as src -> Some(src.Source) | _ -> None)
           match sources with 
           | None -> failwith "Cannot merge frames or series not created by combine"
@@ -304,7 +304,7 @@ type VirtualVectorBuilder() =
                   member x.MergeWith(sources) = 
                     // For every source, we get a list of sources that were used to produce it
                     let sources = 
-                      (x::sources) |> List.tryChooseBy (function
+                      Seq.append [x] sources |> List.ofSeq |> List.tryChooseBy (function
                       | :? VirtualVectorSource.ICombinedVectorSource<'T> as src -> Some(src.Sources |> Array.ofSeq)
                       | _ -> None)
                     match sources with 

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -187,6 +187,20 @@ let ``Creating frame from sorted series returns sorted frame``() =
   df1.RowIndex.IsOrdered  |> shouldEqual true
   df2.RowIndex.IsOrdered  |> shouldEqual true
 
+[<Test>]
+let ``Can create empty frame``() =
+  let d : Frame<int, string> = frame []
+  d.RowCount |> shouldEqual 0
+  d.ColumnCount |> shouldEqual 0
+
+[<Test>]
+let ``Adding first column to an empty frame fixes the row keys``() =
+  let d : Frame<int, string> = frame []
+  d?Test1 <- series [ 1 => 1.1; 3 => 3.3 ]
+  d?Test2 <- series [ 1 => 1.1; 2 => 2.2; 3 => 3.3 ]
+  d.RowKeys |> set |> shouldEqual <| set [1; 3]
+  d.ColumnKeys |> set |> shouldEqual <| set ["Test1"; "Test2"]
+
 // ------------------------------------------------------------------------------------------------
 // Input and output (from records)
 // ------------------------------------------------------------------------------------------------

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -201,6 +201,11 @@ let ``Adding first column to an empty frame fixes the row keys``() =
   d.RowKeys |> set |> shouldEqual <| set [1; 3]
   d.ColumnKeys |> set |> shouldEqual <| set ["Test1"; "Test2"]
 
+[<Test>]
+let ``Rows of an empty frame should return empty series``() =
+  let d : Frame<int, string> = Frame.ofRowKeys [1;2;3]
+  d.Rows.[1].As<float>() |> shouldEqual <| series []
+
 // ------------------------------------------------------------------------------------------------
 // Input and output (from records)
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This adds a test checking that it is possible to create an empty frame
and adds a simple fix for this (via @adamklein). I also added a test
that fixes the behaviour when a new column is added to an empty frame -
when that happens, the frame's row keys are fixed to the row keys of the
first column (and later added columns use left join).
