### PR TITLE
Typed access to Rows via an automatically implemented interface

### DIFF
--- a/docs/content/frame.fsx
+++ b/docs/content/frame.fsx
@@ -182,7 +182,6 @@ let peopleNested =
 
 // Expand the 'People' column
 peopleNested |> Frame.expandCols ["People"]
-
 (*** include-it:ppl ***)
 
 (**
@@ -234,13 +233,9 @@ We'll use the data frame `people` which contains three columns - `Name` of type 
 `Age` of type `int` and `Countries` of type `string list` (we created it from F# records
 in [the previous section](#creating-recd)):
 
-    [lang=text]
-               Age Countries          
-    Joe     -> 51  [UK; US; UK]       
-    Tomas   -> 28  [CZ; UK; US; ... ] 
-    Eve     -> 2   [FR]               
-    Suzanne -> 15  [US]   
-
+*)
+(*** include-value:people ***)
+(**
 To get a column (series) from a frame `df`, you can use operations that are exposed directly
 by the data frame, or you can use `df.Columns` which returns all columns of the frame as a
 series of series.
@@ -321,6 +316,35 @@ the value to a given type. You could also achieve the same thing by writing `row
 and then casting the result to `string list`, but the `GetAs` method provides a more convenient
 syntax.
 
+### Typed access to rows
+
+Accessing columns using `ObjectSeries<T>` is fine for simple tasks, but it has two problems.
+First, it is not type-safe and you can easily get a runtime exception if you specify wrong
+type. Second, it involves boxing and unboxing and so it may be inefficient.
+
+To address these two issues, Deedle provides another alternative. You can specify an _interface_
+that defines the types of columns once and then use this interface to get a series of rows
+where every row is an instance of the interface:
+*)
+/// Expected columns & their types in a row
+type IPerson = 
+  abstract Age : int
+  abstract Countries : string list
+
+// Get rows as series of 'IPerson' values
+let rows = people.GetRowsAs<IPerson>()
+rows.["Tomas"].Countries 
+(**
+You still need to be careful and define the types in the `IPerson` interface correctly, but
+once the `GetRowsAs<IPerson>` call returns a value, you will be able to access the rows in
+a nice typed way. Alternatively, you can also specify the type with `OptionalValue<T>`, in 
+case you want to explicitly handle missing values.
+*)
+/// Alternative that lets us handle missing 'Age' values
+type IPersonOpt = 
+  abstract Age : OptionalValue<int>
+  abstract Countries : string list
+(**
 ### Adding rows and columns
 
 The series type is _immutable_ and so it is not possible to add new values to a series or 

--- a/docs/tools/formatters.fsx
+++ b/docs/tools/formatters.fsx
@@ -1,5 +1,5 @@
 ﻿module Formatters
-#I "../../packages/FSharp.Formatting.2.4.21/lib/net40"
+#I "../../packages/FSharp.Formatting.2.4.36/lib/net40"
 #r "FSharp.Markdown.dll"
 #r "FSharp.Literate.dll"
 #r "../../bin/Deedle.dll"

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -20,8 +20,8 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FSharp.Compiler.Service.0.0.59/lib/net40"
-#I "../../packages/FSharp.Formatting.2.4.21/lib/net40"
+#I "../../packages/FSharp.Compiler.Service.0.0.67/lib/net40"
+#I "../../packages/FSharp.Formatting.2.4.36/lib/net40"
 #I "../../packages/RazorEngine.3.3.0/lib/net40/"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
@@ -51,7 +51,7 @@ let content    = __SOURCE_DIRECTORY__ @@ "../content"
 let output     = __SOURCE_DIRECTORY__ @@ "../output"
 let files      = __SOURCE_DIRECTORY__ @@ "../files"
 let templates  = __SOURCE_DIRECTORY__ @@ "templates"
-let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.4.21/"
+let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.4.36/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
@@ -84,9 +84,9 @@ let buildDocumentation () =
     let sub = if dir.Length > content.Length then dir.Substring(content.Length + 1) else "."
     Literate.ProcessDirectory
       ( dir, docTemplate, output @@ sub, replacements = ("root", root)::info,
-        layoutRoots = layoutRoots, fsiEvaluator = fsiEvaluator )
+        layoutRoots = layoutRoots, fsiEvaluator = fsiEvaluator, generateAnchors = true )
 
 // Generate
 copyFiles()
 buildDocumentation()
-//buildReference()
+buildReference()

--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="FSharp.Charting" version="0.90.6" targetFramework="net40" />
   <package id="FSharp.Data" version="2.0.14" targetFramework="net40" />
-  <package id="FSharp.Formatting" version="2.4.21" targetFramework="net45" />
-  <package id="FSharp.Compiler.Service" version="0.0.59" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.4.36" targetFramework="net45" />
+  <package id="FSharp.Compiler.Service" version="0.0.67" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
   <package id="MathNet.Numerics" version="3.0.0" targetFramework="net45" />

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -515,9 +515,6 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Accessors and slicing]
   member frame.GetRowsAs<'TRow>() : Series<'TRowKey, 'TRow> =    
-    // This is similar to 'frame.Rows' but rather than returning 'ObjectSeries',
-    // we build a Series that contains values of the 'TRow interface.
-
     if typeof<'TColumnKey> <> typeof<string> then 
       failwith "The GetRows operation can only be used when column key is a string."
 
@@ -527,14 +524,6 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
       if address = Address.Invalid then
         failwithf "The interface member '%s' does not exist in the column index." column
       address )
-
-    // We get a vector containing boxed `IVector<obj>` - we turn it into a
-    // vector containing `ObjectSeries`, but lazily to avoid allocations
-    //let vector = createCombinedRowVector () 
-
-    //let vector = vector |> VectorHelpers.lazyMapVector (fun o -> 
-    //  let rowReader = unbox<IVector<obj>> o
-    //  rowBuilder rowReader )
 
     let vector = rowBuilder rowIndex.KeyCount data
     Series<'TRowKey, 'TRow>(rowIndex, vector, vectorBuilder, indexBuilder)

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -522,7 +522,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
       failwith "The GetRows operation can only be used when column key is a string."
 
     let keys = columnIndex.Keys |> Seq.map unbox<string> |> List.ofSeq 
-    let rowBuilder = VectorHelpers.createTypedRowBuilder<'TRow> keys (fun column ->
+    let rowBuilder = VectorHelpers.createTypedRowReader<'TRow> keys (fun column ->
       let address = columnIndex.Locate(unbox<'TColumnKey> column)
       if address = Address.Invalid then
         failwithf "The interface member '%s' does not exist in the column index." column
@@ -530,11 +530,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
     // We get a vector containing boxed `IVector<obj>` - we turn it into a
     // vector containing `ObjectSeries`, but lazily to avoid allocations
-    let vector = createCombinedRowVector () 
-    let vector = vector |> VectorHelpers.lazyMapVector (fun o -> 
-      let rowReader = unbox<IVector<obj>> o
-      rowBuilder rowReader )
+    //let vector = createCombinedRowVector () 
 
+    //let vector = vector |> VectorHelpers.lazyMapVector (fun o -> 
+    //  let rowReader = unbox<IVector<obj>> o
+    //  rowBuilder rowReader )
+
+    let vector = rowBuilder rowIndex.KeyCount data
     Series<'TRowKey, 'TRow>(rowIndex, vector, vectorBuilder, indexBuilder)
 
   /// [category:Accessors and slicing]

--- a/src/Deedle/Vectors/VectorHelpers.fs
+++ b/src/Deedle/Vectors/VectorHelpers.fs
@@ -458,14 +458,14 @@ module Inference =
     | _, _ -> Bottom
 
 /// Helper object called by createTypedVector via reflection
-type createTypedRowReaderHelper = 
+type mapFrameRowVector = 
   static member Create<'T>(builder:IVectorBuilder, data:obj[]) =
     builder.Create(Array.map (Convert.convertType<'T> ConversionKind.Flexible) data)
 
 /// Given object array, create a typed vector of the best possible type
 let createTypedVector (builder:IVectorBuilder) (vectorType:System.Type) (data:obj[]) =
   let flags = System.Reflection.BindingFlags.NonPublic ||| System.Reflection.BindingFlags.Static
-  let createMi = typeof<createTypedRowReaderHelper>.GetMethod("Create", flags).MakeGenericMethod [| vectorType |]
+  let createMi = typeof<mapFrameRowVector>.GetMethod("Create", flags).MakeGenericMethod [| vectorType |]
   createMi.Invoke(null, [| builder; data |]) :?> IVector
 
 /// Find common super type of the specified .NET types
@@ -488,129 +488,200 @@ let createInferredTypeVector (builder:IVectorBuilder) (data:obj[]) =
 open System.Reflection
 open System.Reflection.Emit
 
+/// Creates a vector of typed rows `IVector<'TRow>` from frame data `IVector<IVector>`.
+/// The returned vector uses the specified delegate `ctor` to construct `'TRow` values.
+/// (the `ctor` function takes data and address of the row to be wrapped)
+let mapFrameRowVector 
+    (ctor:System.Func<IVector<IVector>, Addressing.Address, 'TRow>) 
+    length (data:IVector<IVector>)  =
+  { new IVector<'TRow> with
+      member x.GetValue(a) = OptionalValue(ctor.Invoke(data, a))
+      member x.Data = 
+        seq { for i in Seq.range 0L (length-1L) -> (x :> IVector<_>).GetValue(i) }
+        |> VectorData.Sequence
+      member x.Select(g) =  failwith "mapFrameRowVector: Select not supported"
+      member x.SelectMissing(g) = failwith "mapFrameRowVector: SelectMissing not supported"
+      member x.Convert(h, g) = failwith "mapFrameRowVector: Convert not supported"
+    interface IVector with
+      member x.Length = length
+      member x.ObjectSequence = seq { for i in Seq.range 0L (length-1L) -> x.GetObject(i) }
+      member x.SuppressPrinting = data.SuppressPrinting
+      member x.ElementType = typeof<'TRow>
+      member x.GetObject(i) = (x :?> IVector<'TRow>).GetValue(i) |> OptionalValue.map box
+      member x.Invoke(site) = failwith "mapFrameRowVector: Invoke not supported" }
+
+#if DEBUG_TYPED_ROWS
+let name = new AssemblyName("TypedRowAssembly")
+let asmBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(name, AssemblyBuilderAccess.RunAndSave)
+let private typedRowModule = Lazy.Create(fun _ ->
+  asmBuilder.DefineDynamicModule(name.Name, name.Name+".dll"))
+#else 
 /// Dynamic assembly & module for storing generated types
 let private typedRowModule = Lazy.Create(fun _ -> 
   let name = new AssemblyName("TypedRowAssembly")
   let asmBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(name, AssemblyBuilderAccess.RunAndCollect)
-  asmBuilder.DefineDynamicModule(name.Name, name.Name+".dll") )
+  asmBuilder.DefineDynamicModule(name.Name, name.Name+".dll"))
+#endif
 
 /// Helper module with various MemberInfo and similar values
 module private Reflection = 
   let objCtor = typeof<obj>.GetConstructor([| |])
   let addrTyp = typeof<Addressing.Address>
+  let optTyp = typedefof<OptionalValue<_>>
 
 /// Counter of generated types to avoid name clashes
 let private typeCounter = ref 0
 
-let createTypedRowReaderHelper (ctor:System.Func<IVector<IVector>, Addressing.Address, 'TRow>) length (data:IVector<IVector>)  =
-  { //new System.Object() with
-      //member x.Equals(another) = vector.Equals(another)
-      //member x.GetHashCode() = vector.GetHashCode()
-    new IVector<'TRow> with
-      member x.GetValue(a) = OptionalValue(ctor.Invoke(data, a)) // ??? TODO: Handle missing properly
-      member x.Data = 
-        seq { for i in Seq.range 0L (length-1L) -> (x :> IVector<_>).GetValue(i) }
-        |> VectorData.Sequence
-      member x.Select(g) = failwith "Select"
-      member x.SelectMissing(g) = failwith "SelectMissing"
-      member x.Convert(h, g) = failwith "Convert"
-    interface IVector with
-      member x.Length = length
-      member x.ObjectSequence = failwith "ObjectSequence"
-      member x.SuppressPrinting = false
-      member x.ElementType = typeof<'TRow>
-      member x.GetObject(i) = failwith "GetObject"
-      member x.Invoke(site) = failwith "Invoke" }
+/// Cache for optimizing 'createTypedRowBuilder' 
+let private createdTypedRowsCache = Dictionary<Type * string list, obj>() 
 
-let createTypedRowReader<'TRow> keys (columnIndex:string -> Address) = 
+/// Uses Reflection.Emit to create an efficient implementation of the `'TRow` interface.
+let createTypedRowCreator<'TRow> columnKeys (columnIndex:string -> Address) = 
   let rowType = typeof<'TRow>
-  incr typeCounter
-  let typeName = sprintf "Impl%s@%d" rowType.Name typeCounter.Value
-  let rowImpl = 
-    typedRowModule.Value.DefineType
-      (typeName, TypeAttributes.Public, typeof<obj>, [| rowType |])
-
-  let columnTypes = 
-    [ for m in rowType.GetMethods() ->
+  match createdTypedRowsCache.TryGetValue( (rowType, columnKeys) ) with 
+  | true, res -> unbox<Func<IVector<IVector>, Address, 'TRow>> res 
+  | false, _ -> 
+      // Check that the interface has only property getters
+      for m in rowType.GetMethods() do
         if not m.IsSpecialName || not (m.Name.StartsWith("get_")) then
           raise (new InvalidOperationException("Only readonly properties are supported in the interface!"))
-        typedefof<IVector<_>>.MakeGenericType(m.ReturnType) ]
 
-  let vecFields = 
-    columnTypes |> List.mapi (fun i vecTy ->
-        rowImpl.DefineField(sprintf "vector_%d" i, vecTy, FieldAttributes.Private))
-  let addrField = rowImpl.DefineField("address", typeof<Addressing.Address>, FieldAttributes.Private)
+      // Define a type named ImpleIInterface@1 
+      incr typeCounter
+      let typeName = sprintf "Impl%s@%d" rowType.Name typeCounter.Value
+      let rowImpl = 
+        typedRowModule.Value.DefineType
+          (typeName, TypeAttributes.Public, typeof<obj>, [| rowType |])
 
-  let ctor = rowImpl.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, Reflection.addrTyp::columnTypes |> Array.ofSeq)
-  let ilgen = ctor.GetILGenerator()
-  ilgen.Emit(OpCodes.Ldarg_0)
-  ilgen.Emit(OpCodes.Callvirt, Reflection.objCtor)
+      // For every property of type `T`, define a field of type `IVector<T>`
+      // (this stores reference to the typed vector) and define a field
+      // `address` storing the current row address of the `'TRow` value.
+      //
+      // When the property has a type `OptionalValue<T>` then we expect that
+      // the column has a type `T`, but the user wants to see missing values
+      let columnTypes = 
+        [ for m in rowType.GetMethods() ->
+            if m.ReturnType.IsGenericType && m.ReturnType.GetGenericTypeDefinition() = Reflection.optTyp 
+              then true, typedefof<IVector<_>>.MakeGenericType(m.ReturnType.GetGenericArguments().[0])
+              else false, typedefof<IVector<_>>.MakeGenericType(m.ReturnType) ]
+            
+      let vecFields = 
+        columnTypes |> List.mapi (fun i (_, vecTy) ->
+            rowImpl.DefineField(sprintf "vector_%d" i, vecTy, FieldAttributes.Private))
+      let addrField = rowImpl.DefineField("address", typeof<Addressing.Address>, FieldAttributes.Private)
 
-  ilgen.Emit(OpCodes.Ldarg_0)
-  ilgen.Emit(OpCodes.Ldarg_1)
-  ilgen.Emit(OpCodes.Stfld, addrField)
+      // Define constructor which takes address & column vectors and stores them:
+      //
+      //    new(addr, vec1, ..., vecN) =
+      //      base()
+      //      this.address <- addr
+      //      this.vector_1 <- vec1
+      //      (...)
+      ///
+      let ctor = 
+        rowImpl.DefineConstructor
+          ( MethodAttributes.Public, CallingConventions.Standard, 
+            Reflection.addrTyp::(List.map snd columnTypes) |> Array.ofSeq)
+      let ilgen = ctor.GetILGenerator()
+      ilgen.Emit(OpCodes.Ldarg_0)
+      ilgen.Emit(OpCodes.Callvirt, Reflection.objCtor)
+
+      ilgen.Emit(OpCodes.Ldarg_0)
+      ilgen.Emit(OpCodes.Ldarg_1)
+      ilgen.Emit(OpCodes.Stfld, addrField)
   
-  vecFields |> List.iteri (fun i vecField -> 
-    ilgen.Emit(OpCodes.Ldarg_0)
-    ilgen.Emit(OpCodes.Ldarg, 1(*this*) + 1(*address*) + i)
-    ilgen.Emit(OpCodes.Stfld, vecField) )
-  
-  ilgen.Emit(OpCodes.Ret)
-
-  for m, fld in Seq.zip (rowType.GetMethods()) vecFields do
-    let impl = rowImpl.DefineMethod(m.Name, MethodAttributes.Public ||| MethodAttributes.Virtual ||| MethodAttributes.SpecialName, m.ReturnType, [| |])
-    let ilgen = impl.GetILGenerator()
-
-    let optTyp = typedefof<OptionalValue<_>>.MakeGenericType(fld.FieldType.GetGenericArguments().[0])
-    let localOpt = ilgen.DeclareLocal(optTyp)
-
-    ilgen.Emit(OpCodes.Ldarg_0)
-    ilgen.Emit(OpCodes.Ldfld, fld)
-    ilgen.Emit(OpCodes.Ldarg_0)
-    ilgen.Emit(OpCodes.Ldfld, addrField)
-    ilgen.Emit(OpCodes.Callvirt, fld.FieldType.GetMethod("GetValue"))
-    ilgen.Emit(OpCodes.Stloc, localOpt)
-
-    ilgen.Emit(OpCodes.Ldloca_S, localOpt)
-    ilgen.Emit(OpCodes.Call, optTyp.GetProperty("Value").GetGetMethod())
-    ilgen.Emit(OpCodes.Ret)
-  
-    rowImpl.DefineMethodOverride(impl, m)
-
-  let rowImplType = rowImpl.CreateType()
-  
-  let makeRow = DynamicMethod("Make" + rowType.Name, rowType, [| typeof<IVector<IVector>>; typeof<Address> |])
-  let ilgen = makeRow.GetILGenerator()
-
-  let locals = 
-    [ for m in rowType.GetMethods() ->
-        let localOpt = ilgen.DeclareLocal(typeof<OptionalValue<IVector>>)
+      vecFields |> List.iteri (fun i vecField -> 
         ilgen.Emit(OpCodes.Ldarg_0)
-        ilgen.Emit(OpCodes.Ldc_I8, columnIndex (m.Name.Substring(4)))
-        ilgen.Emit(OpCodes.Callvirt, typeof<IVector<IVector>>.GetMethod("GetValue"))
-        ilgen.Emit(OpCodes.Stloc, localOpt)
-        localOpt, m.ReturnType ]
+        ilgen.Emit(OpCodes.Ldarg, 1 (*this*) + 1 (*address*) + i)
+        ilgen.Emit(OpCodes.Stfld, vecField) )
+  
+      ilgen.Emit(OpCodes.Ret)
 
-  ilgen.Emit(OpCodes.Ldarg_1)
-  for loc, retTy in locals do 
-    ilgen.Emit(OpCodes.Ldloca, loc)
-    ilgen.Emit(OpCodes.Call, typeof<OptionalValue<IVector>>.GetProperty("Value").GetGetMethod())
-    ilgen.Emit(OpCodes.Castclass, typedefof<IVector<_>>.MakeGenericType(retTy))
 
-  let ctor = rowImplType.GetConstructors().[0]
-  ilgen.Emit(OpCodes.Newobj, ctor)
-  ilgen.Emit(OpCodes.Ret)
+      // For every property in the interface, define a method that overrides the getter
+      for m, ((isOptional, typ), fld) in Seq.zip (rowType.GetMethods()) (Seq.zip columnTypes vecFields) do
+        // if `isOptional`, i.e. the return type is `OptionalValue<T>` then
+        //
+        //   override this.get_Something() =
+        //     this.vector_i.GetValue(this.address)
+        //
+        // Otherwise, we call `get_Value()` at the end (which fails for missing values):
+        //
+        //   override this.get_Something() =
+        //     let local = this.vector_i.GetValue(this.address)
+        //     local.get_Value()
+        //
+        let impl = 
+          rowImpl.DefineMethod
+            ( m.Name, MethodAttributes.Public ||| MethodAttributes.Virtual 
+              ||| MethodAttributes.SpecialName, m.ReturnType, [| |])
+        let ilgen = impl.GetILGenerator()
 
-  // Return a function that can be used for creating interface 
-  // instances from IVector<obj> values storing the data
-  let createRowImpl : System.Func<IVector<IVector>, Address, 'TRow> = 
-    unbox (makeRow.CreateDelegate(typeof<System.Func<IVector<IVector>, Address, 'TRow>>))
+        ilgen.Emit(OpCodes.Ldarg_0)
+        ilgen.Emit(OpCodes.Ldfld, fld)
+        ilgen.Emit(OpCodes.Ldarg_0)
+        ilgen.Emit(OpCodes.Ldfld, addrField)
+        ilgen.Emit(OpCodes.Callvirt, fld.FieldType.GetMethod("GetValue"))
 
-  //let f = titanic.GetType().GetField("data@83", System.Reflection.BindingFlags.NonPublic ||| System.Reflection.BindingFlags.Instance)
-  //let data : IVector<IVector> = failwith "!" // f.GetValue(titanic) :?> IVector<IVector>
+        if not isOptional then
+          let optTyp = Reflection.optTyp.MakeGenericType(typ.GetGenericArguments().[0])
+          let localOpt = ilgen.DeclareLocal(optTyp)
+          ilgen.Emit(OpCodes.Stloc, localOpt)
+          ilgen.Emit(OpCodes.Ldloca_S, localOpt)
+          ilgen.Emit(OpCodes.Call, optTyp.GetProperty("Value").GetGetMethod())
+        ilgen.Emit(OpCodes.Ret)
+  
+        rowImpl.DefineMethodOverride(impl, m)
 
-  createTypedRowReaderHelper createRowImpl
+      // Finish building the type
+      let rowImplType = rowImpl.CreateType()
+      #if DEBUG_TYPED_ROWS
+      asmBuilder.Save("TypedRowAssembly.dll")
+      #endif
 
+      // Next, we create a delegate `Func<IVector<IVector>, Address, 'TRow>` that 
+      // we can pass to `mapFrameRowVector` in order to build the resulting vector
+      let args = [| typeof<IVector<IVector>>; typeof<Address> |]
+      let makeRow = DynamicMethod("Make" + rowType.Name, rowType, args)
+      let ilgen = makeRow.GetILGenerator()
+
+      // fun data address ->
+      //   let vecOpt1 = data.GetValue( << columnIndex "Property1" >> ) 
+      //   (...)
+      //   let vecOptN = data.GetValue( << columnIndex "PropertyN" >> ) 
+      //
+      //   new ImpleIInterface@1( vecOpt1.Value :?> IVector<'T1>, ...
+      //                          vecOptN.Value :?> IVector<'TN> )
+      let locals = 
+        [ for (_, ty), m in Seq.zip columnTypes (rowType.GetMethods()) ->
+            let localOpt = ilgen.DeclareLocal(typeof<OptionalValue<IVector>>)
+            ilgen.Emit(OpCodes.Ldarg_0)
+            ilgen.Emit(OpCodes.Ldc_I8, columnIndex (m.Name.Substring(4)))
+            ilgen.Emit(OpCodes.Callvirt, typeof<IVector<IVector>>.GetMethod("GetValue"))
+            ilgen.Emit(OpCodes.Stloc, localOpt)
+            localOpt, ty ]
+
+      ilgen.Emit(OpCodes.Ldarg_1)
+      for loc, vecTy in locals do 
+        ilgen.Emit(OpCodes.Ldloca, loc)
+        ilgen.Emit(OpCodes.Call, typeof<OptionalValue<IVector>>.GetProperty("Value").GetGetMethod())
+        ilgen.Emit(OpCodes.Castclass, vecTy)
+
+      let ctor = rowImplType.GetConstructors().[0]
+      ilgen.Emit(OpCodes.Newobj, ctor)
+      ilgen.Emit(OpCodes.Ret)
+
+      // Build the delegate and get it as Systme.Func we can call
+      let createRowImpl : Func<IVector<IVector>, Address, 'TRow> = 
+        unbox (makeRow.CreateDelegate(typeof<Func<IVector<IVector>, Address, 'TRow>>))
+      createdTypedRowsCache.Add( (rowType, columnKeys), createRowImpl )
+      createRowImpl
+
+/// Creates a typed vector of `IVector<'TRow>` for a given interface `'TRow`
+/// (which is expected to have only read-only properties). 
+let createTypedRowReader<'TRow> columnKeys (columnIndex:string -> Address) = 
+  let ctor = createTypedRowCreator<'TRow> columnKeys columnIndex
+  mapFrameRowVector ctor
 
 // --------------------------------------------------------------------------------------
 // Vector constructions

--- a/tests/Deedle.Documentation.Tests/Deedle.Documentation.Tests.fsproj
+++ b/tests/Deedle.Documentation.Tests/Deedle.Documentation.Tests.fsproj
@@ -47,29 +47,29 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="CSharpFormat">
-      <HintPath>..\..\packages\FSharp.Formatting.2.4.21\lib\net40\CSharpFormat.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.36\lib\net40\CSharpFormat.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.CodeFormat">
-      <HintPath>..\..\packages\FSharp.Formatting.2.4.21\lib\net40\FSharp.CodeFormat.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.36\lib\net40\FSharp.CodeFormat.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Compiler.Interactive.Settings">
       <HintPath>..\..\lib\FSharp.Compiler.Interactive.Settings.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Compiler.Service">
-      <HintPath>..\..\packages\FSharp.Compiler.Service.0.0.59\lib\net40\FSharp.Compiler.Service.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Compiler.Service.0.0.67\lib\net40\FSharp.Compiler.Service.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Literate">
-      <HintPath>..\..\packages\FSharp.Formatting.2.4.21\lib\net40\FSharp.Literate.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.36\lib\net40\FSharp.Literate.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
     <Reference Include="FSharp.Markdown">
-      <HintPath>..\..\packages\FSharp.Formatting.2.4.21\lib\net40\FSharp.Markdown.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.36\lib\net40\FSharp.Markdown.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.MetadataFormat">
-      <HintPath>..\..\packages\FSharp.Formatting.2.4.21\lib\net40\FSharp.MetadataFormat.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.36\lib\net40\FSharp.MetadataFormat.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="nunit.framework">

--- a/tests/Deedle.Documentation.Tests/DocTests.fs
+++ b/tests/Deedle.Documentation.Tests/DocTests.fs
@@ -2,10 +2,10 @@
 // Test that the documentation is generated correctly withtout F# errors 
 // --------------------------------------------------------------------------------------
 #if INTERACTIVE
-#I "../../packages/FSharp.Formatting.2.4.21/lib/net40"
+#I "../../packages/FSharp.Formatting.2.4.36/lib/net40"
 #I "../../packages/RazorEngine.3.3.0/lib/net40/"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
-#r "../../packages/FSharp.Compiler.Service.0.0.59/lib/net40/FSharp.Compiler.Service.dll"
+#r "../../packages/FSharp.Compiler.Service.0.0.67/lib/net40/FSharp.Compiler.Service.dll"
 #r "RazorEngine.dll"
 #r "FSharp.Literate.dll"
 #r "FSharp.CodeFormat.dll"

--- a/tests/Deedle.PerfTests/Performance.fs
+++ b/tests/Deedle.PerfTests/Performance.fs
@@ -75,14 +75,26 @@ type ITitanicRow =
   abstract Pclass : int
   abstract Name : string
 
+type ITitanicFloatPClassRow =
+  abstract Pclass : float
+
 [<Test; PerfTest(Iterations=50)>]
 let ``Sum column using typed rows`` () = 
   let rows = titanic.GetRowsAs<ITitanicRow>()
-  for j in 0 .. 10 do
+  for j in 0 .. 10 do 
     let mutable c = 0
     for i in fst rows.KeyRange .. snd rows.KeyRange do
       c <- c + rows.[i].Pclass 
     c |> shouldEqual 2057
+
+[<Test; PerfTest(Iterations=50)>]
+let ``Sum column using typed rows with conversion`` () = 
+  let rows = titanic.GetRowsAs<ITitanicFloatPClassRow>() 
+  for j in 0 .. 10 do 
+    let mutable c = 0.0
+    for i in fst rows.KeyRange .. snd rows.KeyRange do
+      c <- c + rows.[i].Pclass 
+    c |> shouldEqual 2057.0
 
 [<Test; PerfTest(Iterations=5)>]
 let ``Sum column using untyped rows`` () = 

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -164,19 +164,30 @@ let ``Can create frame from IDataReader``() =
 // ------------------------------------------------------------------------------------------------
 
 type IMsftRow =
-  abstract Open : float
-  abstract High : float
-  abstract Low : float
-  abstract Close : float
-  abstract Volume : int64
-  abstract ``Adj Close`` : float
+  abstract Open : decimal
+  abstract High : decimal
+  abstract Low : decimal
+  abstract Close : decimal
+  abstract Volume : int
+  abstract ``Adj Close`` : decimal
 
 [<Test>]
 let ``Can access rows as a typed series via an interface`` () = 
   let df = msft()
   let rows = df.GetRowsAs<IMsftRow>()
-  rows.[DateTime(2000, 10, 10)].Close |> shouldEqual <| df.Rows.[DateTime(2000, 10, 10)]?Close
+  rows.[DateTime(2000, 10, 10)].Close 
+  |> shouldEqual <| df.Rows.[DateTime(2000, 10, 10)].GetAs<decimal>("Close")
 
+type IAandOptB =
+  abstract A : float
+  abstract B : OptionalValue<float>
+
+[<Test>]
+let ``Can access missing data via typed rows`` () = 
+  let df = frame [ "A" => Series.ofValues [1.0; 2.0]; "B" => Series.ofValues [1.0] ]
+  df.GetRowsAs<IAandOptB>().[0].B |> shouldEqual <| OptionalValue(1.0)
+  df.GetRowsAs<IAandOptB>().[1].B |> shouldEqual <| OptionalValue.Missing
+  
 [<Test>]
 let ``Cannot access typed rows when column is not available`` () =
   let df = frame [ "Open" => Series.ofValues [ 1 .. 10 ] ]

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -160,6 +160,30 @@ let ``Can create frame from IDataReader``() =
   |> shouldEqual expected
 
 // ------------------------------------------------------------------------------------------------
+// Typed access to frame rows
+// ------------------------------------------------------------------------------------------------
+
+type IMsftRow =
+  abstract Open : float
+  abstract High : float
+  abstract Low : float
+  abstract Close : float
+  abstract Volume : int64
+  abstract ``Adj Close`` : float
+
+[<Test>]
+let ``Can access rows as a typed series via an interface`` () = 
+  let df = msft()
+  let rows = df.GetRowsAs<IMsftRow>()
+  rows.[DateTime(2000, 10, 10)].Close |> shouldEqual <| df.Rows.[DateTime(2000, 10, 10)]?Close
+
+[<Test>]
+let ``Cannot access typed rows when column is not available`` () =
+  let df = frame [ "Open" => Series.ofValues [ 1 .. 10 ] ]
+  let error = try ignore(df.GetRowsAs<IMsftRow>()); "" with e -> e.Message
+  error |> should contain "High"
+
+// ------------------------------------------------------------------------------------------------
 // Constructing frames and getting frame data
 // ------------------------------------------------------------------------------------------------
 

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -171,12 +171,23 @@ type IMsftRow =
   abstract Volume : int
   abstract ``Adj Close`` : decimal
 
+type IMsftFloatSubRow =
+  abstract High : float
+  abstract Low : float
+
 [<Test>]
 let ``Can access rows as a typed series via an interface`` () = 
   let df = msft()
   let rows = df.GetRowsAs<IMsftRow>()
   rows.[DateTime(2000, 10, 10)].Close 
   |> shouldEqual <| df.Rows.[DateTime(2000, 10, 10)].GetAs<decimal>("Close")
+
+[<Test>]
+let ``Can access rows as a typed series via an interface with convertible types`` () = 
+  let df = msft()
+  let rows = df.GetRowsAs<IMsftFloatSubRow>()
+  rows.[DateTime(2000, 10, 10)].High
+  |> shouldEqual <| df.Rows.[DateTime(2000, 10, 10)]?High
 
 type IAandOptB =
   abstract A : float
@@ -190,7 +201,7 @@ let ``Can access missing data via typed rows`` () =
   
 [<Test>]
 let ``Cannot access typed rows when column is not available`` () =
-  let df = frame [ "Open" => Series.ofValues [ 1 .. 10 ] ]
+  let df = frame [ "Open" => Series.ofValues [ 1.0M .. 10.0M ] ]
   let error = try ignore(df.GetRowsAs<IMsftRow>()); "" with e -> e.Message
   error |> should contain "High"
 

--- a/tests/PerformanceTools/Deedle.PerfTest/Deedle.PerfTest.fsproj
+++ b/tests/PerformanceTools/Deedle.PerfTest/Deedle.PerfTest.fsproj
@@ -45,7 +45,7 @@
       <HintPath>..\..\..\bin\Deedle.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Compiler.Service">
-      <HintPath>..\..\..\packages\FSharp.Compiler.Service.0.0.59\lib\net40\FSharp.Compiler.Service.dll</HintPath>
+      <HintPath>..\..\..\packages\FSharp.Compiler.Service.0.0.67\lib\net40\FSharp.Compiler.Service.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Data">
       <HintPath>..\..\..\packages\FSharp.Data.2.0.14\lib\net40\FSharp.Data.dll</HintPath>


### PR DESCRIPTION
Initial implementation that makes it possible to use frame rows in a more type safe way than using just `df.Rows` (without waiting for type provider features in the next version of F#). This lets the user define an interface (by hand) and then fits the columns of the frame to the members of the interface:

```
type IStockRow = 
  abstract Open : float 
  abstract High : float 
  abstract Low : float 
  abstract Close : float 

// Given a frame "msft" which has the 4 columns specified by the interface
// we can get the rows as "Series<DateTime, IStockRow>" using "GetRowsAs"
let rows = msft.GetRowsAs<IStockRow>()
rows.[DateTime(2000, 10, 10)].Close
```

Here are some things & questions to do before checking this in:
- Is the API right? Would this be useful or should the feature look differently?
- If we're including this, it needs more documentation & testing & performance testing...
