### PR TITLE
Do not run the documentation generation tests on Mono

### DIFF
--- a/tests/Deedle.Documentation.Tests/DocTests.fs
+++ b/tests/Deedle.Documentation.Tests/DocTests.fs
@@ -80,9 +80,13 @@ for file in docFiles do
     errors |> Seq.map (sprintf "%O") |> String.concat "\n" |> printfn "%s"
 #else
 
+let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with _ -> false         
+ 
 [<Test>]
 [<TestCaseSource "docFiles">]
 let ``Documentation generated correctly `` file = 
+ // Do not run this test on Mono, we generate docs on Windows
+ if not runningOnMono then
   let errors = processFile file
 
   let errors =  


### PR DESCRIPTION
Documentation is generated on Windows. Running the documentation generation tests looks a little fragile on Mono.
