### PR TITLE
Fix #480

### DIFF
--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -1550,10 +1550,16 @@ module Series =
         match fillMode with
         | Lookup.ExactOrSmaller ->
             let res = reindexed.Get(k, fillMode)
-            Series([res.KeyRange |> snd], [res.[res.KeyRange |> snd]])
+            if res.ValueCount = 0 then
+              Series([], [])
+            else
+              Series([res.KeyRange |> snd], [res.[res.KeyRange |> snd]])
         | Lookup.ExactOrGreater ->
             let res = reindexed.Get(k, fillMode)
-            Series([res.KeyRange |> fst], [res.[res.KeyRange |> fst]]) 
+            if res.ValueCount = 0 then
+              Series([], [])
+            else
+              Series([res.KeyRange |> fst], [res.[res.KeyRange |> fst]]) 
         | _ -> Series([], [])  )
     |> mapValues f
 

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -553,6 +553,23 @@ let ``Resample uniform - select value of nearest previous key or fill with earli
   actual |> shouldEqual expected
 
 [<Test>]
+let ``Resample uniform - select value of nearest previous key or fill with earlier with missing values`` () =
+  let input = [
+    DateTime(2019,1,1), 1.0
+    DateTime(2019,1,3), nan
+    DateTime(2019,1,5), 3.0] |> series
+  let expected = [
+    DateTime(2019,1,1), 1.0
+    DateTime(2019,1,2), 1.0
+    DateTime(2019,1,3), nan
+    DateTime(2019,1,4), nan
+    DateTime(2019,1,5), 3.0] |> series
+  let actual =
+    SeriesExtensions.ResampleUniform(
+      input, (fun (dt:DateTime) -> dt.Date), (fun dt -> dt.AddDays(1.0)))
+  actual |> shouldEqual expected
+
+[<Test>]
 let ``Series.sampleTime works when using forward direction`` () =
   let start = DateTime(2012, 2, 12)
   let input = generate start (TimeSpan.FromMinutes(5.37)) 50

--- a/tests/Deedle.Tests/VirtualPartitioned.fs
+++ b/tests/Deedle.Tests/VirtualPartitioned.fs
@@ -673,12 +673,12 @@ let ``Can create frame with two virtual series`` () =
   let df = frame [ "Value" => ts; "Sin" => ts2 ]
   
   df.Format() |> ignore
-  df.GetRowAt<float>(ts.KeyCount/2) |> 
-    shouldEqual <| series ["Value" => 500000000.0; "Sin" => sin 500000000.0]
+  df.GetRowAt<float>(ts.KeyCount/2) - series ["Value" => 500000000.0; "Sin" => sin 500000000.0]
+  |> Stats.mean 
+  |> should beWithin (0.0 +/- 1e-5)
 
   accessedDataParts valSrc |> shouldEqual [0; 500; 999]
-
-
+  
 [<Test>]
 let ``Can use ColumnApply and 'abs' on a created frame`` () =
   let idxSrc, valSrc, ts = createTimeSeries 1000 (fun n -> 5000)


### PR DESCRIPTION
Same error in documentation test in Travis's mac environment and Azure pipline's linux environment
```
Failed   Documentation generated correctly ("./frame.fsx")
Error Message:
 Found errors when processing file './frame.fsx':
./frame.fsx (6:11-957:13): Error - The type 'IEquatable`1' is required here and is unavailable. You must add a reference to assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'.
```