### PR TITLE
Remove duplicated sum function in FrameExtensions

### DIFF
--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -1048,9 +1048,6 @@ type FrameExtensions =
   static member Print(frame:Frame<'K, 'V>, printTypes:bool) = Console.WriteLine(frame.Format(printTypes));
 
   [<Extension>]
-  static member Sum(frame:Frame<'R, 'C>) = Stats.sum frame
-
-  [<Extension>]
   static member Window(frame:Frame<'R, 'C>, size) = Frame.window size frame
 
   [<Extension>]

--- a/tests/Deedle.CSharp.Tests/Frame.cs
+++ b/tests/Deedle.CSharp.Tests/Frame.cs
@@ -1,9 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using NUnit.Framework;
 using Deedle;
 using System.Runtime.CompilerServices;
@@ -48,116 +45,136 @@ namespace Deedle.CSharp.Tests
         }
     }
 
-  /* ----------------------------------------------------------------------------------
-   * Creating frames and getting frame data
-   * --------------------------------------------------------------------------------*/
+    /* ----------------------------------------------------------------------------------
+    * Creating frames and getting frame data
+    * --------------------------------------------------------------------------------*/
 
-  public class PublicFields
-  {
-    public readonly int A;
-    public readonly string B;
-    public PublicFields(int a, string b)
+    public class PublicFields
     {
-      this.A = a;
-      this.B = b;
-    }
-  }
-
-  public class FrameCreateAccessTests
-  {
-    [Test]
-    public static void CanCreateFrameFromRecords()
-    {
-      var df = Frame.FromRecords(new[] {
-        new { A = 1, B = "Test" },
-        new { A = 2, B = "Another"}
-      });
-      var firstRow = df.Rows[0].Values.ToArray();
-      Assert.AreEqual(new object[] { 1, "Test" }, firstRow);
-      Assert.AreEqual(new[] { "A", "B" }, df.ColumnKeys.ToArray());
+        public readonly int A;
+        public readonly string B;
+        public PublicFields(int a, string b)
+        {
+            this.A = a;
+            this.B = b;
+        }
     }
 
-    [Test]
-    public static void CanCreateFrameFromFields()
+    public class FrameCreateAccessTests
     {
-      var df = Frame.FromRecords(new[] {
-        new PublicFields(1, "Test"),
-        new PublicFields(2, "Another")
-      });
-      var firstRow = df.Rows[0].Values.ToArray();
-      Assert.AreEqual(new object[] { 1, "Test" }, firstRow);
-      Assert.AreEqual(new[] { "A", "B" }, df.ColumnKeys.ToArray());
+        [Test]
+        public static void CanCreateFrameFromRecords()
+        {
+            var df = Frame.FromRecords(new[] {
+            new { A = 1, B = "Test" },
+            new { A = 2, B = "Another"}
+            });
+            var firstRow = df.Rows[0].Values.ToArray();
+            Assert.AreEqual(new object[] { 1, "Test" }, firstRow);
+            Assert.AreEqual(new[] { "A", "B" }, df.ColumnKeys.ToArray());
+        }
+
+        [Test]
+        public static void CanCreateFrameFromFields()
+        {
+            var df = Frame.FromRecords(new[] {
+            new PublicFields(1, "Test"),
+            new PublicFields(2, "Another")
+            });
+            var firstRow = df.Rows[0].Values.ToArray();
+            Assert.AreEqual(new object[] { 1, "Test" }, firstRow);
+            Assert.AreEqual(new[] { "A", "B" }, df.ColumnKeys.ToArray());
+        }
+
+        [Test]
+        public static void CanRoundtripWithArray2D()
+        {
+            var arr = new double[200, 500];
+            for (var r = 0; r < 200; r++)
+            for (var c = 0; c < 500; c++)
+                arr[r, c] = (r + c == 10) ? Double.NaN : (r + c);
+
+            var arr2 = Frame.FromArray2D(arr).ToArray2D<double>();
+            Assert.AreEqual(arr, arr2);
+        }
+
+        [Test]
+        public static void CannotGetDefaultValueOfBoolean()
+        {
+            var df = Frame.FromColumns(new[] {
+            KeyValue.Create(1, (new SeriesBuilder<string>() { { "A", true } }).Series),
+            KeyValue.Create(2, (new SeriesBuilder<string>() { { "B", true } }).Series)
+            });
+            Assert.Throws<InvalidOperationException>(() =>
+            df.ToArray2D<bool>());
+        }
+
+        [Test]
+        public static void CanGetDataAsBooleanWithDefault()
+        {
+            var df = Frame.FromColumns(new[] {
+            KeyValue.Create(1, (new SeriesBuilder<string>() { { "A", true } }).Series),
+            KeyValue.Create(2, (new SeriesBuilder<string>() { { "B", true } }).Series)
+            });
+            var data = df.ToArray2D<bool>(true);
+            var bools = data.OfType<bool>().ToArray();
+            Assert.AreEqual(new[] { true, true, true, true }, bools);
+        }
+
+        [Test]
+        public static void FramesOrderedAfterBuild()
+        {
+            var builder = new FrameBuilder.Columns<int, string>();
+            builder.Add("column1", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            builder.Add("column2", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            builder.Add("column3", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            builder.Add("column4", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            var frame = builder.Frame;
+
+            Assert.AreEqual(
+            new[] { "column1", "column2", "column3", "column4" },
+            frame.ColumnKeys.ToArray()
+            );
+        }
+
+        [Test]
+        public static void DropSparseRowsFromRecords()
+        {
+            var f = Deedle.Frame.FromRecords(new[] {
+                new { a = "x", b = 1.0 },
+                new { a = "y", b = Double.NaN },
+                new { a = "z", b = 3.0 }
+            });
+            var b = Deedle.FrameModule.DropSparseRows(f).GetColumn<float>("b").GetAllValues().ToArray();
+            Assert.AreEqual(1.0, b[0].Value);
+            Assert.AreEqual(3.0, b[1].Value);
+        }
     }
 
-    [Test]
-    public static void CanRoundtripWithArray2D()
+    /* ----------------------------------------------------------------------------------
+    * Stats functions on frame
+    * --------------------------------------------------------------------------------*/
+    public class FrameStatsTests
     {
-      var arr = new double[200, 500];
-      for (var r = 0; r < 200; r++)
-        for (var c = 0; c < 500; c++)
-          arr[r, c] = (r + c == 10) ? Double.NaN : (r + c);
-
-      var arr2 = Frame.FromArray2D(arr).ToArray2D<double>();
-      Assert.AreEqual(arr, arr2);
+        [Test]
+        public static void SumOfFrame()
+        {
+            var builder = new FrameBuilder.Columns<int, string>();
+            builder.Add("column1", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            builder.Add("column2", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            builder.Add("column3", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            builder.Add("column4", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
+            var df = builder.Frame;
+            var sum = df.Sum().GetAllValues().ToArray();
+            Assert.AreEqual(10.0, sum[0].Value);
+            Assert.AreEqual(10.0, sum[1].Value);
+        }
     }
 
-    [Test]
-    public static void CannotGetDefaultValueOfBoolean()
-    {
-      var df = Frame.FromColumns(new[] {
-        KeyValue.Create(1, (new SeriesBuilder<string>() { { "A", true } }).Series),
-        KeyValue.Create(2, (new SeriesBuilder<string>() { { "B", true } }).Series)
-      });
-      Assert.Throws<InvalidOperationException>(() =>
-        df.ToArray2D<bool>());
-    }
-
-    [Test]
-    public static void CanGetDataAsBooleanWithDefault()
-    {
-      var df = Frame.FromColumns(new[] {
-        KeyValue.Create(1, (new SeriesBuilder<string>() { { "A", true } }).Series),
-        KeyValue.Create(2, (new SeriesBuilder<string>() { { "B", true } }).Series)
-      });
-      var data = df.ToArray2D<bool>(true);
-      var bools = data.OfType<bool>().ToArray();
-      Assert.AreEqual(new[] { true, true, true, true }, bools);
-    }
-
-    [Test]
-    public static void FramesOrderedAfterBuild()
-    {
-      var builder = new FrameBuilder.Columns<int, string>();
-      builder.Add("column1", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
-      builder.Add("column2", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
-      builder.Add("column3", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
-      builder.Add("column4", new[] { 1, 2, 3, 4 }.ToOrdinalSeries());
-      var frame = builder.Frame;
-
-      Assert.AreEqual(
-        new[] { "column1", "column2", "column3", "column4" },
-        frame.ColumnKeys.ToArray()
-        );
-    }
-
-    [Test]
-    public static void DropSparseRowsFromRecords()
-    {
-      var f = Deedle.Frame.FromRecords(new[] {
-          new { a = "x", b = 1.0 },
-          new { a = "y", b = Double.NaN },
-          new { a = "z", b = 3.0 }
-      });
-      var b = Deedle.FrameModule.DropSparseRows(f).GetColumn<float>("b").GetAllValues().ToArray();
-      Assert.AreEqual(1.0, b[0].Value);
-      Assert.AreEqual(3.0, b[1].Value);
-    }
-  }
-
-	/* ----------------------------------------------------------------------------------
-	 * Test data frame dynamic
-	 * --------------------------------------------------------------------------------*/
-	public class DynamicFrameTests
+    /* ----------------------------------------------------------------------------------
+    * Test data frame dynamic
+    * --------------------------------------------------------------------------------*/
+    public class DynamicFrameTests
 	{
 		[Test]
 		public static void CanAddSeriesDynamically()


### PR DESCRIPTION
Fix #514 

There is a redundant `sum` function remaining in `FrameExtensions`. After adding `sum` to `FrameStatsExtensions`, this ambiguous case comes up. But there was no test cases to capture that. This shall be fixed now.