### PR TITLE
BigDeedle improvements (replacing columns, sorting, merging ordinally indexed)

### DIFF
--- a/src/Deedle/Indices/VirtualIndex.fs
+++ b/src/Deedle/Indices/VirtualIndex.fs
@@ -106,7 +106,10 @@ and VirtualIndexBuilder() =
     member x.Create<'K when 'K : equality>(keys:ReadOnlyCollection<'K>, ordered:option<bool>) : IIndex<'K> = failwith "Create"
     member x.Aggregate(index, aggregation, vector, selector) = failwith "Aggregate"
     member x.GroupBy(index, keySel, vector) = failwith "GroupBy"
-    member x.OrderIndex(sc) = failwith "OrderIndex"
+    member x.OrderIndex( (index, vector) ) = 
+      if index.IsOrdered then index, vector
+      else failwith "OrderIndex"
+
     member x.Shift(sc, offset) = failwith "Shift"
     member x.Union(sc1, sc2) = failwith "Union"
     member x.Intersect(sc1, sc2) = failwith "Intersect"

--- a/src/Deedle/VirtualFrame.fs
+++ b/src/Deedle/VirtualFrame.fs
@@ -78,7 +78,7 @@ type Virtual() =
 
   static member CreateOrdinalSeries(source) =
     let vector = VirtualVector(source)
-    let index = VirtualOrdinalIndex(0L, source.Length-1L)
+    let index = VirtualOrdinalIndex(Ranges.Create [ 0L, source.Length-1L ])
     Series(index, vector, VirtualVectorBuilder.Instance, VirtualIndexBuilder.Instance)
 
   static member CreateSeries(indexSource:IVirtualVectorSource<_>, valueSource:IVirtualVectorSource<_>) =
@@ -97,7 +97,7 @@ type Virtual() =
       | _ -> invalidArg "sources" "Sources should have the same length!" ) None
     if count = None then invalidArg "sources" "At least one column is required"
     let count = count.Value
-    createFrame (VirtualOrdinalIndex(0L, count-1L)) (Index.ofKeys (ReadOnlyCollection.ofSeq keys)) sources
+    createFrame (VirtualOrdinalIndex(Ranges.Create [0L, count-1L])) (Index.ofKeys (ReadOnlyCollection.ofSeq keys)) sources
 
   static member CreateFrame(indexSource:IVirtualVectorSource<_>, keys, sources:seq<IVirtualVectorSource>) = 
     for sc in sources do 

--- a/tests/Common/FsUnit.fs
+++ b/tests/Common/FsUnit.fs
@@ -88,6 +88,14 @@ type Recorder<'T>() =
 module Extensions =
   // like "should equal", but validates same-type
   let shouldEqual (x: 'a) (y: 'a) = Assert.AreEqual(x, y, sprintf "Expected: %A\nActual: %A" x y)
