### PR TITLE
Relax value type in FilterRowsBy

### DIFF
--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -1161,8 +1161,7 @@ type FrameExtensions =
     frame.Rows.GetItems(rowKeys) |> FrameUtils.fromRows frame.IndexBuilder frame.VectorBuilder
 
   [<Extension>]
-  static member FilterRowsBy<'TRowKey, 'TColumnKey, 'V when 'TRowKey : equality and 'TColumnKey : equality>
-      (frame:Frame<'TRowKey, 'TColumnKey>, column, value) = 
+  static member FilterRowsBy(frame:Frame<'TRowKey, 'TColumnKey>, column, value) = 
     Frame.filterRowsBy column value frame
 
   [<Extension>]

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -525,6 +525,7 @@ let ``Filter frame rows by column value`` () =
   (df |> Frame.filterRowsBy "X" true)?Y |> shouldEqual <| series [ "a" => 4.0; "e" => 6.0 ]
   (df |> Frame.filterRowsBy "X" false)?Y |> shouldEqual <| series [ "c" => nan; "f" => 4.0 ]
   (df |> Frame.filterRowsBy "Y" 4).GetColumn<bool>("X") |> shouldEqual <| series [ "a" => true; "f" => false ]
+  df.FilterRowsBy("Y", 4).GetColumn<bool>("X") |> shouldEqual <| series [ "a" => true; "f" => false ]
 
 // ------------------------------------------------------------------------------------------------
 // Slices


### PR DESCRIPTION
Fix #491 
`equality` constraint caused unnecessary boxing of value.
Also added test case.