### PR TITLE
Add operator to concatenate string values

### DIFF
--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -466,6 +466,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let newData = vectorBuilder.Build(newColIndex.AddressingScheme, frameCmd, frameData)
     Frame(newRowIndex, newColIndex, newData, indexBuilder, vectorBuilder)
 
+  /// Piecewise concatenate two frames of string values
+  ///
+  /// [category:Joining, merging and zipping]
+  member frame.Concat(df: Frame<'TRowKey, 'TColumnKey>) =
+     frame.Zip<string, string, string>(df, JoinKind.Outer, JoinKind.Outer, Lookup.Exact, true, fun a b -> (+) a b)
+
+
   // ----------------------------------------------------------------------------------------------
   // Frame accessors
   // ----------------------------------------------------------------------------------------------
@@ -969,6 +976,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   static member (?) (frame:Frame<_, _>, column) : Series<'T, float> = 
     frame.GetColumn<float>(column)
 
+
   // ----------------------------------------------------------------------------------------------
   // Some operators
   // ----------------------------------------------------------------------------------------------
@@ -1028,7 +1036,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
   /// [category:Operators]
   static member (+) (frame1:Frame<'TRowKey, 'TColumnKey>, frame2:Frame<'TRowKey, 'TColumnKey>) =
-    Frame<'TRowKey, 'TColumnKey>.PointwiseFrameFrame<float>(frame1, frame2, (+))
+    Frame<'TRowKey, 'TColumnKey>.PointwiseFrameFrame<float>(frame1, frame2, (+))    
   /// [category:Operators]
   static member (-) (frame1:Frame<'TRowKey, 'TColumnKey>, frame2:Frame<'TRowKey, 'TColumnKey>) =
     Frame<'TRowKey, 'TColumnKey>.PointwiseFrameFrame<float>(frame1, frame2, (-))
