### PR TITLE
Don't reverse columns and rows in the FrameBuilder

### DIFF
--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -703,7 +703,7 @@ module FrameBuilder =
       member x.GetEnumerator() = (x :> seq<_>).GetEnumerator() :> Collections.IEnumerator
     interface seq<KeyValuePair<'C, ISeries<'R>>> with
       member x.GetEnumerator() = 
-        (series |> List.rev |> Seq.map (fun (k, v) -> KeyValuePair(k, v))).GetEnumerator()
+        (series |> Seq.map (fun (k, v) -> KeyValuePair(k, v))).GetEnumerator()
 
   type Rows<'R, 'C when 'C : equality and 'R : equality>() = 
     let mutable series = []
@@ -714,7 +714,7 @@ module FrameBuilder =
       member x.GetEnumerator() = (x :> seq<_>).GetEnumerator() :> Collections.IEnumerator
     interface seq<KeyValuePair<'R, ISeries<'C>>> with
       member x.GetEnumerator() = 
-        (series |> List.rev |> Seq.map (fun (k, v) -> KeyValuePair(k, v))).GetEnumerator()
+        (series |> Seq.map (fun (k, v) -> KeyValuePair(k, v))).GetEnumerator()
 
 /// A type with extension method for `KeyValuePair<'K, 'V>` that makes
 /// it possible to create values using just `KeyValue.Create`.

--- a/tests/Deedle.CSharp.Tests/Frame.cs
+++ b/tests/Deedle.CSharp.Tests/Frame.cs
@@ -82,6 +82,22 @@ namespace Deedle.CSharp.Tests
       var bools = data.OfType<bool>().ToArray();
       Assert.AreEqual(new[] { true, true, true, true }, bools);
     }
+
+    [Test]
+    public static void FramesOrderedAfterBuild()
+    {
+      var builder = new FrameBuilder.Columns<int, string>();
+      builder.Add("column1", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+      builder.Add("column2", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+      builder.Add("column3", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+      builder.Add("column4", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+      var frame = builder.Frame;
+
+      Assert.AreEqual(
+        new[] { "column1", "column2", "column3", "column4" },
+        frame.ColumnKeys.ToArray()
+        );
+    }
   }
 
 	/* ----------------------------------------------------------------------------------


### PR DESCRIPTION
It's very unintuitive that `FrameBuilder` reverses columns and rows before creating the actual frame. I'd expect it to be a thin wrapper around `Frame.ofRows` and `Frame.ofColumns` with the same semantics.
