### PR TITLE
move Stats to Deedle.Stats project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ src/Deedle.RProvider.Plugin/bin
 src/Deedle.RProvider.Plugin/obj
 src/Deedle.Excel/bin
 src/Deedle.Excel/obj
+src/Deedle.Stats/bin
+src/Deedle.Stats/obj
 *.suo
 tests/Deedle.Tests/obj
 tests/Deedle.Tests/bin

--- a/build.fsx
+++ b/build.fsx
@@ -122,10 +122,12 @@ let testCoreProjs =
 let buildProjs =
     [ "src/Deedle/Deedle.fsproj"
       "src/Deedle.RProvider.Plugin/Deedle.RProvider.Plugin.fsproj"
+      "src/Deedle.Stats/Deedle.Stats.fsproj"
       "src/Deedle.Excel/Deedle.Excel.fsproj" ]
 
 let buildCoreProjs =
     [ "src/Deedle/Deedle.fsproj"    
+      "src/Deedle.Stats/Deedle.Stats.fsproj" 
       "src/Deedle.Excel/Deedle.Excel.fsproj" ]
 
 

--- a/src/Deedle.Stats/Deedle.Stats.fsproj
+++ b/src/Deedle.Stats/Deedle.Stats.fsproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Stats.fs" />
+    <Compile Include="SeriesStatsExtensions.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Deedle\Deedle.fsproj" />
+  </ItemGroup>
+</Project>

--- a/src/Deedle.Stats/SeriesStatsExtensions.fs
+++ b/src/Deedle.Stats/SeriesStatsExtensions.fs
@@ -1,4 +1,4 @@
-﻿namespace Deedle 
+﻿namespace Deedle.Stats 
 
 open System
 open System.Linq
@@ -8,6 +8,7 @@ open System.Runtime.InteropServices
 open System.Runtime.CompilerServices
 open Microsoft.FSharp.Quotations
 
+open Deedle
 open Deedle.Keys
 open Deedle.Indices
 open Deedle.Internal

--- a/src/Deedle.Stats/Stats.fs
+++ b/src/Deedle.Stats/Stats.fs
@@ -1,8 +1,9 @@
-﻿namespace Deedle
+﻿namespace Deedle.Stats
 
 open System
 open System.Collections.Generic
 
+open Deedle
 open Deedle.Vectors
 open Deedle.Internal
 

--- a/src/Deedle/Deedle.fsproj
+++ b/src/Deedle/Deedle.fsproj
@@ -76,11 +76,9 @@
     <Compile Include="SeriesModule.fs" />
     <Compile Include="SeriesExtensions.fs" />
     <Compile Include="Frame.fs" />
-    <Compile Include="Stats.fs" />
     <Compile Include="FrameUtils.fs" />
     <Compile Include="FrameModule.fs" />
     <Compile Include="FrameExtensions.fs" />
-    <Compile Include="SeriesStatsExtensions.fs" />
     <Compile Include="DelayedSeries.fs" />
     <Compile Include="VirtualFrame.fs" />
     <None Include="paket.references" />

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -1047,9 +1047,6 @@ type FrameExtensions =
   static member Print(frame:Frame<'K, 'V>, printTypes:bool) = Console.WriteLine(frame.Format(printTypes));
 
   [<Extension>]
