### PR TITLE
Preserve column order when merge/join frames

### DIFF
--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -154,7 +154,7 @@ type internal DelayedSource<'K, 'V when 'K : equality>
       | 0 -> return indexBuilder.Create([], None), vectorBuilder.Create([||])
       | 1 -> return fst constrs.[0], vectors.[0]
       | _ -> 
-          let newIndex, cmd = indexBuilder.Merge( List.ofSeq constrs, BinaryTransform.AtMostOne )
+          let newIndex, cmd = indexBuilder.Merge( List.ofSeq constrs, BinaryTransform.AtMostOne, true )
           let newVector = vectorBuilder.Build(newIndex.AddressingScheme, cmd, vectors.ToArray())
           return newIndex, newVector } |> Async.StartAsTask)
 
@@ -249,7 +249,7 @@ and internal DelayedIndexBuilder() =
     member x.Shift(sc, offset) = builder.Shift(sc, offset)
     member x.Union(sc1, sc2) = builder.Union(sc1, sc2)
     member x.Intersect(sc1, sc2) = builder.Intersect(sc1, sc2)
-    member x.Merge(scs, transform) = builder.Merge(scs, transform)
+    member x.Merge(scs, transform, reorder) = builder.Merge(scs, transform, reorder)
     member x.Search(sc, idx, value) = builder.Search(sc, idx, value)
     member x.LookupLevel(sc, key) = builder.LookupLevel(sc, key)
     member x.WithIndex(index1, f, vector) = builder.WithIndex(index1, f, vector)

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -294,7 +294,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     // Append the column indices and get transformation to combine them
     // (LeftOrRight - specifies that when column exist in both data frames then fail)
     let newColumnIndex, colCmd = 
-      indexBuilder.Merge( [(columnIndex, Vectors.Return 0); (otherFrame.ColumnIndex, Vectors.Return 1) ], BinaryTransform.AtMostOne)
+      indexBuilder.Merge( [(columnIndex, Vectors.Return 0); (otherFrame.ColumnIndex, Vectors.Return 1) ], BinaryTransform.AtMostOne, false)
     // Apply transformation to both data vectors
     let newThisData = data.Select(transformColumn vectorBuilder newRowIndex.AddressingScheme thisRowCmd)
     let newOtherData = otherFrame.Data.Select(transformColumn otherFrame.VectorBuilder newRowIndex.AddressingScheme otherRowCmd)
@@ -433,7 +433,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     // Merge the row indices and get a transformation that combines N vectors
     // (AtMostOne - specifies that when the vectors are merged, there should be no overlap)
     let constrs = frames |> Seq.mapi (fun i f -> f.RowIndex, Vectors.Return(i)) |> List.ofSeq
-    let newRowIndex, rowCmd = indexBuilder.Merge(constrs, NaryTransform.AtMostOne)
+    let newRowIndex, rowCmd = indexBuilder.Merge(constrs, NaryTransform.AtMostOne, true)
 
     // Define a function to construct result vector via the above row command, which will dynamically
     // dispatch to a type-specific generic implementation
@@ -460,7 +460,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 
     // build the union of all column keys
     let colConstrs = frames |> Seq.mapi (fun i f -> f.ColumnIndex, Vectors.Return(i)) |> List.ofSeq
-    let newColIndex, frameCmd = indexBuilder.Merge(colConstrs, append)
+    let newColIndex, frameCmd = indexBuilder.Merge(colConstrs, append, false)
 
     let frameData = frames |> Array.map (fun f -> f.Data)
     let newData = vectorBuilder.Build(newColIndex.AddressingScheme, frameCmd, frameData)

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -247,7 +247,7 @@ and IIndexBuilder =
   /// The specified `VectorListTransform` defines how to deal with the case when
   /// a key is defined in both indices (i.e. which value should be in the new vector).
   abstract Merge :
-    list<SeriesConstruction<'K>> * VectorListTransform -> 
+    list<SeriesConstruction<'K>> * VectorListTransform * bool -> 
     IIndex<'K> * VectorConstruction
 
   /// Given an old index and a new index, build a vector transformation that reorders

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -476,8 +476,12 @@ type LinearIndexBuilder(vectorBuilder:Vectors.IVectorBuilder) =
 
     /// Merge is similar to union, but it also combines the vectors using the specified
     /// vector transformation.
