### PR TITLE
Add Frame.dropSparseRowsBy

### DIFF
--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1328,6 +1328,25 @@ module Frame =
       frame.IndexBuilder.Search( (frame.RowIndex, Vectors.Return 0), hasAllFlagVector, true)
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme cmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
+    
+  /// Creates a new data frame that contains only those rows of the original 
+  /// data frame for which the given column has a value (i.e., is not missing).
+  /// The resulting data frame has the same number of columns, but may have 
+  /// fewer rows (or no rows at all).
+  /// 
+  /// [category:Missing values]
+  [<CompiledName("DropSparseRowsBy")>]
+  let dropSparseRowsBy colKey (frame:Frame<'R, 'C>) = 
+    // Create a combined vector that has 'true' for rows which have some values
+    let hasAllFlagVector = 
+        frame.GetColumn(colKey).Vector.DataSequence
+        |> Seq.map (fun opt -> opt.HasValue)
+        |> Vector.ofValues
+    // Collect all rows that have at least some values
+    let newRowIndex, cmd = 
+        frame.IndexBuilder.Search( (frame.RowIndex, Vectors.Return 0), hasAllFlagVector, true)
+    let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme cmd)
+    Frame<_, _>(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
   /// Creates a new data frame that contains only those columns of the original 
   /// data frame that are _dense_, meaning that they have a value for each row.

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -1415,6 +1415,30 @@ let ``Dropping sparse rows works on frame with missing in one column``() =
   actual |> shouldEqual expected
 
 [<Test>]
+let ``Dropping sparse rows by column works on sample frame``() =
+  let frame =
+    Frame.ofValues [ (1,"foo","a"); (1,"bar","b"); (1,"foobar","g");
+                     (2,"foo","c");
+                     (3,"foo","d"); (3,"bar","e");
+                     (4,"bar","f") ]
+  let expectedFoo =
+      Frame.ofValues [ (1,"foo","a"); (1,"bar","b"); (1,"foobar","g");
+                       (2,"foo","c");
+                       (3,"foo","d"); (3,"bar","e");
+                     ]
+  let expectedBar =
+      Frame.ofValues [ (1,"foo","a"); (1,"bar","b"); (1,"foobar","g");
+                       (3,"foo","d"); (3,"bar","e");
+                       (4,"bar","f") ]
+  let expectedFoobar =
+      Frame.ofValues [ (1,"foo","a"); (1,"bar","b"); (1,"foobar","g") ]
+
+  frame |> Frame.dropSparseRowsBy "foo" |> shouldEqual expectedFoo
+  frame |> Frame.dropSparseRowsBy "bar" |> shouldEqual expectedBar
+  frame |> Frame.dropSparseRowsBy "foobar" |> shouldEqual expectedFoobar
+
+
+[<Test>]
 let ``Dropping sparse columns preserves columns``() = 
   let emptyFrame = 
     frame [ for k in ["A"; "B"; "C"] ->


### PR DESCRIPTION
Adds `dropSparesRowsBy column` functionality. This should make it easier for users to deal with missing values in specific columns, e.g., before grouping by those columns (as suggested by @tpetricek in #380).