+  let shouldThrow<'T> f = 
+    try 
+      f() 
+      Assert.Fail("Expected failure, but the operation succeeded.")
+    with e ->
+      if e.GetType() <> typeof<'T> then
+        Assert.Fail(sprintf "Expected exception '%s' but got '%s'." typeof<'T>.Name (e.GetType().Name))
+
   let notEqual x = new NotConstraint(new EqualConstraint(x))
 
   type Range = Within of float * float

--- a/tests/Deedle.Tests/Deedle.Tests.fsproj
+++ b/tests/Deedle.Tests/Deedle.Tests.fsproj
@@ -76,6 +76,7 @@
     <Compile Include="Series.fs" />
     <Compile Include="Frame.fs" />
     <Compile Include="LazySeries.fs" />
+    <Compile Include="Ranges.fs" />
     <Compile Include="VirtualFrame.fs" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/tests/Deedle.Tests/Ranges.fs
+++ b/tests/Deedle.Tests/Ranges.fs
@@ -1,0 +1,109 @@
+﻿#if INTERACTIVE
+#I "../../bin/"
+#load "Deedle.fsx"
+#r "../../packages/NUnit.2.6.3/lib/nunit.framework.dll"
+#r "../../packages/FsCheck.0.9.1.0/lib/net40-Client/FsCheck.dll"
+#load "../Common/FsUnit.fs"
+#else
+module Deedle.Tests.Ranges
+#endif
+
+open System
+open FsUnit
+open NUnit.Framework
+open Deedle
+open Deedle.Indices.Virtual
+
+// ------------------------------------------------------------------------------------------------
+// Ranges
+// ------------------------------------------------------------------------------------------------
+
+let rng = Ranges.Create [| (10L, 19L); (30L, 39L); (50L, 59L) |]
+
+
+[<Test>]
+let ``Merging ranges joins ranges`` () = 
+  let rng1 = Ranges.Create [| (10L, 19L); (30L, 39L); (50L, 59L) |]
+  let rng2 = Ranges.Create [| (20L, 29L); (60L, 69L) |]
+  let res = Ranges.Combine [rng1; rng2]
+  res.Ranges |> shouldEqual [10L,39L; 50L,69L]
+
+
+[<Test>]
+let ``Merging overlapping ranges fails`` () = 
+  let rng1 = Ranges.Create [| (10L, 19L); (30L, 39L); (50L, 59L) |]
+  let rng2 = Ranges.Create [| (20L, 29L); (45L, 69L) |]
+  let rng3 = Ranges.Create [| (19L, 20L) |]
+  (fun _ -> Ranges.Combine [rng1; rng2] |> ignore)
+  |> shouldThrow<System.InvalidOperationException>
+  (fun _ -> Ranges.Combine [rng1; rng2] |> ignore)
+  |> shouldThrow<System.InvalidOperationException>
+
+
+[<Test>]
+let ``Lookup around element inside the range works as expected`` () =
+  rng |> Ranges.lookup 35L Lookup.Greater (fun _ -> true) 
+  |> shouldEqual <| OptionalValue( (36L, 16L) )
+
+  rng |> Ranges.lookup 35L Lookup.Smaller (fun _ -> true)
+  |> shouldEqual <| OptionalValue( (34L, 14L) )
+
+  rng |> Ranges.lookup 35L Lookup.ExactOrGreater (fun a -> Ranges.keyOfAddress a rng > 51L)
+  |> shouldEqual <| OptionalValue( (52L, 22L) )
+
+  rng |> Ranges.lookup 35L Lookup.ExactOrSmaller (fun a -> Ranges.keyOfAddress a rng < 15L)
+  |> shouldEqual <| OptionalValue( (14L, 4L) )
+
+
+[<Test>]
+let ``Lookup using key that is outside of the key range works as expected`` () =
+  rng |> Ranges.lookup 1L Lookup.ExactOrGreater (fun _ -> true)
+  |> shouldEqual <| OptionalValue( (10L, 0L) )
+
+  rng |> Ranges.lookup 1L Lookup.ExactOrSmaller (fun _ -> true)
+  |> shouldEqual OptionalValue.Missing
+
+  rng |> Ranges.lookup 100L Lookup.ExactOrGreater (fun _ -> true)
+  |> shouldEqual OptionalValue.Missing
+
+  rng |> Ranges.lookup 100L Lookup.ExactOrSmaller (fun _ -> true)
+  |> shouldEqual <| OptionalValue( (59L, 29L) )
+
+
+[<Test>]
+let ``Lookup using key that is between two parts of a range works as expected`` () =
+  rng |> Ranges.lookup 25L Lookup.ExactOrGreater (fun _ -> true)
+  |> shouldEqual <| OptionalValue( (30L, 10L) )
+
+  rng |> Ranges.lookup 25L Lookup.ExactOrSmaller (fun _ -> true)
+  |> shouldEqual <| OptionalValue( (19L, 9L) )
+        
+
+[<Test>]
+let ``Size of range works on sample input`` () =
+  rng.Size |> shouldEqual 30L
+
+[<Test>]
+let ``Getting key range works on sample input`` () =
+  Ranges.keyRange rng |> shouldEqual (10L, 59L)
+
+[<Test>]
+let ``Key of address & address of key works on sample inputs`` () =
+  Ranges.keyOfAddress 9L rng |> shouldEqual 19L
+  Ranges.keyOfAddress 10L rng |> shouldEqual 30L
+  Ranges.keyOfAddress 29L rng |> shouldEqual 59L
+  Ranges.addressOfKey 19L rng |> shouldEqual 9L
+  Ranges.addressOfKey 30L rng |> shouldEqual 10L
+  Ranges.addressOfKey 59L rng |> shouldEqual 29L
+
+[<Test>]
+let ``Getting all keys from address returns expected keys`` () =
+  [| for a in 0L .. rng.Size - 1L -> Ranges.keyOfAddress a rng |]
+  |> shouldEqual <| Array.concat [ [| 10L .. 19L |]; [| 30L .. 39L |]; [| 50L .. 59L |] ]
+
+[<Test>]
+let ``Getting all keys using Range.keys returns expected keys`` () =
+  Ranges.keys rng
+  |> shouldEqual <| Array.concat [ [| 10L .. 19L |]; [| 30L .. 39L |]; [| 50L .. 59L |] ]
+
+

--- a/tests/Deedle.Tests/VirtualFrame.fs
+++ b/tests/Deedle.Tests/VirtualFrame.fs
@@ -411,6 +411,13 @@ let ``Can replace column in a frame with a computed column (with the same index)
   f.Format(true).Contains("(string)") |> shouldEqual false
   byDense.Format(true).Contains("(string)") |> shouldEqual true 
 
+[<Test>]
+let ``Sorting a virtual frame that is already sorted does not throw an exception`` () =
+  let s1, s2, f1 = createSimpleFrame()
+  let f2 = f1.SortRowsByKey()
+  f1.RowIndex.IsOrdered |> shouldEqual true
+  f2.RowIndex.IsOrdered |> shouldEqual true
+
 // ------------------------------------------------------------------------------------------------
 
 [<Test>]

--- a/tests/Deedle.Tests/VirtualFrame.fs
+++ b/tests/Deedle.Tests/VirtualFrame.fs
@@ -389,7 +389,7 @@ let ``Can add computed series as a new column to a frame with the same index``()
   set s2.AccessList |> shouldEqual <| set [5000001L]
 
 [<Test>]
-let ``Can index frame by a ordered column computed using series transform`` () =
+let ``Can index frame by an ordered column computed using series transform`` () =
   let s1, s2, f = createTicksFrame()
   f?Times <- f.GetColumn<int64>("Ticks") |> Series.convert fromTicks toTicks
   let byTimes = f |> Frame.indexRowsDateOffs "Times"
@@ -400,6 +400,18 @@ let ``Can index frame by a ordered column computed using series transform`` () =
   prev < date 2010 1 1 |> shouldEqual true
   next > date 2010 1 1 |> shouldEqual true
   ((date 2010 1 1) - prev).Ticks + (next - (date 2010 1 1)).Ticks |> shouldEqual 987654321L
+
+[<Test>]
+let ``Can replace column in a frame with a computed column (with the same index)``() =
+  let s1, s2, f = createNumericFrame()
+  let byDense = f.IndexRows<int>("Dense")
+  let sparseAsString = byDense.GetColumn<string>("Sparse")
+  byDense.ReplaceColumn("Sparse", sparseAsString)
+  // The 'Sparse' column is represented as vector of strings
+  f.Format(true).Contains("(string)") |> shouldEqual false
+  byDense.Format(true).Contains("(string)") |> shouldEqual true 
+
+// ------------------------------------------------------------------------------------------------
 
 [<Test>]
 let ``Can filter virtual frame by a value in a non-index column`` () = 

--- a/tests/Deedle.Tests/VirtualFrame.fs
+++ b/tests/Deedle.Tests/VirtualFrame.fs
@@ -81,7 +81,7 @@ type TrackingSource<'T>(ranges, valueAt:int64 -> 'T, ?asLong:'T -> int64, ?searc
       match res with
       | Choice2Of2 absAddr ->
           if x.IsTracking then x.AccessListCell := absAddr  :: !x.AccessListCell
-          if x.HasMissing && (addr % 3L = 0L) then OptionalValue.Missing
+          if x.HasMissing && (absAddr % 3L = 0L) then OptionalValue.Missing
           else OptionalValue(valueAt absAddr )
       | _ -> failwith "ValueAt: out of range"
 
@@ -196,10 +196,18 @@ let ``Can take, skip etc. without evaluating the series`` () =
   src.AccessList |> Seq.length |> shouldEqual 10
   s1 |> Series.skipLast (10000000-9) |> Stats.sum |> shouldEqual 27.0
   src.AccessList |> Seq.length |> shouldEqual 20
-  s1 |> Series.skip (10000000-9) |> Stats.sum |> shouldEqual 59999973.0
+  s1 |> Series.skip (10000000-9) |> Stats.sum |> shouldEqual 69999967.0
   src.AccessList |> Seq.length |> shouldEqual 30
-  s1 |> Series.takeLast 10 |> Stats.sum |> shouldEqual 59999973.0
+  s1 |> Series.takeLast 10 |> Stats.sum |> shouldEqual 69999967.0
   src.AccessList |> Seq.length |> shouldEqual 40
+
+[<Test>]
+let ``Sliced series contains same values as original series`` () = 
+  let src = TrackingSource.CreateFloats(0L, 10000000L)
+  let s1 = Virtual.CreateOrdinalSeries(src)
+  let s2 = s1.[5123457L .. 5123557L]
+  for i in 5123457L .. 5123557L do
+    s1.TryGet(i) |> shouldEqual <| s2.TryGet(i)
 
 [<Test>]
 let ``Can perform slicing without evaluating the series`` () = 
@@ -208,7 +216,7 @@ let ``Can perform slicing without evaluating the series`` () =
   let s2 = s1.[10000000L-9L ..]
   let s3 = s1.[.. 9L]
 
-  (Stats.sum s2) + (Stats.sum s3) |> shouldEqual 60000000.0
+  (Stats.sum s2) + (Stats.sum s3) |> shouldEqual 69999994.0
   src.AccessList |> Seq.length |> shouldEqual 20
   src.AccessList |> Seq.sum |> shouldEqual 100000000L
 
@@ -361,10 +369,14 @@ let ``Can perform slicing on frame using the Rows property`` () =
   f4.RowIndex.KeyRange
   |> shouldEqual (500000L, 500005L)
 
+  let expected = 
+    [ for i in 500000L .. 500005L -> 
+        f1.GetColumn<string>("S2").TryGet(i) |> OptionalValue.asOption ]
+
   f4.GetColumn<string>("S2") 
-  |> Series.values
+  |> Series.valuesAll
   |> List.ofSeq
-  |> shouldEqual ["ipsum"; "dolor"; "amet"; "consectetur"]
+  |> shouldEqual expected
 
 [<Test>]
 let ``Can access Columns of a virtual frame without evaluating the data`` () =
@@ -417,6 +429,38 @@ let ``Sorting a virtual frame that is already sorted does not throw an exception
   let f2 = f1.SortRowsByKey()
   f1.RowIndex.IsOrdered |> shouldEqual true
   f2.RowIndex.IsOrdered |> shouldEqual true
+
+[<Test>]
+let ``Can merge ordinally-indexed virtual frames`` () = 
+  let s1, s2, f = createSimpleFrame()
+  let fs = f.Rows.[1000000L .. 2000000L]
+  let fe = f.Rows.[5000001L .. 6000001L]
+  let m = fs.Merge(fe)
+
+  for idx, fpart in [ 1000000L,fs; 1500000L,fs; 2000000L,fs; 5000001L,fe; 5500001L,fe; 6000001L,fe ] do
+    m.Rows.[idx] |> shouldEqual f.Rows.[idx]
+    m.Rows.[idx] |> shouldEqual fpart.Rows.[idx]
+  
+[<Test>]
+let ``Can merge ordinally-indexed virtual series of rows`` () = 
+  let s1, s2, f = createSimpleFrame()
+  let fsr = f.Rows.[1000000L .. 2000000L].Rows
+  let fer = f.Rows.[5000001L .. 6000001L].Rows
+  let fmr = fsr.Merge(fer)
+
+  fmr.KeyCount |> shouldEqual (fsr.KeyCount + fer.KeyCount)
+  for idx, fpart in [ 1000000L,fsr; 1500000L,fsr; 2000000L,fsr; 5000001L,fer; 5500001L,fer; 6000001L,fer ] do
+    fmr.[idx] |> shouldEqual f.Rows.[idx]
+    fmr.[idx] |> shouldEqual fpart.[idx]
+
+[<Test>]
+let ``Merging overlapping ordinally-indexed virtual frames fails`` () = 
+  let s1, s2, f = createSimpleFrame()
+  let f0 = f.Rows.[1000000L .. 2000000L]
+  (fun _ -> f0.Merge(f.Rows.[2000000L .. 3000000L]) |> ignore) |> shouldThrow<InvalidOperationException>
+  (fun _ -> f0.Merge(f.Rows.[0900000L .. 1000000L]) |> ignore) |> shouldThrow<InvalidOperationException>
+  (fun _ -> f0.Merge(f.Rows.[0500000L .. 1500000L]) |> ignore) |> shouldThrow<InvalidOperationException>
+  (fun _ -> f0.Merge(f.Rows.[1500000L .. 2500000L]) |> ignore) |> shouldThrow<InvalidOperationException>
 
 // ------------------------------------------------------------------------------------------------
 
@@ -482,7 +526,6 @@ let ``Can merge virtual series of rows indexed by time`` () =
   fmr.[ith 7670246L] |> shouldEqual <| fer.[ith 7670246L]
 
 
-// TODO: Merge ordinally indexed virtual frames
 
 
 


### PR DESCRIPTION
#### Support adding/replacing columns with same-indexed series in BigDeedle

In general, we do not (yet?) support joins on BigDeedle frames and series. But if the newly added (joined) frame or series has the same index, then this should work. But - the index might not even support "GetRange" (which is normally called before testing equality), so we first check if they are the same object (which is a useful optimization anyway).

In the future, it would make sense to have some mechanism for testing which operations are supported (so that we do not try calling "restrict" if it is not supported). But for now, equality test should do.
#### Allow sorting of an already sorted virtual frame/series (#284)

Currently, the abstraction for virtual source does not provide a mechanism for sorting things (and this sounds tricky to do), but if the frame/series is already sorted, we do not need to throw. Better error reporting (or deciding what is not supported) is still TODO.
#### Support merging on ordinally indexed virtual frames & series

To implement this, we need to represent ordinal index not as `int64 * int64` (single range) but as `(int64 * int64) list` (a sequence of non-overlapping ranges). The commit implements this as the `Ranges` module.
There was also a bug in how missing values were generated in the test suite for BigDeedle, so this is fixed (with a few test fixes).
