### PR TITLE
Minor code clean-up

### DIFF
--- a/docs/content/samples/presidents.fsx
+++ b/docs/content/samples/presidents.fsx
@@ -85,7 +85,7 @@ let presidentTerms =
     if string pos.``Basic title`` = "President" then
       // Get start and end year of the position
       let starty = DateTime.Parse(pos.From).Year
-      let endy = if pos.To = null then 2013 else
+      let endy = if isNull pos.To then 2013 else
                    DateTime.Parse(pos.To).Year
       // Get their party
       let dem = pres.Party |> Seq.exists (fun p -> p.Party.Name = "Democratic Party")

--- a/docs/tools/formatters.fsx
+++ b/docs/tools/formatters.fsx
@@ -63,7 +63,7 @@ open FSharp.Charting.ChartTypes
 /// Extract values from any series using reflection
 let (|SeriesValues|_|) (value:obj) = 
   let iser = value.GetType().GetInterface("ISeries`1")
-  if iser <> null then
+  if not (isNull iser) then
     let keys = value.GetType().GetProperty("Keys").GetValue(value) :?> System.Collections.IEnumerable
     let vector = value.GetType().GetProperty("Vector").GetValue(value) :?> IVector
     Some(Seq.zip (Seq.cast<obj> keys) vector.ObjectSequence)

--- a/src/Deedle/Common/BinomialHeap.fs
+++ b/src/Deedle/Common/BinomialHeap.fs
@@ -1,4 +1,4 @@
-﻿/// Purely functional Binomial Heap implementation
+/// Purely functional Binomial Heap implementation
 /// Based on: http://cs.hubfs.net/topic/None/56608
 ///
 /// Characteristics:
@@ -40,7 +40,7 @@ module BinomialHeap =
     { Comparer = comparer; Heap = [] }
 
   /// Returns true when the specified heap is emtpy
-  let isEmpty heap = heap.Heap = []
+  let isEmpty heap = List.isEmpty heap.Heap
 
   /// Returns the rank of the specified tree node
   let internal rank (Node (r,_,_)) = r

--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -820,7 +820,7 @@ module Seq =
       // Walk over all windows; use 'f' to determine if the item
       // should be added - if so, add it, otherwise yield window
       let win = ref windows.First
-      while win.Value <> null do
+      while not (isNull win.Value) do
         let start, items = win.Value.Value
         let next = win.Value.Next
         if f start v then win.Value.Value <- start, v::items
@@ -1004,7 +1004,7 @@ module Seq =
       // Walk over all windows; use 'f' to determine if the item
       // should be added - if so, add it, otherwise yield window
       let win = ref windows.First
-      while win.Value <> null do
+      while not (isNull win.Value) do
         let value, startIdx, endIdx = win.Value.Value
         let next = win.Value.Next
         if f value v then win.Value.Value <- value, startIdx, !index