-    member builder.Merge<'K when 'K : equality>(constructions:SeriesConstruction<'K> list, transform) = 
-      let allOrdered = constructions |> List.forall (fun (index, _) -> index.IsOrdered)
+    member builder.Merge<'K when 'K : equality>(constructions:SeriesConstruction<'K> list, transform, reorder) =
+      let allOrdered =
+        if reorder then
+          constructions |> List.forall (fun (index, _) -> index.IsOrdered)
+        else
+          false
 
       // Merge ordered sequences (assuming `allOrdered = true`)
       let mergeOrdered comparer =

--- a/src/Deedle/Indices/VirtualIndex.fs
+++ b/src/Deedle/Indices/VirtualIndex.fs
@@ -180,7 +180,7 @@ and VirtualIndexBuilder() =
     // We can merge series as long as they all have `VirtualOrderedIndex` or as long as they
     // all have `VirtualOrdinalIndex`. If they differ or they are fully evaluated, we call the
     // base vector builder and fully materialize them.
-    member x.Merge<'K when 'K : equality>(scs:list<SeriesConstruction<'K>>, transform) = 
+    member x.Merge<'K when 'K : equality>(scs:list<SeriesConstruction<'K>>, transform, reorder) = 
 
       /// Succeeds if all the specified indices are `VirtualOrderedIndex`
       let (|OrderedSources|_|) : list<SeriesConstruction<'K>> -> _ = 
@@ -217,7 +217,7 @@ and VirtualIndexBuilder() =
                 match index with
                 | :? VirtualOrderedIndex<'K> | :? VirtualOrdinalIndex -> materializeIndex index, vector
                 | _ -> index, vector ]
-          baseBuilder.Merge(scs, transform)
+          baseBuilder.Merge(scs, transform, true)
 
 
     // Search the given vector for a given value and return an index that represents only

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -481,7 +481,7 @@ and
     // (LeftOrRight - specifies that when column exist in both data frames then fail)
     let newIndex, cmd = 
       indexBuilder.Merge( [(index, Vectors.Return 0); (otherSeries.Index, Vectors.Return 1)], 
-                           BinaryTransform.AtMostOne )
+                           BinaryTransform.AtMostOne, true )
     let newVector = vectorBuilder.Build(newIndex.AddressingScheme, cmd, [| series.Vector; otherSeries.Vector |])
     Series(newIndex, newVector, vectorBuilder, indexBuilder)
 
@@ -497,7 +497,7 @@ and
     let vectors = otherSeries |> Array.map (fun s -> s.Vector)
 
     let newIndex, cmd = 
-      indexBuilder.Merge( (index, Vectors.Return 0)::constrs, BinaryTransform.AtMostOne )
+      indexBuilder.Merge( (index, Vectors.Return 0)::constrs, BinaryTransform.AtMostOne, true )
     let newVector = vectorBuilder.Build(newIndex.AddressingScheme, cmd, [| yield series.Vector; yield! vectors |])
     Series(newIndex, newVector, vectorBuilder, indexBuilder)
 

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -926,6 +926,15 @@ let ``Can append multiple frames`` () =
   actual.Rows.[8].TryGetAt(0).HasValue |> shouldEqual false
 
 [<Test>]
+let ``Can merge frames with original column order`` () =
+  let df1 = frame [ "Z" => series [ "a" => 1.0; "c" => 2.0 ]]
+  let df2 = frame [ "A" => series [ "a" => 1.0; "c" => 2.0 ] ]
+  let actual1 = df1.Merge(df2)
+  let actual2 = df2.Merge(df1)
+  actual1.ColumnKeys |> List.ofSeq |> shouldEqual ["Z"; "A"]
+  actual2.ColumnKeys |> List.ofSeq |> shouldEqual ["A"; "Z"]
+
+[<Test>]
 let ``AppendN works on non-primitives`` () =
   let df = frame []
   df?X <- series [ "a" => Decimal(1.0); "b" => Decimal(1.0); "c" => Decimal(2.0); "d" => Decimal(2.0)]


### PR DESCRIPTION
Fix #304 

This is a behavior breaking change.

The columns of merged frames will not be reordered during `merge` or `join`. User needs to call `Frame.sortColsByKey` explicitly to sort output frame by column keys.