### PR TITLE
Add util, extension and test to read a frame from a CSV string

### DIFF
--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -502,6 +502,37 @@ module ``F# Frame extensions`` =
           ?separators, ?culture, ?maxRows, ?missingValues, ?preferOptions ) =
       FrameUtils.readCsv reader hasHeaders inferTypes inferRows schema missingValues separators culture maxRows preferOptions
 
+    /// Load data frame from a string representing a UTF8-encoded CSV file. The operation automatically
+    /// reads column names from the string (if they are present) and infers the type of values for each column. Columns
+    /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
+    /// types (such as dates) are not converted automatically.
+    ///
+    /// ## Parameters
+    ///
+    ///  * `dataString` - Specifies the input stringcontaining the CSV
+    ///  * `hasHeaders` - Specifies whether the input CSV string has header row
+    ///  * `inferTypes` - Specifies whether the method should attempt to infer types
+    ///    of columns automatically (set this to `false` if you want to specify schema)
+    ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
+    ///    rows to use for type inference. The default value is 100.
+    ///  * `schema` - A string that specifies CSV schema. See the documentation for
+    ///    information about the schema format.
+    ///  * `separators` - A string that specifies one or more (single character) separators
+    ///    that are used to separate columns in the CSV string. Use for example `";"` to
+    ///    parse semicolon separated files.
+    ///  * `culture` - Specifies the name of the culture that is used when parsing
+    ///    values in the CSV string (such as `"en-US"`). The default is invariant culture.
+    ///  * `maxRows` - The maximal number of rows that should be read from the CSV string.
+    ///  * `missingValues` - An array of strings that contains values which should be treated
+    ///    as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".
+    ///
+    /// [category:Input and output]
+    static member ReadCsvString
+        ( csvString:string, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
+          ?culture, ?maxRows, ?missingValues, ?preferOptions ) =
+      FrameUtils.readString csvString hasHeaders inferTypes inferRows schema missingValues separators culture maxRows preferOptions
+
+
     /// Creates a frame with ordinal Integer index from a sequence of rows.
     /// The column indices of individual rows are unioned, so if a row has fewer
     /// columns, it will be successfully added, but there will be missing values.

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -509,7 +509,7 @@ module ``F# Frame extensions`` =
     ///
     /// ## Parameters
     ///
-    ///  * `dataString` - Specifies the input stringcontaining the CSV
+    ///  * `dataString` - Specifies the input string containing the CSV
     ///  * `hasHeaders` - Specifies whether the input CSV string has header row
     ///  * `inferTypes` - Specifies whether the method should attempt to infer types
     ///    of columns automatically (set this to `false` if you want to specify schema)

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -509,7 +509,7 @@ module ``F# Frame extensions`` =
     ///
     /// ## Parameters
     ///
-    ///  * `dataString` - Specifies the input string containing the CSV
+    ///  * `csvString` - Specifies the input string containing the CSV
     ///  * `hasHeaders` - Specifies whether the input CSV string has header row
     ///  * `inferTypes` - Specifies whether the method should attempt to infer types
     ///    of columns automatically (set this to `false` if you want to specify schema)

--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -1,4 +1,4 @@
-﻿namespace Deedle
+namespace Deedle
 
 // ------------------------------------------------------------------------------------------------
 // Utilities that use reflection (flattening records etc.)
@@ -494,6 +494,10 @@ module internal FrameUtils =
     let rowIndex = Index.ofKeys (Array.init length id)
     Frame(rowIndex, columnIndex, Vector.ofValues columns, IndexBuilder.Instance, VectorBuilder.Instance)
 
+  /// Load data from a string representing a UTF8-encoded CSV file using F# Data API
+  let readString (csvString:string) hasHeaders inferTypes inferRows schema (missingValues:string[] option) separators culture maxRows preferOptions =
+    let stream =  new MemoryStream(Text.Encoding.UTF8.GetBytes(csvString))
+    readCsv (new StreamReader(stream)) hasHeaders inferTypes inferRows schema (missingValues:string[] option) separators culture maxRows preferOptions
 
   /// Create data frame from a sequence of values using
   /// projections that return column/row keys and the value

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -34,6 +34,11 @@ let msftNoHeaders() =
   let data = System.Text.Encoding.UTF8.GetBytes(noHeaders)
   Frame.ReadCsv(new IO.MemoryStream(data), false, inferRows=10)
 
+let msftString() =
+  let csvString = IO.File.ReadAllText(__SOURCE_DIRECTORY__ + "/data/MSFT.csv")
+  Frame.ReadCsvString(csvString, inferRows=10)
+  |> Frame.indexRowsDate "Date"
+
 [<Test>]
 let ``Can create empty data frame and empty series`` () =
   let f : Frame<int, int> = frame []
@@ -41,6 +46,12 @@ let ``Can create empty data frame and empty series`` () =
   s.KeyCount |> shouldEqual 0
   f.ColumnCount |> shouldEqual 0
   f.RowCount |> shouldEqual 0
+
+[<Test>]
+let ``Can read MSFT data from CSV string`` () =
+  let df = msftString()
+  df.RowKeys |> Seq.length |> shouldEqual 6527
+  df.ColumnKeys |> Seq.length |> shouldEqual 6
 
 [<Test>]
 let ``Can read MSFT data from CSV file`` () =


### PR DESCRIPTION
This PR adds a Frame extension that can read CSV from a string. 

Currently, two extra steps are needed to do that: reading the bytes from the string, and passing a `MemoryStream` based on that to `Frame.ReadCsv`:

```fsharp
let byteArray = Encoding.UTF8.GetBytes(dataString)
use stream = new MemoryStream(byteArray)
Frame.ReadCsv(stream,true,separators=",")
```

### Why add this?

While this saves 'only' 2 LOC in scripts, this is a common operation when getting data via HTTP requests and therefore justifies the addition IMHO. This happens often when analyzing data from online sources. Examples where i use it can be seen in the [Plotly.NET docs](https://plotly.net/5_0_choropleth-map.html#Using-GeoJSON)

I added a test based on the tests already implemented. If i should add more or change something, please let m know ;)