### PR TITLE
Bump version and update release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ tests/PerformanceTools/Deedle.PerfTest/bin
 .paket/Paket.Restore.targets
 /.vs/*
 /.fake
+docs/content/RELEASE_NOTES.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,87 +1,61 @@
-### 0.9.0-beta
- * Initial release
+# Release Notes
 
-### 0.9.1-beta
- * First beta version on NuGet
+## 2.0.0-beta01 - 2018-08-04
+* Support for netstandard2.0 [#382](https://github.com/fslaborg/Deedle/pull/382), [#393](https://github.com/fslaborg/Deedle/pull/393) and [#391](https://github.com/fslaborg/Deedle/pull/391)
+* Excel support [#255](https://github.com/fslaborg/Deedle/pull/255) and [#399](https://github.com/fslaborg/Deedle/pull/399)
+* Iterate once in Frame.ofRowsOrdinal [#396](https://github.com/fslaborg/Deedle/pull/396)
+* Fix for some concurrency errors [#394](https://github.com/fslaborg/Deedle/pull/394)
+* Fix bug in Series.hasNot [#361](https://github.com/fslaborg/Deedle/pull/361)
+* Arithmetic operators for decimal series [#351](https://github.com/fslaborg/Deedle/pull/351)
 
-### 0.9.2-beta
- * Update paths in NuGet package
+## 1.2.5
+ * Reading CSV (#332) and DropSparseRows (#333)
+ * Fix where filter in C# (#338)
 
-### 0.9.3-beta
- * Saving CSV, fix series alignment
+## 1.2.4
+ * Fix RowsDense broken by BigDeedle changes (#319)
+ * Make ChunkSizeInto behave according to documentation (#314)
+ * Expand public fields (#313)
+ * Keep order of columns/rows in FrameBuilder (#322)
 
-### 0.9.4-beta
- * Rename and various fixes and additions
+## 1.2.3
+ * Finish cleanup of BigDeedle code with partitioning support
+ * Add BigDeedle partitioning comment to design notes
+ * Update documentation tools dependencies
 
-### 0.9.5-beta
- * Update documentation and tools, adding functionality
+## 1.2.2
+ * BigDeedle: Materialize series on grouping and other operations
+ * BigDeedle: Support resampling without materializing series
+ * Better handling of materialization via addressing schemes
+ * Refactoring and cleanup of BigDeedle code
+ * Fix bugs in ordinal virtual index
+ * SelectOptional and SelectValues can be performed lazilly
 
-### 0.9.6-beta
- * Load script automatically references F# data (for CSV reading)
+## 1.2.1
+ * Support public fields in Frame.ofRecords
 
-### 0.9.7-beta
- * Fix series formatting
+## 1.2.0
+ * Update version number for a BigDeedle release
 
-### 0.9.8-beta
- * Add reflection-based frame expansion
+## 1.1.5
+ * Aggregate bug fixes from previous beta releases
+ * Provide virtual index and virtual vector (aka BigDeedle)
+ * Compare indices using lazy sequences (to support BigDeedle)
 
-### 0.9.9-beta
- * Performance improvements, API additions, experimental R plugin
+## 1.1.4-beta
+ * Allow creation of empty ranges
+ * Support more operations on virtualized sources
+ * Fix handling of missing values in virtual Series.map
 
-### 0.9.10-beta
- * Support time series in the R plugin
+## 1.1.3-beta
+ * Introduce generic `Ranges<T>` type to simplify working with ranges
+   (mainly useful for custom BigDeedle implementations)
 
-### 0.9.11-beta
- * Fix bug when creating empty data frame
+## 1.1.2-beta
+ * Abstract handling of addresses (mainly for BigDeedle)
+ * Avoid accessing series Length in series and frame printing
 
-### 0.9.12
- * Improved C# compatibility, added C# documentation
-
-### 1.0.0-alpha1
- * API redesign, performance improvements and new features
-
-### 1.0.0-alpha2
- * Update to a new pre-release of RProvider
-
-### 1.0.0
- * Performance and API design improvements
-
-### 1.0.1
- * Update RProvider references
-
-### 1.0.2
- * Operations GetAs, TryAs (ObjectSeries), GetColumns, GetRows, GetAllValues, ColumnApply (Frame)
-   and filling of missing values uses "safe" conversion (allows conversion to bigger numeric type)
- * Avoid boxing when filling missing values (#222)
- * Fix documentation bugs (#221, #226) and update formatters from FsLab
-
-### 1.0.3
- * Added Stats.min and Stats.max for frame
-
-### 1.0.4
- * Merge BigDeedle pull request (#247), add merging on big frames
- * Fix PivotTable (#248) and CSV writing (#242)
- * Update R provider reference to 1.0.16 (support shadow copy in F# 3.2.1)
-
-### 1.0.5
- * Update R provider reference to 1.0.17
-
-### 1.0.6
- * Fix bugs related to frame with no columns (#272)
- * Remove FSharp.Core dependency from BigDeedle public API
-
-### 1.0.7
- * Add typed frame access (frame.GetRowsAs<T>) (#281)
- * BigDeedle improvements (#284, #285)
- * Expose type information via frame.ColumnTypes (#286)
- * Simplify load script (#292)
- * Remove F# Data dependency & use Paket (#288, #293)
- * Update depndencies (F# Formatting 2.6.2 and RProvider 1.1.8)
-
-### 1.1.0-beta
- * Enable materializing delayed series into a virtual series
-
-### 1.1.1-beta
+## 1.1.1-beta
  * Allow specifying custom NA values (#231)
  * Documentation improvements and add F# Frame extension docs (#254)
  * Use 100 rows for inference by default in C# and fix docs (#271)
@@ -91,49 +65,85 @@
  * Change Stats.sum to return NaN for empty series (#259)
  * Change C#-version of ReadCsv to accept inferTypes param (#270)
 
-### 1.1.2-beta
- * Abstract handling of addresses (mainly for BigDeedle)
- * Avoid accessing series Length in series and frame printing
+## 1.1.0-beta
+ * Enable materializing delayed series into a virtual series
 
-### 1.1.3-beta
- * Introduce generic `Ranges<T>` type to simplify working with ranges
-   (mainly useful for custom BigDeedle implementations)
+## 1.0.7
+ * Add typed frame access (frame.GetRowsAs<T>) (#281)
+ * BigDeedle improvements (#284, #285)
+ * Expose type information via frame.ColumnTypes (#286)
+ * Simplify load script (#292)
+ * Remove F# Data dependency & use Paket (#288, #293)
+ * Update depndencies (F# Formatting 2.6.2 and RProvider 1.1.8)
 
-### 1.1.4-beta
- * Allow creation of empty ranges
- * Support more operations on virtualized sources
- * Fix handling of missing values in virtual Series.map
+## 1.0.6
+ * Fix bugs related to frame with no columns (#272)
+ * Remove FSharp.Core dependency from BigDeedle public API
 
-### 1.1.5
- * Aggregate bug fixes from previous beta releases
- * Provide virtual index and virtual vector (aka BigDeedle)
- * Compare indices using lazy sequences (to support BigDeedle)
+## 1.0.5
+ * Update R provider reference to 1.0.17
 
-### 1.2.0
- * Update version number for a BigDeedle release
+## 1.0.4
+ * Merge BigDeedle pull request (#247), add merging on big frames
+ * Fix PivotTable (#248) and CSV writing (#242)
+ * Update R provider reference to 1.0.16 (support shadow copy in F# 3.2.1)
 
-### 1.2.1
- * Support public fields in Frame.ofRecords
+## 1.0.3
+ * Added Stats.min and Stats.max for frame
 
-### 1.2.2
- * BigDeedle: Materialize series on grouping and other operations
- * BigDeedle: Support resampling without materializing series
- * Better handling of materialization via addressing schemes
- * Refactoring and cleanup of BigDeedle code
- * Fix bugs in ordinal virtual index
- * SelectOptional and SelectValues can be performed lazilly
+## 1.0.2
+ * Operations GetAs, TryAs (ObjectSeries), GetColumns, GetRows, GetAllValues, ColumnApply (Frame)
+   and filling of missing values uses "safe" conversion (allows conversion to bigger numeric type)
+ * Avoid boxing when filling missing values (#222)
+ * Fix documentation bugs (#221, #226) and update formatters from FsLab
 
-### 1.2.3
- * Finish cleanup of BigDeedle code with partitioning support
- * Add BigDeedle partitioning comment to design notes
- * Update documentation tools dependencies
+## 1.0.1
+ * Update RProvider references
 
-### 1.2.4
- * Fix RowsDense broken by BigDeedle changes (#319)
- * Make ChunkSizeInto behave according to documentation (#314)
- * Expand public fields (#313)
- * Keep order of columns/rows in FrameBuilder (#322)
- 
-### 1.2.5
- * Reading CSV (#332) and DropSparseRows (#333)
- * Fix where filter in C# (#338)
+## 1.0.0
+ * Performance and API design improvements
+
+## 1.0.0-alpha1
+ * API redesign, performance improvements and new features
+
+## 1.0.0-alpha2
+ * Update to a new pre-release of RProvider
+
+## 0.9.12
+ * Improved C# compatibility, added C# documentation
+
+## 0.9.11-beta
+ * Fix bug when creating empty data frame
+
+## 0.9.10-beta
+ * Support time series in the R plugin
+
+## 0.9.9-beta
+ * Performance improvements, API additions, experimental R plugin
+
+## 0.9.8-beta
+ * Add reflection-based frame expansion
+
+## 0.9.7-beta
+ * Fix series formatting
+
+## 0.9.6-beta
+ * Load script automatically references F# data (for CSV reading)
+
+## 0.9.5-beta
+ * Update documentation and tools, adding functionality
+
+## 0.9.4-beta
+ * Rename and various fixes and additions
+
+## 0.9.3-beta
+ * Saving CSV, fix series alignment
+
+## 0.9.2-beta
+ * Update paths in NuGet package
+
+## 0.9.1-beta
+ * First beta version on NuGet
+
+## 0.9.0-beta
+ * Initial release

--- a/build.fsx
+++ b/build.fsx
@@ -89,7 +89,8 @@ Target "AssemblyInfo" (fun _ ->
         Attribute.Product project
         Attribute.Description summary
         Attribute.Version release.AssemblyVersion
-        Attribute.FileVersion release.AssemblyVersion] 
+        Attribute.InformationalVersion release.NugetVersion
+        Attribute.FileVersion release.NugetVersion] 
 )
 
 // --------------------------------------------------------------------------------------

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -92,6 +92,7 @@ let buildReference () =
 
 // Build documentation from `fsx` and `md` files in `docs/content`
 let buildDocumentation () =
+  CopyFile content (__SOURCE_DIRECTORY__ @@ "../../RELEASE_NOTES.md")
   let fsiEvaluator = Formatters.createFsiEvaluator root output "#.####"
   let subdirs = Directory.EnumerateDirectories(content, "*", SearchOption.AllDirectories)
   for dir in Seq.append [content] subdirs do

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -50,7 +50,7 @@
             <li><a href="@Properties["project-nuget"]">Get Library via NuGet</a></li>
             <li><a href="@Properties["project-github"]">Source Code on GitHub</a></li>
             <li><a href="@Properties["project-github"]/blob/master/LICENSE.md">License (BSD)</a></li>
-            <li><a href="@Properties["project-github"]/blob/master/RELEASE_NOTES.md">Release notes</a></li>
+            <li><a href="@Root/RELEASE_NOTES.html">Release notes</a></li>
             <li><a href="@Root/design.html">Design notes</a></li>
             <li><a href="http://stackoverflow.com/questions/tagged/deedle">Ask a question!</a></li>
             

--- a/src/Deedle/Common/AssemblyInfo.fs
+++ b/src/Deedle/Common/AssemblyInfo.fs
@@ -5,13 +5,15 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("Deedle")>]
 [<assembly: AssemblyProductAttribute("Deedle")>]
 [<assembly: AssemblyDescriptionAttribute("Easy to use .NET library for data manipulation and scientific programming")>]
-[<assembly: AssemblyVersionAttribute("1.2.5")>]
-[<assembly: AssemblyFileVersionAttribute("1.2.5")>]
+[<assembly: AssemblyVersionAttribute("2.0.0")>]
+[<assembly: AssemblyInformationalVersionAttribute("2.0.0-beta01")>]
+[<assembly: AssemblyFileVersionAttribute("2.0.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "Deedle"
     let [<Literal>] AssemblyProduct = "Deedle"
     let [<Literal>] AssemblyDescription = "Easy to use .NET library for data manipulation and scientific programming"
-    let [<Literal>] AssemblyVersion = "1.2.5"
-    let [<Literal>] AssemblyFileVersion = "1.2.5"
+    let [<Literal>] AssemblyVersion = "2.0.0"
+    let [<Literal>] AssemblyInformationalVersion = "2.0.0-beta01"
+    let [<Literal>] AssemblyFileVersion = "2.0.0"


### PR DESCRIPTION
* Changed the version to 2.0.0-beta01. Not sure what the new version should be, but that sounded reasonable. 
* I looked through the latest PRs and updated the release notes with those.
* Reversed the order of release notes. The latest version is now listed first. I think its easier to read that way. 
* Added the release notes as a proper html page instead of linking to this repository.