### PR TITLE
Update dotnet sdk on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ install:
 matrix:
   include:
     - mono: latest
-      dotnet: 2.1.302
+      dotnet: 2.1.402
       os: linux
     - mono: latest
-      dotnet: 2.1.302
+      dotnet: 2.1.402
       os: osx
 
 before_install:


### PR DESCRIPTION
Update dotnet sdk to 2.1.402 on Travis to match build.fsx to fix the linux CI error