### PR TITLE
Breaking change of Stats.min and Stats.max

### DIFF
--- a/src/Deedle/SeriesStatsExtensions.fs
+++ b/src/Deedle/SeriesStatsExtensions.fs
@@ -37,12 +37,12 @@ type SeriesStatsExtensions =
   /// Returns the smallest of all elements of the series.
   /// [category:Statistics]
   [<Extension>]
-  static member inline Min(series:Series<'K, 'V>) = Stats.min series |> Option.get
+  static member inline Min(series:Series<'K, 'V>) = Stats.tryMin series |> Option.get
 
   /// Returns the greatest of all elements of the series.
   /// [category:Statistics]
   [<Extension>]
-  static member inline Max(series:Series<'K, 'V>) = Stats.max series |> Option.get
+  static member inline Max(series:Series<'K, 'V>) = Stats.tryMax series |> Option.get
 
   /// Returns the mean of the elements of the series.
   /// [category:Statistics]
@@ -145,7 +145,7 @@ type SeriesStatsExtensions =
   /// [category:Statistics]
   [<Extension>]
   static member inline MinLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) = 
-    Series.applyLevelOptional groupSelector.Invoke Stats.min series
+    Series.applyLevelOptional groupSelector.Invoke Stats.tryMin series
 
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `groupSelector` and then returns a new series containing
@@ -160,7 +160,7 @@ type SeriesStatsExtensions =
   /// [category:Statistics]
   [<Extension>]
   static member inline MaxLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) = 
-    Series.applyLevelOptional groupSelector.Invoke Stats.max series
+    Series.applyLevelOptional groupSelector.Invoke Stats.tryMax series
 
   /// Linearly interpolates an ordered series given a new sequence of keys. 
   ///

--- a/src/Deedle/Stats.fs
+++ b/src/Deedle/Stats.fs
@@ -655,26 +655,16 @@ type Stats =
   /// Returns the series of main statistic values of the series.
   ///
   /// [category:Series statistics]
-  static member inline describe (series:Series<'K, 'V>) = 
-    match series with
-    | :? Series<_, float> as floatSeries -> 
-       [|
-        ("min", Stats.tryMin floatSeries);
-        ("max", Stats.tryMax floatSeries);
-        ("mean", Some(Stats.mean floatSeries));
-        ("std", Some(Stats.stdDev floatSeries));
-        ("unique", Some(float(Stats.uniqueCount floatSeries)));
-        |] |> Array.toSeq |> Series.ofObservations
-    | _ -> 
-      [|
-        ("min", None);
-        ("max", None);
-        ("mean", None);
-        ("std", None);
-        ("unique", Some(float(Stats.uniqueCount series)));
-      |] |> Array.toSeq |> Series.ofObservations
-
-
+  static member inline describe (series:Series<'K, 'V>) =
+    [
+      "min", Stats.min series
+      "max", Stats.max series
+      "mean", Stats.mean series
+      "std", Stats.stdDev series
+      "unique", Stats.uniqueCount series |> float
+    ]
+    |> Series.ofObservations
+   
   // ------------------------------------------------------------------------------------
   // Series interpolation
   // ------------------------------------------------------------------------------------

--- a/src/Deedle/Stats.fs
+++ b/src/Deedle/Stats.fs
@@ -587,13 +587,37 @@ type Stats =
   /// When the series contains no values, the result is `None`.
   ///
   /// [category:Series statistics]
-  static member inline min (series:Series<'K, 'V>) = trySeriesExtreme min series
+  static member inline tryMin (series:Series<'K, 'V>) =
+    trySeriesExtreme min series
 
   /// Returns the maximum of the values in a series. The result is an option value.
   /// When the series contains no values, the result is `None`.
   ///
   /// [category:Series statistics]