@@ -1467,7 +1467,7 @@ module Convert =
         else System.Convert.ChangeType(value, typeof<'T>) :?> 'T
     | ConversionKind.Safe ->
         if value :? 'T then value :?> 'T
-        elif value <> null then
+        elif not (isNull value) then
           match sourcesByTarget.TryGetValue(typeof<'T>) with
           | true, sources when sources.ContainsKey(value.GetType()) ->
               System.Convert.ChangeType(value, typeof<'T>) :?> 'T

--- a/src/Deedle/FSharp.Data/CommonRuntime/IO.fs
+++ b/src/Deedle/FSharp.Data/CommonRuntime/IO.fs
@@ -1,4 +1,4 @@
-﻿/// Helper functions called from the generated code for working with files
+/// Helper functions called from the generated code for working with files
 module FSharp.Data.Runtime.IO
 
 open System
@@ -7,6 +7,7 @@ open System.IO
 open System.Text
 open FSharp.Data
 
+[<Struct>]
 type internal UriResolutionType =
     | DesignTime
     | Runtime

--- a/src/Deedle/FSharp.Data/CommonRuntime/NameUtils.fs
+++ b/src/Deedle/FSharp.Data/CommonRuntime/NameUtils.fs
@@ -42,11 +42,9 @@ let nicePascalName (s:string) =
     | Upper _ -> consume from true (i + 1)
     | Lower _ -> consume from false (i + 1)
     | _ ->
-        let r1 = struct (from, i)
-        let r2 = restart (i + 1)
         seq {
-          yield r1
-          yield! r2
+          yield struct (from, i)
+          yield! restart (i + 1)
         }
   // Consume are letters of the same kind (either all lower or all upper)
   and consume from takeUpper i = 
@@ -54,18 +52,14 @@ let nicePascalName (s:string) =
     | false, Lower _ -> consume from takeUpper (i + 1)
     | true, Upper _ -> consume from takeUpper (i + 1)
     | true, Lower _ ->
-        let r1 = struct (from, (i - 1))
-        let r2 = restart (i - 1)
         seq {
-          yield r1
-          yield! r2
+          yield struct (from, (i - 1))
+          yield! restart (i - 1)
         }
     | _ ->
-        let r1 = struct(from, i)
-        let r2 = restart i
         seq {
-          yield r1
-          yield! r2 }
+          yield struct(from, i)
+          yield! restart i }
 
   // Split string into segments and turn them to PascalCase
   seq { for i1, i2 in restart 0 do

--- a/src/Deedle/FSharp.Data/CommonRuntime/StructuralInference.fs
+++ b/src/Deedle/FSharp.Data/CommonRuntime/StructuralInference.fs
@@ -303,7 +303,7 @@ let parseUnitOfMeasure (provider:IUnitsOfMeasureProvider) (str:string) =
             if str.EndsWith suffix then
                 let baseUnitStr = str.[..str.Length - suffix.Length - 1]
                 let baseUnit = provider.SI baseUnitStr
-                if baseUnit = null then
+                if isNull baseUnit then
                     None
                 else
                     baseUnit |> trans provider |> Some
@@ -313,4 +313,4 @@ let parseUnitOfMeasure (provider:IUnitsOfMeasureProvider) (str:string) =
     | Some _ -> unit
     | None ->
         let unit = provider.SI str
-        if unit = null then None else Some unit
+        if isNull unit then None else Some unit

--- a/src/Deedle/FSharp.Data/CommonRuntime/TextRuntime.fs
+++ b/src/Deedle/FSharp.Data/CommonRuntime/TextRuntime.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharp.Data.Runtime
+namespace FSharp.Data.Runtime
 
 open System
 open System.Globalization
@@ -19,7 +19,7 @@ type TextRuntime =
     then CultureInfo.InvariantCulture
     else
       let mutable cache = TextRuntime.cultureInfoCache
-      if cache = null then
+      if isNull cache then
         cache                         <- Collections.Generic.Dictionary<string, CultureInfo> ()
         TextRuntime.cultureInfoCache  <- cache
       match cache.TryGetValue cultureStr with

--- a/src/Deedle/FSharp.Data/Net/Http.fs
+++ b/src/Deedle/FSharp.Data/Net/Http.fs
@@ -1199,7 +1199,7 @@ module private HttpHelpers =
             source.Dispose ()
         }
 
-    let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e -> false
+    let runningOnMono = try not(isNull (System.Type.GetType "Mono.Runtime")) with e -> false
 
     let writeBody (req:HttpWebRequest) (data: Stream) =
         async {
@@ -1212,7 +1212,7 @@ module private HttpHelpers =
     let reraisePreserveStackTrace (e:Exception) =
         try
             let remoteStackTraceString = typeof<exn>.GetField("_remoteStackTraceString", BindingFlags.Instance ||| BindingFlags.NonPublic);
-            if remoteStackTraceString <> null then
+            if not (isNull remoteStackTraceString) then
                 remoteStackTraceString.SetValue(e, e.StackTrace + Environment.NewLine)
         with _ -> ()
         raise e
@@ -1223,7 +1223,7 @@ module private HttpHelpers =
         with
             // If an exception happens, augment the message with the response
             | :? WebException as exn ->
-              if exn.Response = null then reraisePreserveStackTrace exn
+              if isNull exn.Response then reraisePreserveStackTrace exn
               let responseExn =
                   try
                     let newResponse = new WebResponse(exn.Response)
@@ -1332,7 +1332,7 @@ module private HttpHelpers =
                         return! getResponseAsync req
                     with
                         | :? WebException as exc ->
-                            if exc.Response <> null then
+                            if not (isNull exc.Response) then
                                return exc.Response
                             else
                                 reraisePreserveStackTrace exc
@@ -1601,14 +1601,14 @@ type Http private() =
             let cookies = CookieHandling.getCookiesAndManageCookieContainer uri resp.ResponseUri headers cookieContainer
                                                                             addCookiesFromHeadersToCookieContainer (defaultArg silentCookieErrors false)
 
-            let contentType = if resp.ContentType = null then "application/octet-stream" else resp.ContentType
+            let contentType = if isNull resp.ContentType then "application/octet-stream" else resp.ContentType
 
             let statusCode, characterSet =
                 match resp with
                 | :? HttpWebResponse as resp -> int resp.StatusCode, resp.CharacterSet
                 | _ -> 0, ""
 
-            let characterSet = if characterSet = null then "" else characterSet
+            let characterSet = if isNull characterSet then "" else characterSet
 
             let stream = resp.GetResponseStream()
 

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -1662,8 +1662,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
           |> Seq.zip offsets                                // seq of (srcloc, label)
           |> Seq.zip frame.RowKeys                          // seq of (rowkey, (srcloc, label))
           |> Seq.groupBy (fun (rk, (i, l)) -> l)            // seq of (label, seq of (rowkey, (srcloc, label)))
-          |> Seq.map (fun (k, s) -> s)                      // seq of (seq of (rowkey, (srcloc, label)))
-          |> Seq.concat                                     // seq of (rowkey, (srcloc, label))
+          |> Seq.collect (fun (k, s) -> s)                  // seq of (rowkey, (srcloc, label))
           |> Seq.zip offsets                                // seq of (dstloc, (rowkey, (srcloc, label)))
           |> Seq.map (fun (dst, (rowkey, (src, grp))) ->
              (grp, rowkey), (dst, src))                     // seq of (label, rowkey), (dstloc, srcloc)

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -96,7 +96,7 @@ type Frame =
       (if inferTypes.HasValue then Some inferTypes.Value else None)
       (if inferRows.HasValue then Some inferRows.Value else None)
       (Some schema) (Some missingValues)
-      (if separators = null then None else Some separators) (Some culture)
+      (if isNull separators then None else Some separators) (Some culture)
       (if maxRows.HasValue then Some maxRows.Value else None)
       (Some preferOptions)
 
@@ -137,7 +137,7 @@ type Frame =
       (if inferTypes.HasValue then Some inferTypes.Value else None)
       (if inferRows.HasValue then Some inferRows.Value else None)
       (Some schema) (Some missingValues)
-      (if separators = null then None else Some separators) (Some culture)
+      (if isNull separators then None else Some separators) (Some culture)
       (if maxRows.HasValue then Some maxRows.Value else None)
       (if preferOptions.HasValue then Some preferOptions.Value else None)
 
@@ -979,7 +979,7 @@ type FrameExtensions =
   /// [category:Data structure manipulation]
   [<Extension>]
   static member Nest(frame:Frame<Tuple<'TRowKey1, 'TRowKey2>, 'TColumnKey>) =
-    frame |> Frame.mapRowKeys (fun t -> t) |> Frame.nest
+    frame |> Frame.mapRowKeys id |> Frame.nest
 
   /// Given a data frame whose row index has two levels, create a series
   /// whose keys are the unique results of the keyselector projection, and
@@ -1021,7 +1021,7 @@ type FrameExtensions =
   [<Extension>]
   static member SaveCsv(frame:Frame<'R, 'C>, writer: TextWriter, [<Optional>] includeRowKeys, [<Optional>] keyNames, [<Optional>] separator, [<Optional>] culture) =
     let separator = if separator = '\000' then None else Some separator
-    let culture = if culture = null then None else Some culture
+    let culture = if isNull culture then None else Some culture
     let keyNames = if keyNames = Unchecked.defaultof<_> then None else Some keyNames
     FrameUtils.writeCsv (writer) None separator culture (Some includeRowKeys) keyNames frame
 
@@ -1042,7 +1042,7 @@ type FrameExtensions =
   [<Extension>]
   static member SaveCsv(frame:Frame<'R, 'C>, path:string, [<Optional>] includeRowKeys, [<Optional>] keyNames, [<Optional>] separator, [<Optional>] culture) =
     let separator = if separator = '\000' then None else Some separator
-    let culture = if culture = null then None else Some culture
+    let culture = if isNull culture then None else Some culture
     let keyNames = if keyNames = Unchecked.defaultof<_> then None else Some keyNames
     use writer = new StreamWriter(path)
     FrameUtils.writeCsv writer (Some path) separator culture (Some includeRowKeys) keyNames frame
@@ -1064,7 +1064,7 @@ type FrameExtensions =
   static member SaveCsv(frame:Frame<'R, 'C>, path:string, keyNames, [<Optional>] separator, [<Optional>] culture) =
     use writer = new StreamWriter(path)
     let separator = if separator = '\000' then None else Some separator
-    let culture = if culture = null then None else Some culture
+    let culture = if isNull culture then None else Some culture
     FrameUtils.writeCsv writer (Some path) separator culture (Some true) (Some keyNames) frame
 
   /// Returns the data of the frame as a .NET `DataTable` object. The column keys are
@@ -1395,7 +1395,7 @@ type FrameExtensions =
   [<Extension; Obsolete("Use overload taking TextWriter instead")>]
   static member SaveCsv(frame:Frame<'R, 'C>, stream:Stream, [<Optional>] includeRowKeys, [<Optional>] keyNames, [<Optional>] separator, [<Optional>] culture) =
     let separator = if separator = '\000' then None else Some separator
-    let culture = if culture = null then None else Some culture
+    let culture = if isNull culture then None else Some culture
     let keyNames = if keyNames = Unchecked.defaultof<_> then None else Some keyNames
     use writer = new StreamWriter(stream)
     FrameUtils.writeCsv (writer) None separator culture (Some includeRowKeys) keyNames frame

--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -104,7 +104,7 @@ module internal Reflection =
 
   /// Given value, return names, types and values of all its IDictionary contents (or None)
   let expandDictionary (value:obj) =
-    if value = null then None else
+    if isNull value then None else
     match value with
     | :? ISeries<string> as sstr ->
         seq { for key in sstr.Index.Keys do
@@ -231,7 +231,7 @@ module internal Reflection =
   /// implements the interface, but we do not know it statically)
   let convertRecordSequenceUntyped(data:System.Collections.IEnumerable) =
     let seqTy = data.GetType().GetInterface("System.Collections.Generic.IEnumerable`1")
-    if seqTy = null then invalidOp "convertRecordSequenceUntyped: Argument must implement seq<T>."
+    if isNull seqTy then invalidOp "convertRecordSequenceUntyped: Argument must implement seq<T>."
     let argTy = seqTy.GetGenericArguments().[0]
     let bindFlags = BindingFlags.NonPublic ||| BindingFlags.Static ||| BindingFlags.Public
     let mi = typeof<ConvertRecordHelper>.GetMethod("ConvertRecordSequence", bindFlags).MakeGenericMethod(argTy)
@@ -276,7 +276,7 @@ module internal FrameUtils =
   // Create flat headers (if there is a hierarchical column index)
   let flattenKeys keys =
     keys |> Seq.map (fun objs ->
-      objs |> Seq.map (fun o -> if o = null then "" else o.ToString())
+      objs |> Seq.map (fun o -> if isNull o then "" else o.ToString())
             |> String.concat " - ")
 
   /// Store data frame to a CSV file using the specified information
@@ -419,12 +419,12 @@ module internal FrameUtils =
     // from C#, we get `Some default(T)` and so we need to check for both here!
     let inferRows = defaultArg inferRows 100
     let schema = defaultArg schema ""
-    let schema = if schema = null then "" else schema
+    let schema = if isNull schema then "" else schema
     let culture = defaultArg culture ""
-    let culture = if culture = null then "" else culture
+    let culture = if isNull culture then "" else culture
     let cultureInfo = System.Globalization.CultureInfo.GetCultureInfo(culture)
     let missingValues = defaultArg missingValues TextConversions.DefaultMissingValues
-    let missingValues = if missingValues = null then TextConversions.DefaultMissingValues else missingValues
+    let missingValues = if isNull missingValues then TextConversions.DefaultMissingValues else missingValues
     let preferOptionals = defaultArg preferOptions false
 
     // Default parameters that cannot be overriden (Frames can always contain NAs)

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------
 // A concrete implementation of an index. Represents an index where the values are sto-
 // red in an array (or similar structure) with linearly ordered addresses without holes.
 // --------------------------------------------------------------------------------------
@@ -60,7 +60,7 @@ type LinearIndex<'K when 'K : equality>
   let mutable lookup = null
 
   let ensureLookup () =
-    if lookup = null then
+    if isNull lookup then
       let dict = Dictionary<'K, Address>()
       let mutable idx = 0L
       for k in keys do

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -835,7 +835,7 @@ and
     let ks key =  x.TryGet(key) |> OptionalValue.map (fun v -> keySelector.Invoke(KeyValuePair(key, v)))
     let cmd = indexBuilder.GroupBy(index, ks, VectorConstruction.Return 0)
     let newIndex  = Index.ofKeys (cmd |> ReadOnlyCollection.map fst)
-    let newGroups = cmd |> Seq.map snd |> Seq.map (fun sc ->
+    let newGroups = cmd |> Seq.map (snd >> fun sc ->
         Series(fst sc, vectorBuilder.Build(newIndex.AddressingScheme, snd sc, [| x.Vector |]), vectorBuilder, indexBuilder))
     Series<'TNewKey, _>(newIndex, Vector.ofValues newGroups, vectorBuilder, indexBuilder)
 


### PR DESCRIPTION
Minor code clean-up:
- `x = null` -> `isNull x` because: https://latkin.org/blog/2015/05/18/null-checking-considerations-in-f-its-harder-than-you-think/
- Faster niceName, but when this library is updated to F# 6 (to use ValueSome instead of Some with `[<return:Struct>]` that (and some other parts) can be made better).
