### PR TITLE
Optimize Frame.AggregateRowsBy

### DIFF
--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -1630,11 +1630,12 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let nKeys = grpKeys |> Seq.length
     if nKeys = 0 then invalidOp "GroupBy columns do not exist in the data frame"
     let labels =
-      let x =
+      let columns =
         frame.Columns.[grpKeys].ValuesAll
         |> Array.ofSeq
-        |> Array.map(fun v -> v.ValuesAll |> Array.ofSeq)
-      Array.init (x.[0].Length) (fun i -> Array.init nKeys (fun j -> x.[j].[i]))
+        |> Array.map(fun v -> v.ValuesAll |> Array.ofSeq) 
+      // transpose columns arrays
+      Array.init frame.RowCount (fun i -> Array.init nKeys (fun j -> columns.[j].[i]))
     let nested = frame.NestRowsBy(labels)
     nested
     |> Series.map (fun _ f -> [for c in aggBy -> (c, aggFunc.Invoke(f.GetColumn<_>(c)) |> box)] )

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -1627,13 +1627,20 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let keySet = HashSet(groupBy)
     let filterFunc k = keySet.Contains(k)
     let grpKeys = frame.ColumnKeys |> Seq.filter filterFunc
-    let labels = frame.Rows.Values |> Seq.map (Series.getAll grpKeys >> Series.valuesAll >> Array.ofSeq) 
+    let nKeys = grpKeys |> Seq.length
+    if nKeys = 0 then invalidOp "GroupBy columns do not exist in the data frame"
+    let labels =
+      let x =
+        frame.Columns.[grpKeys].ValuesAll
+        |> Array.ofSeq
+        |> Array.map(fun v -> v.ValuesAll |> Array.ofSeq)
+      Array.init (x.[0].Length) (fun i -> Array.init nKeys (fun j -> x.[j].[i]))
     let nested = frame.NestRowsBy(labels)
     nested
-    |> Series.map (fun _ f -> [for c in aggBy -> (c, aggFunc.Invoke(f.GetColumn<_>(c)) |> box |> Some)] )
-    |> Series.map (fun k v -> v |> Seq.append (k |> Seq.zip grpKeys) |> Series.ofOptionalObservations)
+    |> Series.map (fun _ f -> [for c in aggBy -> (c, aggFunc.Invoke(f.GetColumn<_>(c)) |> box)] )
+    |> Series.map (fun k v -> v |> Seq.append (k |> Seq.zip grpKeys) |> Series.ofObservations)
     |> Series.indexOrdinally
-    |> FrameUtils.fromRows frame.IndexBuilder frame.VectorBuilder 
+    |> FrameUtils.fromRows frame.IndexBuilder frame.VectorBuilder
 
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. The generic type parameter is (typically) needed to specify the type of the 


### PR DESCRIPTION
Address #269 
The current performance bottleneck is in getting labels by rows.

Typical cases in using Frame.AggregateRowsBy has data frame with way more rows than columns. Switching to getting labels by columns yields a 3x speed improvement in a test case of 100000 rows.

Didn't change the row index to group keys as it will be a breaking change. Will consider it next time as it's more in line with what `pandas` does.

Needs to fix the breaking performance test to document speed different among different versions in the future.