### PR TITLE
Avoid iterating seq multiple times in Frame.ofRecords

### DIFF
--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -216,10 +216,11 @@ module internal Reflection =
       [| for _, (input, body) in convertors ->
            let cast = Expression.Convert(body, typeof<IVector>)
            Expression.Lambda<Func<seq<'T>, IVector>>(cast, input).Compile() |]
+    let data = data |> Array.ofSeq
     let frameData =
       [| for convFunc in convertors -> convFunc.Invoke(data) |]
       |> vectorBuilder.Create
-    Frame<int, string>(Index.ofKeys [0 .. (Seq.length data) - 1], colIndex, frameData, IndexBuilder.Instance, VectorBuilder.Instance)
+    Frame<int, string>(Index.ofKeys [0 .. data.Length - 1], colIndex, frameData, IndexBuilder.Instance, VectorBuilder.Instance)
 
   /// Helper that makes it possible to call convertRecordSequence on untyped enumerable
   type ConvertRecordHelper =

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -306,6 +306,18 @@ let ``Can read simple sequence of records using a specified column as index`` ()
   df.RowKeys |> Seq.head |> shouldEqual rows.[0].Date
 
 [<Test>]  
+let ``Can read simple sequence of records deterministically `` () =
+  let mutable n = 0
+  let values = 
+    seq { 
+      yield n, n
+      n <- n + 1
+      yield n, n
+      n <- n + 1 }
+  let expected = [|0, 0; 1, 1|] |> Frame.ofRecords
+  values |> Frame.ofRecords |> shouldEqual expected
+
+[<Test>]  
 let ``Can expand properties of a simple record sequence`` () =
   let df = frame [ "MSFT" => Series.ofValues (typedRows ()) ]
   let exp1 = df |> Frame.expandAllCols 1 


### PR DESCRIPTION
I would like to address the issue https://github.com/fslaborg/Deedle/issues/364

I simply converted seq into array to avoid Frame.ofRecords iterating seq multiple times. It avoids creating frame unintended by user. I also added a test cases using the sample in issue 364.

@tpetricek Are you ok with this temporary allocation?