### PR TITLE
Expand public fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -111,3 +111,6 @@
 
 ### 1.2.0
  * Update version number for a BigDeedle release
+
+### 1.2.1
+ * Support public fields in Frame.ofRecords

--- a/src/Deedle/Common/AssemblyInfo.fs
+++ b/src/Deedle/Common/AssemblyInfo.fs
@@ -4,9 +4,9 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Deedle")>]
 [<assembly: AssemblyProductAttribute("Deedle")>]
 [<assembly: AssemblyDescriptionAttribute("Easy to use .NET library for data manipulation and scientific programming")>]
-[<assembly: AssemblyVersionAttribute("1.2.0")>]
-[<assembly: AssemblyFileVersionAttribute("1.2.0")>]
+[<assembly: AssemblyVersionAttribute("1.2.1")>]
+[<assembly: AssemblyFileVersionAttribute("1.2.1")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "1.2.0"
+    let [<Literal>] Version = "1.2.1"

--- a/tests/Deedle.CSharp.Tests/Frame.cs
+++ b/tests/Deedle.CSharp.Tests/Frame.cs
@@ -34,6 +34,18 @@ namespace Deedle.CSharp.Tests
   /* ----------------------------------------------------------------------------------
    * Creating frames and getting frame data
    * --------------------------------------------------------------------------------*/
+
+  public class PublicFields
+  {
+    public readonly int A;
+    public readonly string B;
+    public PublicFields(int a, string b)
+    {
+      this.A = a; 
+      this.B = b;
+    }
+  }
+
   public class FrameCreateAccessTests
   {
     [Test]
@@ -42,6 +54,18 @@ namespace Deedle.CSharp.Tests
       var df = Frame.FromRecords(new[] {
         new { A = 1, B = "Test" },
         new { A = 2, B = "Another"}
+      });
+      var firstRow = df.Rows[0].Values.ToArray();
+      Assert.AreEqual(new object[] { 1, "Test" }, firstRow);
+      Assert.AreEqual(new[] { "A", "B" }, df.ColumnKeys.ToArray());
+    }
+
+    [Test]
+    public static void CanCreateFrameFromFields()
+    {
+      var df = Frame.FromRecords(new[] {
+        new PublicFields(1, "Test"),
+        new PublicFields(2, "Another")
       });
       var firstRow = df.Rows[0].Values.ToArray();
       Assert.AreEqual(new object[] { 1, "Test" }, firstRow);


### PR DESCRIPTION
Although this is not the most common scenario, there are some nice libraries that expose data as public (readonly) fields. This PR adds support for reading frame columns from public fields (this does not affect normal .NET classes with _private_ fields).

[This is adding just one commit to the existing PR - so we need to merge that one first]
