### PR TITLE
Fix docs for `ReadCsv.inferRows`

### DIFF
--- a/docs/content/frame.fsx
+++ b/docs/content/frame.fsx
@@ -64,7 +64,7 @@ The following parameters can be used:
  * `inferTypes` - Specifies whether the method should attempt to infer types
    of columns automatically (set this to `false` if you want to specify schema)
  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-   rows to use for type inference. The default value is 0, meaninig all rows.
+   rows to use for type inference. The default value is 100. Value 0 means all rows.
  * `schema` - A string that specifies CSV schema. See the documentation for 
    information about the schema format.
  * `separators` - A string that specifies one or more (single character) separators

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -390,7 +390,7 @@ module ``F# Frame extensions`` =
     ///  * `inferTypes` - Specifies whether the method should attempt to infer types
     ///    of columns automatically (set this to `false` if you want to specify schema)
     ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-    ///    rows to use for type inference. The default value is 0, meaninig all rows.
+    ///    rows to use for type inference. The default value is 100. Value 0 means all rows.
     ///  * `schema` - A string that specifies CSV schema. See the documentation for 
     ///    information about the schema format.
     ///  * `separators` - A string that specifies one or more (single character) separators


### PR DESCRIPTION
In the documentation it says that if `inferRows` is not specified, then all rows will be scanned whereas in the source code, the default is to scan only 100 rows - see the link below for source code.

https://github.com/fslaborg/Deedle/blob/bdf460d851964bef5bbaa37814e8128e12aa9aab/src/Deedle/FrameUtils.fs#L420

I got bitten by this one, because my dataset had only ones and zeros in the first 100 lines so it deduced that the column would be `bool` instead of `int`.

In my code, specifically stating `inferRows=0` fixed the problem. If the `inferRows` parameter was omitted, then values other than 0 or 1 were treated as missing.

Similar bug was reported in #271