### PR TITLE
add lib/net40 search path, make it work with paket

### DIFF
--- a/src/Deedle/Deedle.fsx
+++ b/src/Deedle/Deedle.fsx
@@ -4,6 +4,7 @@
 #I "../bin"
 #I "bin"
 #I "lib"
+#I "lib/net40"
 #I "../packages/Deedle.1.0.6/lib/net40"
 #I "../../packages/Deedle.1.0.6/lib/net40"
 #I "../../../packages/Deedle.1.0.6/lib/net40"


### PR DESCRIPTION
When installing with paket, the Deedle.dll is in lib/net40 relative to Deedle.fsx, so added this search path to make it work.