@@ -1091,6 +1099,19 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   static member (/) (series:Series<'TRowKey, int>, frame:Frame<'TRowKey, 'TColumnKey>) =
     Frame<'TRowKey, 'TColumnKey>.PointwiseFrameSeriesL<float>(frame, Series.mapValues float series, (/))
 
+  // Binary operators taking string series on the left/right
+  /// [category:Operators]
+  static member (+) (frame:Frame<'TRowKey, 'TColumnKey>, series:Series<'TRowKey, string>) =
+    Frame<'TRowKey, 'TColumnKey>.PointwiseFrameSeriesR<string>(frame, series, (+))
+  /// [category:Operators]
+  static member (+) (series:Series<'TRowKey, string>, frame:Frame<'TRowKey, 'TColumnKey>) =
+    Frame<'TRowKey, 'TColumnKey>.PointwiseFrameSeriesL<string>(frame, series, (+))
+  /// [category:Operators]
+  static member (+) (frame:Frame<'TRowKey, 'TColumnKey>, scalar:string) =
+    Frame<'TRowKey, 'TColumnKey>.ScalarOperationR<string>(frame, scalar, (+))
+  /// [category:Operators]
+  static member (+) (scalar:string, frame:Frame<'TRowKey, 'TColumnKey>) =
+    Frame<'TRowKey, 'TColumnKey>.ScalarOperationL<string>(frame, scalar, (+))
     
   // Binary operators taking float/int scalar on the left/right (int is converted to float)
 

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -469,7 +469,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Piecewise concatenate two frames of string values
   ///
   /// [category:Joining, merging and zipping]
-  member frame.Concat(df: Frame<'TRowKey, 'TColumnKey>) =
+  member frame.StrConcat(df: Frame<'TRowKey, 'TColumnKey>) =
      frame.Zip<string, string, string>(df, JoinKind.Outer, JoinKind.Outer, Lookup.Exact, true, fun a b -> (+) a b)
 
 

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1534,6 +1534,14 @@ module Frame =
   let zip (op:'V1->'V2->'V) (frame1:Frame<'R, 'C>) (frame2:Frame<'R, 'C>) : Frame<'R, 'C> =
     zipAlign JoinKind.Inner JoinKind.Inner Lookup.Exact op frame1 frame2
 
+  /// Piecewise concatenate two frames of string values
+  ///
+  /// [category:Joining, merging and zipping]
+  [<CompiledName("Concat")>]
+  let concat (frame1:Frame<'R, 'C>) (frame2:Frame<'R, 'C>) : Frame<'R, 'C> =
+    frame1.Concat(frame2)
+
+
   // ----------------------------------------------------------------------------------------------
   // Hierarchical index operations
   // ----------------------------------------------------------------------------------------------

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1537,9 +1537,9 @@ module Frame =
   /// Piecewise concatenate two frames of string values
   ///
   /// [category:Joining, merging and zipping]
-  [<CompiledName("Concat")>]
-  let concat (frame1:Frame<'R, 'C>) (frame2:Frame<'R, 'C>) : Frame<'R, 'C> =
-    frame1.Concat(frame2)
+  [<CompiledName("StrConcat")>]
+  let strConcat (frame1:Frame<'R, 'C>) (frame2:Frame<'R, 'C>) : Frame<'R, 'C> =
+    frame1.StrConcat(frame2)
 
 
   // ----------------------------------------------------------------------------------------------

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -1033,6 +1033,13 @@ and
   static member (*) (s1, s2) = Series<'K, _>.VectorOperation<decimal>(s1, s2, (*))
   /// [category:Operators]
   static member (/) (s1, s2) = Series<'K, _>.VectorOperation<decimal>(s1, s2, (/))
+  
+  /// [category:Operators]
+  static member (+) (s1, s2) = Series<'K, _>.VectorOperation<string>(s1, s2, (+))
+  /// [category:Operators]
+  static member (+) (series, scalar) = Series<'K, _>.ScalarOperationL<string>(series, scalar, (+))
+  /// [category:Operators]
+  static member (+) (scalar, series) = Series<'K, _>.ScalarOperationR<string>(scalar, series, (+))
 
   // Trigonometric
   

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -864,7 +864,7 @@ let ``Concatenate two frames of string values`` () =
                     "Y" => series [| 1 => "C"; 2 => "D"; 3 => "E"|] ]
   let df2 = frame [ "X" => series [| 1 => "F"; 2 => "G"|]
                     "Y" => series [| 1 => "H"; 2 => "I"; 3 => "J"|] ]
-  let combined = df1.Concat(df2)
+  let combined = df1.StrConcat(df2)
   combined.GetColumn<string>("X").TryGet(1) |> shouldEqual (OptionalValue "AF")
   combined.GetColumn<string>("Y").TryGet(2) |> shouldEqual (OptionalValue "DI")
   combined.GetColumn<string>("X").TryGet(3) |> shouldEqual OptionalValue.Missing

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -831,6 +831,45 @@ let ``Applying (+) on frame & frame with uncommon columns will result missing va
   actual?b.TryGetAt(0) |> shouldEqual (OptionalValue 4.0)
   actual?b.TryGetAt(2) |> shouldEqual OptionalValue.Missing
 
+[<Test>]
+let ``Applying (+) on frame & string series`` () =
+  let df = frame [ "X" => series [| 1 => "A"; 2 => "B"|]
+                   "Y" => series [| 1 => "C"; 2 => "D"; 3 => "E"|] ]
+  let s = series [| 1 => "F"; 2 => "G"|]
+  let combined1 = df + s
+  let combined2 = s + df
+  combined1.GetColumn<string>("X").TryGet(1) |> shouldEqual (OptionalValue "AF")
+  combined1.GetColumn<string>("Y").TryGet(2) |> shouldEqual (OptionalValue "DG")
+  combined1.GetColumn<string>("Y").TryGet(3) |> shouldEqual OptionalValue.Missing
+  combined2.GetColumn<string>("X").TryGet(1) |> shouldEqual (OptionalValue "FA")
+  combined2.GetColumn<string>("Y").TryGet(2) |> shouldEqual (OptionalValue "GD")
+  combined2.GetColumn<string>("Y").TryGet(3) |> shouldEqual OptionalValue.Missing
+
+[<Test>]
+let ``Applying (+) on frame & string scalar`` () =
+  let df = frame [ "X" => series [| 1 => "A"; 2 => "B"|]
+                   "Y" => series [| 1 => "C"; 2 => "D"; 3 => "E"|] ]
+  let combined1 = df + "F"
+  let combined2 = "F" + df
+  combined1.GetColumn<string>("X").TryGet(1) |> shouldEqual (OptionalValue "AF")
+  combined1.GetColumn<string>("Y").TryGet(2) |> shouldEqual (OptionalValue "DF")
+  combined1.GetColumn<string>("X").TryGet(3) |> shouldEqual OptionalValue.Missing
+  combined2.GetColumn<string>("X").TryGet(1) |> shouldEqual (OptionalValue "FA")
+  combined2.GetColumn<string>("Y").TryGet(2) |> shouldEqual (OptionalValue "FD")
+  combined2.GetColumn<string>("X").TryGet(3) |> shouldEqual OptionalValue.Missing
+
+[<Test>]
+let ``Concatenate two frames of string values`` () =
+  let df1 = frame [ "X" => series [| 1 => "A"; 2 => "B"|]
+                    "Y" => series [| 1 => "C"; 2 => "D"; 3 => "E"|] ]
+  let df2 = frame [ "X" => series [| 1 => "F"; 2 => "G"|]
+                    "Y" => series [| 1 => "H"; 2 => "I"; 3 => "J"|] ]
+  let combined = df1.Concat(df2)
+  combined.GetColumn<string>("X").TryGet(1) |> shouldEqual (OptionalValue "AF")
+  combined.GetColumn<string>("Y").TryGet(2) |> shouldEqual (OptionalValue "DI")
+  combined.GetColumn<string>("X").TryGet(3) |> shouldEqual OptionalValue.Missing
+  ()
+
 // ------------------------------------------------------------------------------------------------
 // Operations - append
 // ------------------------------------------------------------------------------------------------

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -265,6 +265,17 @@ let ``Can perform numerical operations on series of integers`` () =
   (sn - sn).[3] |> shouldEqual 0
   (sn / sn).[3] |> shouldEqual 1
 
+[<Test>]
+let ``Can perform string concatenation operations on series of strings`` () =
+  let s1 = series [ 1 => "A"; 2 => "B"; 3 => "C" ]
+  let s2 = series [ 1 => "D"; 2 => "E"; 3 => "F" ]
+  let expected1 = series [ 1 => "AD"; 2 => "BE"; 3 => "CF" ]
+  let expected2 = series [ 1 => "AD"; 2 => "BD"; 3 => "CD" ]
+  let expected3 = series [ 1 => "DA"; 2 => "DB"; 3 => "DC" ]
+  s1 + s2 |> shouldEqual expected1
+  s1 + "D" |> shouldEqual expected2
+  "D" + s1 |> shouldEqual expected3
+
 // ------------------------------------------------------------------------------------------------
 // Operations - union, grouping, diff, etc.
 // ------------------------------------------------------------------------------------------------

--- a/tests/PerformanceTools/Deedle.PerfTest/Program.fs
+++ b/tests/PerformanceTools/Deedle.PerfTest/Program.fs
@@ -4,6 +4,8 @@ open System
 open System.IO
 open System.Reflection
 open System.Diagnostics
+open FSharp.Data
+open FSharp.Compiler.SourceCodeServices
 
 // ------------------------------------------------------------------------------------------------
 // Helpers
@@ -25,9 +27,6 @@ module Utils =
 open Utils
 
 module internal Compiler = 
-  open FSharp.Data
-  open Microsoft.FSharp.Compiler.SourceCodeServices
-
   type PerfConfig = XmlProvider<"perf.config">
 
   let checker = FSharpChecker.Create()


### PR DESCRIPTION
Fix #482 

Overloaded the following operators
`Series<'K, string> + Series<'K, string>`,
`Series<'K, string> + string`, 
`string + Series<'K, string>`, 
`Series<'K, string> + Frame`, 
`Frame + Series<'K, string>`, 
`Frame + string`
`string + Frame`

Added `Frame.strConcat` method to concatenate two frames of string values

