### PR TITLE
Make ChunkSizeInto behave according to documentation

### DIFF
--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -957,8 +957,8 @@ module Series =
     series.Aggregate(ChunkSize(bounds), (fun d -> d.Data.Keys |> if (snd bounds).HasFlag(Boundary.AtBeginning) then Seq.last else Seq.head), fun ds -> OptionalValue(f ds))
 
   /// Aggregates the input into a series of adacent chunks using the specified size and boundary behavior and returns
-  /// the produced chunks as a nested series. The key is the last key of the chunk, unless
-  /// boundary behavior is `Boundary.AtEnding` (in which case it is the first key).
+  /// the produced chunks as a nested series. The key is the first key of the chunk, unless
+  /// boundary behavior has `Boundary.AtBeginning` flag (in which case it is the last key).
   ///
   /// ## Parameters
   ///  - `bounds` - Specifies the chunk size and bounary behavior. The boundary behavior

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -939,8 +939,8 @@ module Series =
 
   /// Aggregates the input into a series of adacent chunks using the specified size and boundary behavior and then
   /// applies the provided value selector `f` on each chunk to produce the result
-  /// which is returned as a new series. The key is the last key of the chunk, unless
-  /// boundary behavior is `Boundary.AtEnding` (in which case it is the first key).
+  /// which is returned as a new series. The key is the first key of the chunk, unless
+  /// boundary behavior has `Boundary.AtBeginning` flag (in which case it is the last key).
   ///
   /// ## Parameters
   ///  - `bounds` - Specifies the chunk size and bounary behavior. The boundary behavior
@@ -953,7 +953,8 @@ module Series =
   /// [category:Grouping, windowing and chunking]
   [<CompiledName("ChunkSizeInto")>]
   let inline chunkSizeInto bounds f (series:Series<'K, 'T>) : Series<'K, 'R> =
-    series.Aggregate(ChunkSize(bounds), (fun d -> d.Data.Keys |> if snd bounds = Boundary.AtEnding then Seq.head else Seq.last), fun ds -> OptionalValue(f ds))
+    // Seq.chunkRangesWithBounds checks for boundary.HasFlag(Boundary.AtBeginning) and assumes AtEnding otherwise
+    series.Aggregate(ChunkSize(bounds), (fun d -> d.Data.Keys |> if (snd bounds).HasFlag(Boundary.AtBeginning) then Seq.last else Seq.head), fun ds -> OptionalValue(f ds))
 
   /// Aggregates the input into a series of adacent chunks using the specified size and boundary behavior and returns
   /// the produced chunks as a nested series. The key is the last key of the chunk, unless

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -953,7 +953,7 @@ module Series =
   /// [category:Grouping, windowing and chunking]
   [<CompiledName("ChunkSizeInto")>]
   let inline chunkSizeInto bounds f (series:Series<'K, 'T>) : Series<'K, 'R> =
-    series.Aggregate(ChunkSize(bounds), (fun d -> d.Data.Keys |> Seq.head), fun ds -> OptionalValue(f ds))
+    series.Aggregate(ChunkSize(bounds), (fun d -> d.Data.Keys |> if snd bounds = Boundary.AtEnding then Seq.head else Seq.last), fun ds -> OptionalValue(f ds))
 
   /// Aggregates the input into a series of adacent chunks using the specified size and boundary behavior and returns
   /// the produced chunks as a nested series. The key is the last key of the chunk, unless

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -655,31 +655,16 @@ let b =
   [ DateTime(2013,9,8) => 8.0; // no matching point in a
     DateTime(2013,9,11) => 11.0 ] |> series
 
-let dense =
-  [ 1 => 1.0; 
-    2 => 2.0; 
-    3 => 3.0;
-    4 => 4.0;
-    5 => 5.0; ]
-    |> series
-
-let sparse = 
-  [ 2 => 20.0;
-    4 => 40.0 ] |> series
 
 let lift2 f a b = 
     match a, b with
     | Some x, Some y -> Some(f x y)
-    | None, Some y              -> None
-    | Some x, None              -> None
-    | None, None                -> None
-    | _                 -> failwith "expecting an option"
+    | _              -> None
 
 [<Test>]
 let ``ZipInto correctly zips series with missing values and custom operation``() =
   let res = (a, b) ||> Series.zipInto (fun l r -> (l**2.0) * r)
   res.GetAt(0) |> shouldEqual (99.0)
-
 
 [<Test>]
 let ``ZipAlignInto correctly left-aligns and zips series with nearest smaller option``() =
@@ -688,12 +673,6 @@ let ``ZipAlignInto correctly left-aligns and zips series with nearest smaller op
   res.GetAt(1) |> shouldEqual 32.0
   res.GetAt(2) |> shouldEqual 99.0
   res.GetAt(3) |> shouldEqual (16.0 * 11.0)
-
-  let res = (dense, sparse) ||> Series.zipAlignInto JoinKind.Left Lookup.ExactOrSmaller (lift2 (fun l r -> (l**2.0) * r))
-  res.TryGetAt(0) |> shouldEqual OptionalValue.Missing
-  res.GetAt(1) |> shouldEqual ((2.0**2.0)*20.0)
-  res.GetAt(2) |> shouldEqual ((3.0**2.0)*20.0)
-  res.GetAt(3) |> shouldEqual ((4.0**2.0)*40.0)
 
 [<Test>]
 let ``ZipAlignInto correctly left-aligns and zips series with nearest greater option``() =


### PR DESCRIPTION
Make ChunkSizeInto behave according to the documentation with regards to the key for `Boundary.AtBeginning` is the last key. This is needed for overlapped windows build by ChunkSizeInto with size X and then by moving window on the chunks with widths Y and merging chunks inside each window. The result is overlapped windows with widths `X*Y` and step `X`. With current behavior, the key for each overlapped window is the first key of the last inner chunk, i.e. `_ _ ._` not `_ _ _.` . if we have 3 inner chunks.