-  static member Sum(frame:Frame<'R, 'C>) = Stats.sum frame
-
-  [<Extension>]
   static member Window(frame:Frame<'R, 'C>, size) = Frame.window size frame
 
   [<Extension>]

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1164,26 +1164,6 @@ module Frame =
   let reduceValues (op:'T -> 'T -> 'T) (frame:Frame<'R, 'C>) = 
     frame.GetColumns<'T>() |> Series.map (fun _ -> Series.reduceValues op) 
 
-  /// Returns a row of the data frame which has the greatest value of the
-  /// specified `column`. The row is returned as an optional value (which is
-  /// `None` for empty frame) and contains a key together with an object
-  /// series representing the row.
-  ///
-  /// [category:Frame transformations]
-  [<CompiledName("MaxRowBy")>]
-  let inline maxRowBy column (frame:Frame<'R, 'C>) = 
-    frame.Rows |> Stats.maxBy (fun row -> row.GetAs<float>(column))
-
-  /// Returns a row of the data frame which has the smallest value of the
-  /// specified `column`. The row is returned as an optional value (which is
-  /// `None` for empty frame) and contains a key together with an object
-  /// series representing the row.
-  ///
-  /// [category:Frame transformations]
-  [<CompiledName("MinRowBy")>]
-  let inline minRowBy column (frame:Frame<'R, 'C>) = 
-    frame.Rows |> Stats.minBy (fun row -> row.GetAs<float>(column))
-
   /// Returns a frame with columns shifted by the specified offset. When the offset is 
   /// positive, the values are shifted forward and first `offset` keys are dropped. When the
   /// offset is negative, the values are shifted backwards and the last `offset` keys are dropped.

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -67,9 +67,9 @@ and
   let mutable valueCount = -1 
 
   /// Returns the vector builder associated with this series
-  member internal x.VectorBuilder = vectorBuilder
+  member x.VectorBuilder = vectorBuilder
   /// Returns the index builder associated with this series
-  member internal x.IndexBuilder = indexBuilder
+  member x.IndexBuilder = indexBuilder
 
   // ----------------------------------------------------------------------------------------------
   // Series data

--- a/tests/Deedle.PerfTests/Deedle.PerfTests.fsproj
+++ b/tests/Deedle.PerfTests/Deedle.PerfTests.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PerformanceTools\Deedle.PerfTest.Core\Deedle.PerfTest.Core.fsproj" />
     <ProjectReference Include="..\..\src\Deedle\Deedle.fsproj" />
+    <ProjectReference Include="..\..\src\Deedle.Stats\Deedle.Stats.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../Common/FsUnit.fs">

--- a/tests/Deedle.PerfTests/Performance.fs
+++ b/tests/Deedle.PerfTests/Performance.fs
@@ -15,6 +15,7 @@ open System
 open FsUnit
 open NUnit.Framework
 open Deedle
+open Deedle.Stats
 open Deedle.PerfTest
 
 // ------------------------------------------------------------------------------------------------

--- a/tests/Deedle.Tests/Common.fs
+++ b/tests/Deedle.Tests/Common.fs
@@ -16,6 +16,7 @@ open FsUnit
 open FsCheck
 open NUnit.Framework
 open Deedle
+open Deedle.Stats
 open Deedle.Internal
 
 [<Test>]

--- a/tests/Deedle.Tests/Deedle.Tests.fsproj
+++ b/tests/Deedle.Tests/Deedle.Tests.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deedle\Deedle.fsproj" />
+    <ProjectReference Include="..\..\src\Deedle.Stats\Deedle.Stats.fsproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -18,6 +18,7 @@ open FsUnit
 open FsCheck
 open NUnit.Framework
 open Deedle
+open Deedle.Stats
 
 // ------------------------------------------------------------------------------------------------
 // Input and output (CSV files, IDataReader)

--- a/tests/Deedle.Tests/LazySeries.fs
+++ b/tests/Deedle.Tests/LazySeries.fs
@@ -15,6 +15,7 @@ open FsUnit
 open FsCheck
 open NUnit.Framework
 open Deedle
+open Deedle.Stats
 open Deedle.Delayed
 open Deedle.Internal
 open Deedle.Indices

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -18,6 +18,7 @@ open FsCheck
 open NUnit.Framework
 
 open Deedle
+open Deedle.Stats
 
 // ------------------------------------------------------------------------------------------------
 // Indexing and accessing values

--- a/tests/Deedle.Tests/Stats.fs
+++ b/tests/Deedle.Tests/Stats.fs
@@ -18,6 +18,7 @@ open FsCheck
 open NUnit.Framework
 
 open Deedle
+open Deedle.Stats
 
 // ------------------------------------------------------------------------------------------------
 // Statistics

--- a/tests/Deedle.Tests/VirtualFrame.fs
+++ b/tests/Deedle.Tests/VirtualFrame.fs
@@ -13,6 +13,7 @@ open System
 open FsUnit
 open NUnit.Framework
 open Deedle
+open Deedle.Stats
 open Deedle.Internal
 open Deedle.Addressing
 open Deedle.Vectors

--- a/tests/Deedle.Tests/VirtualPartitioned.fs
+++ b/tests/Deedle.Tests/VirtualPartitioned.fs
@@ -13,6 +13,7 @@ open System
 open FsUnit
 open NUnit.Framework
 open Deedle
+open Deedle.Stats
 open Deedle.Ranges
 open Deedle.Addressing
 open Deedle.Virtual


### PR DESCRIPTION

There is an attempt to move stats module to the separated project. It is the first steps for implement https://github.com/fslaborg/Deedle/issues/423
Some things are left:

- Fix documentation.
- For now I left tests as it is. Should think: do we need to move tests fo statas into separated Test project. For now I don't see there some problems to keep tests as it is now.