### PR TITLE
Don't iterate sequence twice in Frame.ofRowsOrdinal

### DIFF
--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -511,7 +511,8 @@ module ``F# Frame extensions`` =
     ///
     /// [category:Frame construction]
     static member ofRowsOrdinal(rows:seq<#Series<'K, 'V>>) = 
-      FrameUtils.fromRows IndexBuilder.Instance VectorBuilder.Instance (Series(rows |> Seq.mapi (fun i _ -> i), rows))
+      let cached = Array.ofSeq rows // caches rows since it's going to be iterated twice
+      FrameUtils.fromRows IndexBuilder.Instance VectorBuilder.Instance (Series(cached |> Seq.mapi (fun i _ -> i), cached))
 
     /// Creates a frame from a sequence of row keys and row series pairs. 
     /// The row series can contain values of any type, but it has to be the same 

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -511,8 +511,7 @@ module ``F# Frame extensions`` =
     ///
     /// [category:Frame construction]
     static member ofRowsOrdinal(rows:seq<#Series<'K, 'V>>) = 
-      let cached = Array.ofSeq rows // caches rows since it's going to be iterated twice
-      FrameUtils.fromRows IndexBuilder.Instance VectorBuilder.Instance (Series(cached |> Seq.mapi (fun i _ -> i), cached))
+      FrameUtils.fromRows IndexBuilder.Instance VectorBuilder.Instance (rows |> Seq.mapi (fun i row -> (i, row)) |> series)
 
     /// Creates a frame from a sequence of row keys and row series pairs. 
     /// The row series can contain values of any type, but it has to be the same 


### PR DESCRIPTION
This addresses issue #356

`Frame.ofRowsOrdinal` iterates the sequence TWICE. This is a big issue
when the implementation of the sequence involves some resources at may
only be able to be iterated once, for example, an IDataReader instance
from a database connection.

While it can be worked around by caching the sequence into an array
before feeding it to Frame.ofRowsOrdinal. But in general, the common
practice of working with seq and IEnumerable is that the function that
takes the sequence (the callee) should take care of caching if it is to
be iterates multiple times.
