### PR TITLE
Handle missing column keys in case when inferTypes = false

### DIFF
--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -452,7 +452,14 @@ module internal FrameUtils =
           let headers =
             match data.Headers with
             | None -> [| for i in 1 .. data.NumberOfColumns -> sprintf "Column%d" i |]
-            | Some headers -> headers
+            | Some headers ->
+                headers
+                |> Array.mapi
+                    (fun i header ->
+                        if String.IsNullOrWhiteSpace header
+                        then sprintf "Column%d" (i + 1)
+                        else header)
+
           headers |> Array.map (fun c -> PrimitiveInferedProperty.Create(c, typeof<string>, true, None))
 
     // We create `IResizeVector` instance for each of the columns (with appropriate parsing function)

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -107,6 +107,54 @@ let ``Can read CSV file that contains custom missing value formats`` () =
   actual.Rows.[0].TryGetAs<float>("Second").HasValue |> shouldEqual false
 
 [<Test>]
+let ``Can read CSV file without headers when inferTypes = true`` () =
+  let csv =
+    "1.0,2.0,3.0\n" +
+    "4.0,5.0,6.0\n" +
+    "7.0,8.0,9.0"
+  use reader = new System.IO.StringReader(csv)
+  let actual = Frame.ReadCsv(reader,hasHeaders=false,inferTypes=true) 
+  actual.ColumnKeys
+  |> Seq.toArray
+  |> shouldEqual [| "Column1"; "Column2"; "Column3" |]
+
+[<Test>]
+let ``Can read CSV file without headers when inferTypes = false`` () =
+  let csv =
+    "1.0,2.0,3.0\n" +
+    "4.0,5.0,6.0\n" +
+    "7.0,8.0,9.0"
+  use reader = new System.IO.StringReader(csv)
+  let actual = Frame.ReadCsv(reader,hasHeaders=false,inferTypes=false) 
+  actual.ColumnKeys
+  |> Seq.toArray
+  |> shouldEqual [| "Column1"; "Column2"; "Column3" |]
+
+[<Test>]
+let ``Can read CSV file with missing column keys when inferTypes = true`` () =
+  let csv =
+    "a,,\n" +
+    "1.0,2.0,3.0\n" +
+    "3.0,4.0,5.0"
+  use reader = new System.IO.StringReader(csv)
+  let actual = Frame.ReadCsv(reader,hasHeaders=true,inferTypes=true) 
+  actual.ColumnKeys
+  |> Seq.toArray
+  |> shouldEqual [| "a"; "Column2"; "Column3" |]
+
+[<Test>]
+let ``Can read CSV file with missing column keys when inferTypes = false`` () =
+  let csv =
+    "a,,\n" +
+    "1.0,2.0,3.0\n" +
+    "3.0,4.0,5.0"
+  use reader = new System.IO.StringReader(csv)
+  let actual = Frame.ReadCsv(reader,hasHeaders=true,inferTypes=false) 
+  actual.ColumnKeys
+  |> Seq.toArray
+  |> shouldEqual [| "a"; "Column2"; "Column3" |]
+
+[<Test>]
 let ``Can save MSFT data as CSV to a TextWriter and read it afterwards (with default args)`` () =
   let builder = new System.Text.StringBuilder()
   use writer = new System.IO.StringWriter(builder)


### PR DESCRIPTION
Fixes: #63 