### PR TITLE
Check lengths of keys and values.

### DIFF
--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -54,8 +54,12 @@ and
       vectorBuilder : IVectorBuilder, indexBuilder : IIndexBuilder ) =
   
   // Check that the addressing schemes match
-  do if index.AddressingScheme <> vector.AddressingScheme then
+  do
+    if index.AddressingScheme <> vector.AddressingScheme then
        invalidOp "Index and vector of a series should share addressing scheme!"
+    if index :? Deedle.Indices.Linear.LinearIndex<'K> then
+      if index.KeyCount <> vector.Length then
+        invalidOp "Index and vector of a series should have the same length!"
 
   /// Value to hold the number of elements (so that we do not recalculate this all the time)
   /// (This is calculated on first access; we do not use Lazy<T> to avoid allocations)

--- a/tests/Deedle.Tests/VirtualFrame.fs
+++ b/tests/Deedle.Tests/VirtualFrame.fs
@@ -405,18 +405,20 @@ let ``Can access Columns of a virtual frame without evaluating the data`` () =
   s1.AccessList |> shouldEqual [10L]
   s2.AccessList |> shouldEqual []
 
-[<Test>]
-let ``Can add computed series as a new column to a frame with the same index``() = 
-  let s1, s2, f = createNumericFrame()
-  let times = f |> Frame.mapRows (fun _ row -> 
-    let t = row.GetAs<int64>("Dense")
-    DateTimeOffset(DateTime(2000,1,1).AddTicks(t * 1233456789L), TimeSpan.FromHours(1.0)) )
-  f.AddColumn("Times", times)
-  f.GetRow<obj>(5000001L).["Dense"] |> shouldEqual (box 5000001L)
-  f.GetRow<obj>(5000001L).TryGet("Sparse") |> shouldEqual OptionalValue.Missing
-  (f.GetRow<obj>(5000001L).["Times"] |> unbox<DateTimeOffset>).Year |> shouldEqual 2019
-  set s1.AccessList |> shouldEqual <| set [5000001L]
-  set s2.AccessList |> shouldEqual <| set [5000001L]
+// TODO: Fix the following test case which was commented out for fixing issue 330
+//
+//[<Test>]
+//let ``Can add computed series as a new column to a frame with the same index``() = 
+//  let s1, s2, f = createNumericFrame()
+//  let times = f |> Frame.mapRows (fun _ row -> 
+//    let t = row.GetAs<int64>("Dense")
+//    DateTimeOffset(DateTime(2000,1,1).AddTicks(t * 1233456789L), TimeSpan.FromHours(1.0)) )
+//  f.AddColumn("Times", times)
+//  f.GetRow<obj>(5000001L).["Dense"] |> shouldEqual (box 5000001L)
+//  f.GetRow<obj>(5000001L).TryGet("Sparse") |> shouldEqual OptionalValue.Missing
+//  (f.GetRow<obj>(5000001L).["Times"] |> unbox<DateTimeOffset>).Year |> shouldEqual 2019
+//  set s1.AccessList |> shouldEqual <| set [5000001L]
+//  set s2.AccessList |> shouldEqual <| set [5000001L]
 
 [<Test>]
 let ``Can index frame by an ordered column computed using series transform`` () =


### PR DESCRIPTION
To fix issue #330

As discussed, the following test case on virtual frame is commented out for further investigation
```fsharp
[<Test>]
let ``Can add computed series as a new column to a frame with the same index``() = 
  let s1, s2, f = createNumericFrame()
  let times = f |> Frame.mapRows (fun _ row -> 
    let t = row.GetAs<int64>("Dense")
    DateTimeOffset(DateTime(2000,1,1).AddTicks(t * 1233456789L), TimeSpan.FromHours(1.0)) )
  f.AddColumn("Times", times)
  f.GetRow<obj>(5000001L).["Dense"] |> shouldEqual (box 5000001L)
  f.GetRow<obj>(5000001L).TryGet("Sparse") |> shouldEqual OptionalValue.Missing
  (f.GetRow<obj>(5000001L).["Times"] |> unbox<DateTimeOffset>).Year |> shouldEqual 2019
  set s1.AccessList |> shouldEqual <| set [5000001L]
  set s2.AccessList |> shouldEqual <| set [5000001L]
```