### PR TITLE
Expose information about column types via frame.ColumnTypes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,3 +73,4 @@
 ### 1.0.7
  * Add typed frame access (frame.GetRowsAs<T>) (#281)
  * BigDeedle improvements (#284, #285)
+ * Expose type information via frame.ColumnTypes

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -457,6 +457,10 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.ColumnKeys = columnIndex.Keys :> seq<_>
 
   /// [category:Accessors and slicing]
+  member frame.ColumnTypes = 
+    seq { for kvp in columnIndex.Mappings -> data.GetValue(kvp.Value).Value.ElementType }
+
+  /// [category:Accessors and slicing]
   member frame.Columns = 
     let newData = data.Select(fun vect -> ObjectSeries<_>(rowIndex, boxVector vect, vectorBuilder, indexBuilder))
     ColumnSeries(Series(columnIndex, newData, vectorBuilder, indexBuilder))

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -159,6 +159,12 @@ let ``Can create frame from IDataReader``() =
   Frame.ReadReader(dt.CreateDataReader())
   |> shouldEqual expected
 
+[<Test>]
+let ``Can get type information about columns`` () =
+  let df = frame [ "A" =?> series [1=>1.0]; "B" =?> series [1=>"hi"] ]
+  df.ColumnTypes |> List.ofSeq
+  |> shouldEqual <| [typeof<float>; typeof<string>]
+
 // ------------------------------------------------------------------------------------------------
 // Typed access to frame rows
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This can easily be accessed from the internal representation, so we can easily expose this...
