### PR TITLE
Add basic expanding ema

### DIFF
--- a/Deedle.Tests.sln
+++ b/Deedle.Tests.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29424.173
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{ACC11088-D082-4141-BBA5-B80209449475}"
 	ProjectSection(SolutionItems) = preProject
@@ -8,22 +8,24 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{ACC110
 		paket.lock = paket.lock
 	EndProjectSection
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Deedle.Tests", "tests\Deedle.Tests\Deedle.Tests.fsproj", "{484A96E6-D217-47EE-974C-5D7B3CFB401E}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Deedle.Tests", "tests\Deedle.Tests\Deedle.Tests.fsproj", "{484A96E6-D217-47EE-974C-5D7B3CFB401E}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Deedle.Tests.Console", "tests\Deedle.Tests.Console\Deedle.Tests.Console.fsproj", "{09D8960B-9703-425E-AF0B-FA39525F5B9C}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Deedle.Tests.Console", "tests\Deedle.Tests.Console\Deedle.Tests.Console.fsproj", "{09D8960B-9703-425E-AF0B-FA39525F5B9C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deedle.CSharp.Tests", "tests\Deedle.CSharp.Tests\Deedle.CSharp.Tests.csproj", "{B0584275-6E9D-4DB8-A35D-4F37B623F97E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deedle.CSharp.Tests", "tests\Deedle.CSharp.Tests\Deedle.CSharp.Tests.csproj", "{B0584275-6E9D-4DB8-A35D-4F37B623F97E}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Deedle.Documentation.Tests", "tests\Deedle.Documentation.Tests\Deedle.Documentation.Tests.fsproj", "{79F004B4-093B-49C8-B7BF-7B3EF7CC829E}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Deedle.Documentation.Tests", "tests\Deedle.Documentation.Tests\Deedle.Documentation.Tests.fsproj", "{79F004B4-093B-49C8-B7BF-7B3EF7CC829E}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Deedle.RPlugin.Tests", "tests\Deedle.RPlugin.Tests\Deedle.RPlugin.Tests.fsproj", "{51D38BDE-02E7-45D4-A135-DC478B7C57E9}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Deedle.RPlugin.Tests", "tests\Deedle.RPlugin.Tests\Deedle.RPlugin.Tests.fsproj", "{51D38BDE-02E7-45D4-A135-DC478B7C57E9}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Deedle.PerfTests", "tests\Deedle.PerfTests\Deedle.PerfTests.fsproj", "{0275C56B-9A00-4578-A826-A6CF1F089086}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Deedle.PerfTests", "tests\Deedle.PerfTests\Deedle.PerfTests.fsproj", "{0275C56B-9A00-4578-A826-A6CF1F089086}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Performance", "Performance", "{DEA1237A-77B6-4988-AC8C-065C546435BB}"
 	ProjectSection(SolutionItems) = preProject
 		tests\PerformanceTools\performance.fsx = tests\PerformanceTools\performance.fsx
 	EndProjectSection
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Deedle", "src\Deedle\Deedle.fsproj", "{12AAF4B2-6E96-49AC-AA10-AFAB1FF55026}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,8 +57,15 @@ Global
 		{0275C56B-9A00-4578-A826-A6CF1F089086}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0275C56B-9A00-4578-A826-A6CF1F089086}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0275C56B-9A00-4578-A826-A6CF1F089086}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12AAF4B2-6E96-49AC-AA10-AFAB1FF55026}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12AAF4B2-6E96-49AC-AA10-AFAB1FF55026}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12AAF4B2-6E96-49AC-AA10-AFAB1FF55026}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12AAF4B2-6E96-49AC-AA10-AFAB1FF55026}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8699C921-1B6D-4BD9-B581-2C3E81D72DFD}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Hi.

I've seen the idea to add a separate package for Deedle.Math: https://github.com/fslaborg/Deedle/pull/475

This includes support for exponential smoothing which is nice.

I would very much like an expanding version of exponential smoothing much like exists in pandas. This is particularly helpful in financial applications when you want to use all history up to the given point in time.

My commit below just follows: 
  // pandas v0.24.2: series.ewm(alpha=0.97, adjust=False, ignore_na=True).mean()

- Do you think this fits here?
- Would we need to support all different options currently in pandas?
