### PR TITLE
Fix two csv issues

### DIFF
--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -155,6 +155,34 @@ let ``Can read CSV file with missing column keys when inferTypes = false`` () =
   |> shouldEqual [| "a"; "Column2"; "Column3" |]
 
 [<Test>]
+let ``Can read CSV with headers of multilines`` () =
+  let csv = """"
+col_A
+";"
+col_A
+2";col_B
+1;2;3
+4;5;6"""
+  use reader = new System.IO.StringReader(csv)
+  let df = Frame.ReadCsv(reader,separators = ";")
+  let actual = df.ColumnKeys |> Seq.toArray
+  Assert.IsTrue(
+    actual = [| "col_A"; "col_A\n2"; "col_B" |] ||
+    actual = [| "col_A"; "col_A\r\n2"; "col_B" |] )
+
+[<Test>]
+let ``Can read CSV file with empty cell`` () =
+  let csv = 
+    "row,c1,c2,c3\n" +
+    "1,,5,\n" +
+    "2,4,6,"
+  use reader = new System.IO.StringReader(csv)
+  let df = Frame.ReadCsv(reader) 
+  let actual = df?c1
+  let expected = [nan; 4.0] |> Series.ofValues
+  actual |> shouldEqual expected
+
+[<Test>]
 let ``Can save MSFT data as CSV to a TextWriter and read it afterwards (with default args)`` () =
   let builder = new System.Text.StringBuilder()
   use writer = new System.IO.StringWriter(builder)


### PR DESCRIPTION
Fix #479 and #441 

I overrides two places in csvinference.fs from FSharp.Data/
1. The code to separate column name by `\n` is for type provider's field name inference. It serves no purpose in Deedle's CSV scenario.
https://github.com/fsharp/FSharp.Data/blob/master/src/Csv/CsvInference.fs#L308
2. The pull request to change the inference of empty cell is still pending in FSharp.Data repo. It should be fine to change here first as it passed all unit tests.
https://github.com/fsharp/FSharp.Data/issues/1192