-  static member inline max (series:Series<'K, 'V>) = trySeriesExtreme max series
+  static member inline tryMax (series:Series<'K, 'V>) =
+    trySeriesExtreme max series
+
+  /// Returns the minimum of the values in a series. The result is an float value.
+  /// When the series contains no values, the result is NaN.
+  ///
+  /// [category:Series statistics]
+  static member inline min (series:Series<'K, 'V>) =
+    let values = series.Values
+    if values |> Seq.isEmpty then
+      nan
+    else
+      values |> Seq.map float |> Seq.min
+
+  /// Returns the maximum of the values in a series. The result is an float value.
+  /// When the series contains no values, the result is NaN.
+  ///
+  /// [category:Series statistics]
+  static member inline max (series:Series<'K, 'V>) =
+    let values = series.Values
+    if values |> Seq.isEmpty then
+      nan
+    else
+      values |> Seq.map float |> Seq.max
 
   /// Returns the number of unique values in a series.
   static member inline uniqueCount (series:Series<'K, 'V>) =
@@ -635,8 +659,8 @@ type Stats =
     match series with
     | :? Series<_, float> as floatSeries -> 
        [|
-        ("min", Stats.min floatSeries);
-        ("max", Stats.max floatSeries);
+        ("min", Stats.tryMin floatSeries);
+        ("max", Stats.tryMax floatSeries);
         ("mean", Some(Stats.mean floatSeries));
         ("std", Some(Stats.stdDev floatSeries));
         ("unique", Some(float(Stats.uniqueCount floatSeries)));
@@ -761,9 +785,7 @@ type Stats =
   ///
   /// [category:Frame statistics]
   static member min (frame:Frame<'R, 'C>) = 
-    frame.GetColumns<float>() |> Series.map (fun _ s -> 
-      let res = Stats.min s 
-      defaultArg res nan )  
+    frame.GetColumns<float>() |> Series.map (fun _ s -> Stats.min s)  
 
   /// For each numerical column, returns the maximal values as a series.
   /// The function skips over missing and `NaN` values. When there are no values,
@@ -771,9 +793,7 @@ type Stats =
   ///
   /// [category:Frame statistics]
   static member max (frame:Frame<'R, 'C>) = 
-    frame.GetColumns<float>() |> Series.map (fun _ s -> 
-      let res = Stats.max s 
-      defaultArg res nan )  
+    frame.GetColumns<float>() |> Series.map (fun _ s -> Stats.max s)  
 
   /// For each column, returns the number of unique values.
   static member uniqueCount (frame: Frame<'R, 'C>) =

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -89,8 +89,8 @@ let ``describe works`` ()=
   let s = Series.ofValues [ 0.0; 1.0; 2.0; 3.0; 4.0 ]
   let desc = Stats.describe s
 
-  desc.Get("min")  |> should equal (Stats.min s)
-  desc.Get("max")  |> should equal (Stats.max s)
+  desc.Get("min")  |> should equal (Stats.tryMin s)
+  desc.Get("max")  |> should equal (Stats.tryMax s)
   desc.Get("mean") |> should equal (Some(Stats.mean s))
   desc.Get("unique") |> should equal (Some(float(Stats.uniqueCount s)))
 

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -89,12 +89,11 @@ let ``describe works`` ()=
   let s = Series.ofValues [ 0.0; 1.0; 2.0; 3.0; 4.0 ]
   let desc = Stats.describe s
 
-  desc.Get("min")  |> should equal (Stats.tryMin s)
-  desc.Get("max")  |> should equal (Stats.tryMax s)
-  desc.Get("mean") |> should equal (Some(Stats.mean s))
-  desc.Get("unique") |> should equal (Some(float(Stats.uniqueCount s)))
-
-  (Option.get (desc.Get("std")))  |> should beWithin  ((Stats.stdDev s) +/- 1e-9)
+  desc.Get("min")  |> should equal (Stats.min s)
+  desc.Get("max")  |> should equal (Stats.max s)
+  desc.Get("mean") |> should equal (Stats.mean s)
+  desc.Get("unique") |> should equal (Stats.uniqueCount s |> float)
+  desc.Get("std")  |> should beWithin  ((Stats.stdDev s) +/- 1e-9)
 
 [<Test>]
 let ``Moving skew works`` () =


### PR DESCRIPTION
To address issue https://github.com/fslaborg/Deedle/issues/419
1. Renamed original min/max functions to tryMin/tryMax
2. Added new min/max functions that output Double.NaN. I figure all other inline functions essentially converted integer to float in output. It's ok to have Stats.min and Stats.max output float as well. User can convert it back to int if they really want to stick to the original type. This design is still easier to use than the original optional values.