### PR TITLE
Add Frame.concat

### DIFF
--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -811,6 +811,48 @@ let ``AppendN works on non-primitives`` () =
   df2.RowCount |> shouldEqual df.RowCount
 
 // ------------------------------------------------------------------------------------------------
+// Operations - concat
+// ------------------------------------------------------------------------------------------------
+
+[<Test>]
+let ``Can concat frames with identical columns`` () = 
+  let df1 = Frame.ofColumns [ "A" => series [ for i in 1 .. 5 -> i, i ];
+                              "B" => series [ for i in 1 .. 5 -> i, (i + 5) ]]
+  let df2 = Frame.ofColumns [ "A" => series [ for i in 6 .. 10 -> i, i ];
+                              "B" => series [ for i in 6 .. 10 -> i, (i + 5) ]]
+  let expected = Frame.ofColumns [ "A" => series [ for i in 1 .. 10 -> i, i ];
+                                   "B" => series [ for i in 1 .. 10 -> i, (i + 5) ]]
+  let actual = Frame.concat [df1; df2]                             
+  actual |> shouldEqual expected
+
+[<Test>]
+let ``Concat works on overlapping frames with missing values`` () =
+  let df1 = Frame.ofColumns [ "A" => series [ for i in 1 .. 5 -> i, i ];
+                            "B" => series [ for i in 2 .. 5 -> i, (i + 5) ]]
+  let df2 = Frame.ofColumns [ "A" => series [ for i in 6 .. 9 -> i, i ];
+                            "B" => series [ for i in 6 .. 10 -> i, (i + 5) ]]
+  let expected = Frame.ofColumns [ "A" => series [ for i in 1 .. 9 -> i, i ];
+                            "B" => series [ for i in 2 .. 10 -> i, (i + 5) ]]
+  let actual = Frame.concat [df1; df2]                        
+  actual |> shouldEqual expected
+
+[<Test>]
+let ``Concat fails on overlapping row keys`` () =
+  let df1 = Frame.ofColumns [ "A" => series [ for i in 1 .. 5 -> i, i ];
+                            "B" => series [ for i in 2 .. 5 -> i, (i + 5) ]]
+  let df2 = Frame.ofColumns [ "A" => series [ for i in 6 .. 9 -> i, i ];
+                            "B" => series [ for i in 6 .. 10 -> i, (i + 5) ]]
+  (fun () -> Frame.concat [df1; df2] |> ignore) |> should throw (typeof<System.Exception>)
+
+[<Test>]
+let ``Concat fails for non-identical columns`` () = 
+  let df1 = Frame.ofColumns [ "A" => series [ for i in 1 .. 5 -> i, i ];
+                            "B" => series [ for i in 2 .. 5 -> i, (i + 5) ]]
+  let df2 = Frame.ofColumns [ "A" => series [ for i in 6 .. 9 -> i, i ];
+                            "B" => series [ for i in 6 .. 10 -> i, (i + 5) ]]
+  (fun () -> Frame.concat [df1; df2] |> ignore) |> should throw (typeof<System.Exception>)
+
+// ------------------------------------------------------------------------------------------------
 // Operations - zip
 // ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds a concatenation function appending the columns of multiple frames. This is essentially a special case of `merge`, however much more efficient if the column keys of all input frames are identical.

I wrote (a variant of) this function when trying to nest/unnest large frames, which would never finish. `unnest` uses `mergeAll`, which (at least when used with a frame created by `nest` that has identical column keys) is much to general and possibly much too slow. Down the line I would thus suggest to use the `concat` function for `unnest`.

I will add unit tests for `concat` in the next couple of days.