### PR TITLE
Fix deprecated [category:] XML doc syntax and invalid XML in doc comments

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <FsDocsLicenseLink>https://github.com/fslaborg/Deedle/blob/master/LICENSE.md</FsDocsLicenseLink>
     <FsDocsReleaseNotesLink>https://github.com/fslaborg/Deedle/blob/master/RELEASE_NOTES.md</FsDocsReleaseNotesLink>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <WarnOn>3390</WarnOn>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />

--- a/docs/series.fsx
+++ b/docs/series.fsx
@@ -358,7 +358,7 @@ adjust $ sample.Diff(1)
 
 Many of the time series operations can be applied to entire data frames as well:
 *)
-/// Multiply all numeric columns by a given constant
+// Multiply all numeric columns by a given constant
 alignedDf * 0.65
 
 // Sum each column and divide results by a constant

--- a/src/Deedle.Math/Extensions.fs
+++ b/src/Deedle.Math/Extensions.fs
@@ -6,7 +6,7 @@ open Deedle
 
 /// Extension of Frame<'R, 'C>
 ///
-/// [category:Matrix conversions and operators]
+/// <category>Matrix conversions and operators</category>
 [<Extension>]
 type FrameExtensions =
 
@@ -42,7 +42,7 @@ type FrameExtensions =
 
 /// Extension of Series<'C, float>
 ///
-/// [category:Matrix conversions and operators]
+/// <category>Matrix conversions and operators</category>
 [<Extension>]
 type SeriesExtensions =
   /// series multiply frame
@@ -77,7 +77,7 @@ type SeriesExtensions =
 
 /// Extension of Matrix<float>
 ///
-/// [category:Matrix conversions and operators]
+/// <category>Matrix conversions and operators</category>
 [<Extension>]
 type MatrixExtensions =
   /// matrix multiply frame
@@ -112,7 +112,7 @@ type MatrixExtensions =
 
 /// Extension of Vector<float>
 ///
-/// [category:Vector conversions and operators]
+/// <category>Vector conversions and operators</category>
 [<Extension>]
 type VectorExtensions =
   /// vector multiply frame

--- a/src/Deedle.Math/Extensions.fs
+++ b/src/Deedle.Math/Extensions.fs
@@ -4,7 +4,7 @@ open System.Runtime.CompilerServices
 open MathNet.Numerics.LinearAlgebra
 open Deedle
 
-/// Extension of Frame<'R, 'C>
+/// Extension of <c>Frame&lt;'R, 'C&gt;</c>
 ///
 /// <category>Matrix conversions and operators</category>
 [<Extension>]
@@ -40,7 +40,7 @@ type FrameExtensions =
   static member ToMatrix (df:Frame<'R, 'C>) =
     Matrix.ofFrame df
 
-/// Extension of Series<'C, float>
+/// Extension of <c>Series&lt;'C, float&gt;</c>
 ///
 /// <category>Matrix conversions and operators</category>
 [<Extension>]

--- a/src/Deedle.Math/Finance.fs
+++ b/src/Deedle.Math/Finance.fs
@@ -6,12 +6,12 @@ open MathNet.Numerics.LinearAlgebra
 
 /// Financial analysis
 ///
-/// [category:Financial Analysis]
+/// <category>Financial Analysis</category>
 type Finance =
 
   /// Exponentially weighted moving volatility on series
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmVol (x:Series<'R, float>, ?com, ?span, ?halfLife, ?alpha) =
     // Return to RiskMetrics: The Evolution of a Standard
     // https://www.msci.com/documents/10199/dbb975aa-5dc2-4441-aa2d-ae34ab5f0945
@@ -34,7 +34,7 @@ type Finance =
 
   /// Exponentially weighted moving volatility on frame
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmVol (df:Frame<'R, 'C>, ?com, ?span, ?halfLife, ?alpha) =
     let alpha = StatsInternal.ewDecay(com, span, halfLife, alpha)
     df
@@ -50,7 +50,7 @@ type Finance =
 
   /// Exponentially weighted moving variance on frame
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmVar (df:Frame<'R, 'C>, ?com, ?span, ?halfLife, ?alpha) =
     let alpha = StatsInternal.ewDecay(com, span, halfLife, alpha)
     Finance.ewmVol(df, alpha = alpha)
@@ -58,7 +58,7 @@ type Finance =
 
   /// Exponentially weighted moving covariance matrix
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmCovMatrix (df:Frame<'R, 'C>, ?com, ?span, ?halfLife, ?alpha) =
     // Return to RiskMetrics: The Evolution of a Standard
     // https://www.msci.com/documents/10199/dbb975aa-5dc2-4441-aa2d-ae34ab5f0945
@@ -78,7 +78,7 @@ type Finance =
 
   /// Exponentially weighted moving covariance frame
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmCov (df:Frame<'R, 'C>, ?com, ?span, ?halfLife, ?alpha) =
     let alpha = StatsInternal.ewDecay(com, span, halfLife, alpha)
     Finance.ewmCovMatrix(df, alpha = alpha)
@@ -86,7 +86,7 @@ type Finance =
 
   /// Exponentially weighted moving correlation matrix
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmCorrMatrix (df:Frame<'R, 'C>, ?com, ?span, ?halfLife, ?alpha) =
     let alpha = StatsInternal.ewDecay(com, span, halfLife, alpha)
     Finance.ewmCov(df, alpha = alpha)
@@ -94,7 +94,7 @@ type Finance =
 
   /// Exponentially weighted moving correlation frame
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmCorr (df:Frame<'R, 'C>, ?com, ?span, ?halfLife, ?alpha) =
     let alpha = StatsInternal.ewDecay(com, span, halfLife, alpha)
     Finance.ewmCov(df, alpha = alpha)

--- a/src/Deedle.Math/Frame.fs
+++ b/src/Deedle.Math/Frame.fs
@@ -4,7 +4,7 @@ open MathNet.Numerics.LinearAlgebra
 
 /// Frame to matrix conversion
 ///
-/// [category:Matrix conversions and operators]
+/// <category>Matrix conversions and operators</category>
 type Frame =
   /// Convert matrix to frame
   ///

--- a/src/Deedle.Math/LinearAlgebra.fs
+++ b/src/Deedle.Math/LinearAlgebra.fs
@@ -5,7 +5,7 @@ open Deedle
 
 /// Linear algebra on frame using MathNet.Numerics library.
 ///
-/// [category:Linear Algebra]
+/// <category>Linear Algebra</category>
 type LinearAlgebra =
   /// Transpose.
   /// Performance is faster than generic Frame.transpose as it only applies to frame of float values
@@ -168,76 +168,76 @@ type LinearAlgebra =
 
 /// Matrix conversions and operators between Frame and Series
 ///
-/// [category:Matrix conversions and operators]
+/// <category>Matrix conversions and operators</category>
 type Matrix =
 
   /// Convert frame to matrix
   ///
-  /// [category: Conversions]
+  /// <category>Conversions</category>
   static member ofFrame df =
     df |> Frame.toMatrix
 
   /// Convert matrix to frame
   ///
-  /// [category: Conversions]
+  /// <category>Conversions</category>
   static member toFrame (rows: 'R seq) (cols: 'C seq) (m:Matrix<float>) =
     m |> Frame.ofMatrix rows cols
 
   /// frame multiply matrix
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (df:Frame<'R, 'C>, m2:Matrix<float>) =
     let m1 = df |> Frame.toMatrix
     m1 * m2 |> Frame.ofMatrix df.RowKeys df.RowKeys
 
   /// matrix multiply frame
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (m:Matrix<float>, df:Frame<'R, 'C>) =
     let m2 = df |> Frame.toMatrix
     m * m2
 
   /// vector multiply frame
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (v:Vector<float>, df:Frame<'R, 'C>) =
     let m = df |> Frame.toMatrix
     v * m
 
   /// frame multiply vector
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (df:Frame<'R, 'C>, v:Vector<float>) =
     let m = df |> Frame.toMatrix
     m * v |> Series.ofVector df.RowKeys
 
   /// series multiply matrix
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (s:Series<'K, float>, m:Matrix<float>) =
     (Series.toVector s) * m
 
   /// matrix multiply series
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (m:Matrix<float>, s:Series<'K, float>) =
     m * (Series.toVector s)
 
   /// vector multiply series
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (v:Vector<float>, s:Series<'R, float>) =
     v * (Series.toVector s)
 
   /// series multiply vector
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (s:Series<'R, float>, v:Vector<float>) =
     (Series.toVector s) * v
 
   /// frame multiply frame
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (df1:Frame<'R0, 'C>, df2:Frame<'C, 'R1>) =
     let set1 = df1.ColumnKeys |> Set.ofSeq
     let set2 = df2.RowKeys |> Set.ofSeq
@@ -250,7 +250,7 @@ type Matrix =
 
   /// frame multiply series
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (df:Frame<'R, 'C>, s:Series<'C, float>) =
     let set1 = df.ColumnKeys |> Set.ofSeq
     let set2 = s.Keys |> Set.ofSeq
@@ -265,7 +265,7 @@ type Matrix =
 
   /// series multiply frame
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (s:Series<'C, float>, df:Frame<'R, 'C>) =
     let set1 = s.Keys |> Set.ofSeq
     let set2 = df.ColumnKeys |> Set.ofSeq
@@ -280,7 +280,7 @@ type Matrix =
 
   /// series multiply series
   ///
-  /// [category: Matrix multiplication]
+  /// <category>Matrix multiplication</category>
   static member dot (s1:Series<'C, float>, s2:Series<'C, float>) =
     let v1 = Series.toVector s1
     let v2 = Series.toVector s2

--- a/src/Deedle.Math/Stats.fs
+++ b/src/Deedle.Math/Stats.fs
@@ -32,7 +32,7 @@ type StatsInternal =
 
 /// Correlation method (Pearson or Spearman)
 ///
-/// [category:Statistical Analysis]
+/// <category>Statistical Analysis</category>
 type CorrelationMethod =
   /// Pearson correlation
   | Pearson = 0
@@ -41,11 +41,11 @@ type CorrelationMethod =
 
 /// Statistical analysis using MathNet.Numerics
 ///
-/// [category:Statistical Analysis]
+/// <category>Statistical Analysis</category>
 type Stats =
   /// Exponentially weighted moving average on series
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmMean (x:Series<'R, float>, ?com, ?span, ?halfLife, ?alpha) =
     let alpha = StatsInternal.ewDecay(com, span, halfLife, alpha)
     let data =
@@ -70,7 +70,7 @@ type Stats =
 
   /// Exponentially weighted moving average on frame
   ///
-  /// [category: Exponentially Weighted Moving]
+  /// <category>Exponentially Weighted Moving</category>
   static member ewmMean (df:Frame<'R, 'C>, ?com, ?span, ?halfLife, ?alpha) =
     let alpha = StatsInternal.ewDecay(com, span, halfLife, alpha)
     df
@@ -80,7 +80,7 @@ type Stats =
 
   /// Convert covariance matrix to standard deviation series and correlation frame
   ///
-  /// [category: Correlation and Covariance]
+  /// <category>Correlation and Covariance</category>
   static member cov2Corr (covFrame:Frame<'C, 'C>) =
     let cov = Matrix.ofFrame covFrame
     let keys = covFrame.RowKeys |> Array.ofSeq
@@ -95,7 +95,7 @@ type Stats =
 
   /// Convert standard deviation series and correlation frame to covariance frame
   ///
-  /// [category: Correlation and Covariance]
+  /// <category>Correlation and Covariance</category>
   static member corr2Cov(sigmaSeries:Series<'C, float>, corrFrame:Frame<'C, 'C>) =
     let sigma = sigmaSeries.ToVector()
     let corr = corrFrame.ToMatrix()
@@ -105,7 +105,7 @@ type Stats =
 
   /// Correlation matrix
   ///
-  /// [category: Correlation and Covariance]
+  /// <category>Correlation and Covariance</category>
   static member corrMatrix (df:Frame<'R, 'C>, ?method:CorrelationMethod) =
     let method = defaultArg method CorrelationMethod.Pearson
     let arr =
@@ -120,7 +120,7 @@ type Stats =
 
   /// Correlation frame
   ///
-  /// [category: Correlation and Covariance]
+  /// <category>Correlation and Covariance</category>
   static member corr (df:Frame<'R, 'C>, ?method:CorrelationMethod) =
     let method = defaultArg method CorrelationMethod.Pearson
     Stats.corrMatrix(df, method)
@@ -128,7 +128,7 @@ type Stats =
 
   /// Correlation of two series
   ///
-  /// [category: Correlation and Covariance]
+  /// <category>Correlation and Covariance</category>
   static member corr (s1:Series<'K, float>, s2:Series<'K, float>, ?method:CorrelationMethod) =
     let method = defaultArg method CorrelationMethod.Pearson
     let df = [1, s1; 2, s2] |> Frame.ofColumns
@@ -136,7 +136,7 @@ type Stats =
 
   /// Covariance matrix
   ///
-  /// [category: Correlation and Covariance]
+  /// <category>Correlation and Covariance</category>
   static member covMatrix (df:Frame<'R, 'C>) =
     // Treat nan as zero, the same as MATLAB
     let corr = Stats.corrMatrix(df) |> Matrix.map(fun x -> if Double.IsNaN x then 0. else x)
@@ -146,7 +146,7 @@ type Stats =
 
   /// Covariance frame
   ///
-  /// [category: Correlation and Covariance]
+  /// <category>Correlation and Covariance</category>
   static member cov (df:Frame<'R, 'C>) =
     df
     |> Stats.covMatrix
@@ -154,7 +154,7 @@ type Stats =
 
   /// Quantile
   ///
-  /// [category: Descriptive Statistics]
+  /// <category>Descriptive Statistics</category>
   static member inline quantile (series:Series<'R, 'V>, tau:float, ?definition:QuantileDefinition) =
     let definition = defaultArg definition QuantileDefinition.Excel
     series.Values
@@ -164,7 +164,7 @@ type Stats =
 
   /// Ranks of Series
   ///
-  /// [category: Descriptive Statistics]
+  /// <category>Descriptive Statistics</category>
   static member inline ranks (series:Series<'R, 'V>, ?rankDefinition:RankDefinition) =
     let rankDefinition = defaultArg rankDefinition RankDefinition.Average
     series.Values
@@ -177,7 +177,7 @@ type Stats =
 
   /// Median of Series
   ///
-  /// [category: Descriptive Statistics]
+  /// <category>Descriptive Statistics</category>
   static member inline median (series:Series<'R, 'V>) =
     series.Values
     |> Seq.map float
@@ -186,7 +186,7 @@ type Stats =
 
   /// Median of Frame
   ///
-  /// [category: Descriptive Statistics]
+  /// <category>Descriptive Statistics</category>
   static member median (df:Frame<'R, 'C>) =
     df
     |> Frame.getNumericCols
@@ -194,7 +194,7 @@ type Stats =
 
   /// Quantile of Frame
   ///
-  /// [category: Descriptive Statistics]
+  /// <category>Descriptive Statistics</category>
   static member quantile (df:Frame<'R, 'C>, tau:float, ?definition:QuantileDefinition) =
     let definition = defaultArg definition QuantileDefinition.Excel
     df
@@ -203,7 +203,7 @@ type Stats =
 
   /// Ranks of Frame
   ///
-  /// [category: Descriptive Statistics]
+  /// <category>Descriptive Statistics</category>
   static member ranks (df:Frame<'R, 'C>, ?rankDefinition:RankDefinition) =
     let rankDefinition = defaultArg rankDefinition RankDefinition.Average
     df
@@ -213,7 +213,7 @@ type Stats =
 
   /// Moving standard deviation (parallel implementation)
   ///
-  /// [category: Moving statistics]
+  /// <category>Moving statistics</category>
   static member movingStdDevParallel window (df:Frame<'R, 'C>) =
     let rowKeys = df.RowKeys |> Array.ofSeq
     let len = rowKeys |> Array.length
@@ -226,7 +226,7 @@ type Stats =
 
   /// Moving variance of frame (parallel implementation)
   ///
-  /// [category: Moving statistics]
+  /// <category>Moving statistics</category>
   static member movingVarianceParallel window (df:Frame<'R, 'C>) =
     let rowKeys = df.RowKeys |> Array.ofSeq
     let len = rowKeys |> Array.length
@@ -239,7 +239,7 @@ type Stats =
 
   /// Moving covariance of frame (parallel implementation)
   ///
-  /// [category: Moving statistics]
+  /// <category>Moving statistics</category>
   static member movingCovarianceParallel window (df:Frame<'R, 'C>) =
     let rowKeys = df.RowKeys |> Array.ofSeq
     let len = rowKeys |> Array.length

--- a/src/Deedle/Common/Address.fs
+++ b/src/Deedle/Common/Address.fs
@@ -8,6 +8,7 @@ open System.Linq.Expressions
 // Address type and operations
 // --------------------------------------------------------------------------------------
 
+/// <summary>
 /// An `Address` value is used as an interface between vectors and indices. The index maps
 /// keys of various types to address, which is then used to get a value from the vector.
 ///
@@ -22,6 +23,7 @@ open System.Linq.Expressions
 ///  - In the BigDeedle representation, address is abstracted and comes with
 ///    `AddressOperations` that specifies how to use it (tests use linear
 ///    offset and partitioned representation)
+/// </summary>
 ///
 /// <category>Vectors and indices</category>
 module Addressing =
@@ -31,7 +33,6 @@ module Addressing =
   type Address = int64<address>
   and [<Measure>] address
 
-  [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
   module Address =
     /// Represents an invalid address (which is returned from
     /// optimized lookup functions when they fail)

--- a/src/Deedle/Common/BinomialHeap.fs
+++ b/src/Deedle/Common/BinomialHeap.fs
@@ -10,21 +10,24 @@ namespace Deedle.Internal
 
 open System.Collections.Generic
 
+/// <summary>
 /// Tree where nodes contain values and zero or more child trees.
 /// For each node, we store rank - the number of children
-///
+/// </summary>
 /// <exclude />
 type RankedTree<'T> = Node of int * 'T * RankedTree<'T> list
 
+/// <summary>
 /// Binomial heap stores a list of trees together with custom comparer
-///
+/// </summary>
 /// <exclude />
 type BinomialHeap<'T> =
   { Comparer : IComparer<'T>
     Heap : RankedTree<'T> list }
 
+/// <summary>
 /// Module with functions for working with binomial heaps
-///
+/// </summary>
 /// <exclude />
 module BinomialHeap =
   /// Active pattern that makes it easier to deal with results from IComparer

--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -4,9 +4,11 @@ namespace Deedle
 open System
 open System.Runtime.CompilerServices
 
+/// <summary>
 /// Represents different kinds of type conversions that can be used by Deedle internally.
-/// This is used, for example, when converting `ObjectSeries<'K>` to `Series<'K, 'T>` -
+/// This is used, for example, when converting <c>ObjectSeries&lt;'K&gt;</c> to <c>Series&lt;'K, 'T&gt;</c> -
 /// The conversion kind can be specified as an argument to allow certain conversions.
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 type ConversionKind =
@@ -21,9 +23,11 @@ type ConversionKind =
   | Flexible = 2
 
 
+/// <summary>
 /// Thrown when a value at the specified index does not exist in the data frame or series.
 /// This exception is thrown only when the key is defined, but the value is not available,
 /// in other situations `KeyNotFoundException` is thrown
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 type MissingValueException(key:obj, message) =
@@ -41,16 +45,18 @@ type Diff<'T> =
     | Remove v -> sprintf "-%A" v
     | Add v -> sprintf "+%A" v
 
+/// <summary>
 /// Value type that represents a potentially missing value. This is similar to
-/// `System.Nullable<T>`, but does not restrict the contained value to be a value
+/// <c>System.Nullable&lt;T&gt;</c>, but does not restrict the contained value to be a value
 /// type, so it can be used for storing values of any types. When obtained from
-/// `DataFrame<R, C>` or `Series<K, T>`, the `Value` will never be `Double.NaN` or `null`
+/// <c>DataFrame&lt;R, C&gt;</c> or <c>Series&lt;K, T&gt;</c>, the <c>Value</c> will never be <c>Double.NaN</c> or <c>null</c>
 /// (but this is not, in general, checked when constructing the value).
 ///
 /// The type is only used in C#-friendly API. F# operations generally use expose
-/// standard F# `option<T>` type instead. However, there the `OptionalValue` module
-/// contains helper functions for using this type from F# as well as `Missing` and
-/// `Present` active patterns.
+/// standard F# <c>option&lt;T&gt;</c> type instead. However, there the <c>OptionalValue</c> module
+/// contains helper functions for using this type from F# as well as <c>Missing</c> and
+/// <c>Present</c> active patterns.
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 [<Struct; CustomEquality; NoComparison>]
@@ -99,17 +105,19 @@ type OptionalValue<'T> private (hasValue:bool, value:'T) =
         | _ -> false
     | _ -> false
 
-/// Non-generic type that makes it easier to create `OptionalValue<T>` values
+/// <summary>
+/// Non-generic type that makes it easier to create <c>OptionalValue&lt;T&gt;</c> values
 /// from C# by benefiting the type inference for generic method invocations.
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 type OptionalValue =
-  /// Creates an `OptionalValue<T>` from a nullable value of type `T?`
+  /// Creates an <c>OptionalValue&lt;T&gt;</c> from a nullable value of type <c>T?</c>
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member OfNullable(v:Nullable<'T>) =
     if v.HasValue then OptionalValue(v.Value) else OptionalValue<'T>.Missing
 
-  /// Creates an `OptionalValue<'T>` that contains a value `v`
+  /// Creates an <c>OptionalValue&lt;'T&gt;</c> that contains a value <c>v</c>
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member Create(v) =
     OptionalValue(v)
@@ -118,11 +126,13 @@ type OptionalValue =
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member Empty<'T>() = OptionalValue<'T>.Missing
 
+/// <summary>
 /// Represents a value or an exception. This type is used by functions such as
 /// `Series.tryMap` and `Frame.tryMap` to capture the result of a lambda function,
 /// which may be either a value or an exception. The type is a discriminated union,
 /// so it can be processed using F# pattern matching, or using `Value`, `HasValue`
 /// and `Exception` properties
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 type TryValue<'T> =
@@ -148,18 +158,23 @@ type TryValue<'T> =
   override x.ToString() =
     match x with Success v -> v.ToString() | _ -> "<error>"
 
-/// A type alias for the `TryValue<T>` type. The type alias can be used
+/// <summary>
+/// A type alias for the <c>TryValue&lt;T&gt;</c> type. The type alias can be used
 /// to make F# type declarations that explcitly handle exceptions more succinct.
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 type 'T tryval = TryValue<'T>
 
-/// A type alias for the `OptionalValue<T>` type. The type alias can be used
+/// <summary>
+/// A type alias for the <c>OptionalValue&lt;T&gt;</c> type. The type alias can be used
 /// to make F# type definitions that use optional values directly more succinct.
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 type 'T opt = OptionalValue<'T>
 
+/// <summary>
 /// Represents different behaviors of key lookup in series. For unordered series,
 /// the only available option is `Lookup.Exact` which finds the exact key - methods
 /// fail or return missing value if the key is not available in the index. For ordered
@@ -167,6 +182,7 @@ type 'T opt = OptionalValue<'T>
 /// a value. `Lookup.Smaller` searches for the first smaller key. The options
 /// `Lookup.ExactOrGreater` and `Lookup.ExactOrSmaller` finds the exact key (if it is
 /// present) and otherwise search for the nearest larger or smaller key, respectively.
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 [<System.Flags>]
@@ -201,29 +217,32 @@ type Lookup =
 /// `Series.Pairwise`.
 /// </summary>
 /// <example>
+/// <code>
+/// let abc =
+///   [ 1 =&gt; "a"; 2 =&gt; "b"; 3 =&gt; "c" ]
+///   |&gt; Series.ofObservations
 ///
-///     let abc =
-///       [ 1 => "a"; 2 => "b"; 3 => "c" ]
-///       |> Series.ofObservations
+/// // Using 'Forward' the key of the first element is used
+/// abc.Pairwise(direction=Direction.Forward)
+/// // [ 1 =&gt; ("a", "b"); 2 =&gt; ("b", "c") ]
 ///
-///     // Using 'Forward' the key of the first element is used
-///     abc.Pairwise(direction=Direction.Forward)
-///     [fsi:[ 1 => ("a", "b"); 2 => ("b", "c") ]]
-///
-///     // Using 'Backward' the key of the second element is used
-///     abc.Pairwise(direction=Direction.Backward)
-///     [fsi:[ 2 => ("a", "b"); 3 => ("b", "c") ]]
+/// // Using 'Backward' the key of the second element is used
+/// abc.Pairwise(direction=Direction.Backward)
+/// // [ 2 =&gt; ("a", "b"); 3 =&gt; ("b", "c") ]
+/// </code>
 /// </example>
 /// <category>Parameters and results of various operations</category>
 type Direction =
   | Backward = 0
   | Forward = 1
 
+/// <summary>
 /// Represents boundary behaviour for operations such as floating window. The type
 /// specifies whether incomplete windows (of smaller than required length) should be
 /// produced at the beginning (`AtBeginning`) or at the end (`AtEnding`) or
 /// skipped (`Skip`). For chunking, combinations are allowed too - to skip incomplete
 /// chunk at the beginning, use `Boundary.Skip ||| Boundary.AtBeginning`.
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 [<Flags>]
@@ -232,7 +251,9 @@ type Boundary =
   | AtEnding = 2
   | Skip = 4
 
-/// Represents a kind of `DataSegment<T>`. See that type for more information.
+/// <summary>
+/// Represents a kind of <c>DataSegment&lt;T&gt;</c>. See that type for more information.
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 type DataSegmentKind = Complete | Incomplete
@@ -245,17 +266,16 @@ type DataSegmentKind = Complete | Incomplete
 /// size).
 /// </summary>
 /// <example>
-///
 /// For example (using internal `windowed` function):
+/// <code>
+/// open Deedle.Internal
 ///
-///     open Deedle.Internal
-///
-///     Seq.windowedWithBounds 3 Boundary.AtBeginning [ 1; 2; 3; 4 ]
-///     [fsi:  [| DataSegment(Incomplete, [| 1 |])         ]
-///     [fsi:       DataSegment(Incomplete, [| 1; 2 |])    ]
-///     [fsi:       DataSegment(Complete [| 1; 2; 3 |])    ]
-///     [fsi:       DataSegment(Complete [| 2; 3; 4 |]) |] ]
-///
+/// Seq.windowedWithBounds 3 Boundary.AtBeginning [ 1; 2; 3; 4 ]
+/// // [| DataSegment(Incomplete, [| 1 |])         ]
+/// //    DataSegment(Incomplete, [| 1; 2 |])    ]
+/// //    DataSegment(Complete [| 1; 2; 3 |])    ]
+/// //    DataSegment(Complete [| 2; 3; 4 |]) |]
+/// </code>
 /// If you do not need to distinguish the two cases, you can use the `Data` property
 /// to get the array representing the segment data.
 /// </example>
@@ -277,7 +297,9 @@ type DataSegment<'T> =
     else sprintf "DataSegment(%s, %s)" (if x.Kind = Complete then "Complete" else "Incomplete") s
 
 
+/// <summary>
 /// Provides helper functions and active patterns for working with `DataSegment` values
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 module DataSegment =
@@ -313,9 +335,11 @@ module DataSegment =
 // OptionalValue module (to be used from F#)
 // --------------------------------------------------------------------------------------
 
+/// <summary>
 /// Extension methods for working with optional values from C#. These make
 /// it easier to provide default values and convert optional values to
 /// `Nullable` (when the contained value is value type)
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 [<Extension>]
@@ -333,16 +357,17 @@ type OptionalValueExtensions =
   static member OrDefault(opt:OptionalValue<'T>, defaultValue) =
     if opt.HasValue then opt.Value else defaultValue
 
-/// Provides various helper functions for using the `OptionalValue<T>` type from F#
-/// (The functions are similar to those in the standard `Option` module).
+/// <summary>
+/// Provides various helper functions for using the <c>OptionalValue&lt;T&gt;</c> type from F#
+/// (The functions are similar to those in the standard <c>Option</c> module).
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module OptionalValue =
 
-  /// If the `OptionalValue<T>` does not contain a value, then returns a new
-  /// `OptionalValue<R>.Empty`. Otherwise, returns the result of applying the
-  /// function `f` to the value contained in the provided optional value.
+  /// If the <c>OptionalValue&lt;T&gt;</c> does not contain a value, then returns a new
+  /// <c>OptionalValue&lt;R&gt;.Empty</c>. Otherwise, returns the result of applying the
+  /// function <c>f</c> to the value contained in the provided optional value.
   [<CompiledName("Bind")>]
   let inline bind f (input:OptionalValue<'T>) : OptionalValue<'R> =
     if input.HasValue then f input.Value
@@ -1352,8 +1377,8 @@ type IFsiFormattable =
 
 /// <exclude />
 /// An interface implemented by frames that support nice formatting for .NET interactive notebooks
-/// This seems to be needed as you cannot register formatters for Frame<_,_> in .NET interactive
-/// (The `Deedle.Interactive` packages uses this interface for registering custom formatters.)
+/// This seems to be needed as you cannot register formatters for <c>Frame&lt;_,_&gt;</c> in .NET interactive
+/// (The <c>Deedle.Interactive</c> packages uses this interface for registering custom formatters.)
 type IFrameFormattable =
   abstract InteractiveFormat : nRows:int * nCols:int * showColumnTypes:bool -> string [] []
   abstract GetColLevels : unit -> int
@@ -1363,7 +1388,7 @@ type IFrameFormattable =
 
 /// <exclude />
 /// An interface implemented by series that support nice formatting for .NET interactive notebooks
-/// This seems to be needed as you cannot register formatters for Series<_,_> in .NET interactive
+/// This seems to be needed as you cannot register formatters for <c>Series&lt;_,_&gt;</c> in .NET interactive
 /// (The `Deedle.Interactive` packages uses this interface for registering custom formatters.)
 type ISeriesFormattable =
   abstract InteractiveFormat : int -> string [] []

--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -196,10 +196,11 @@ type Lookup =
   | Smaller = 4
 
 
+/// <summary>
 /// Specifies in which direction should we look when performing operations such as
 /// `Series.Pairwise`.
-///
-/// ## Example
+/// </summary>
+/// <example>
 ///
 ///     let abc =
 ///       [ 1 => "a"; 2 => "b"; 3 => "c" ]
@@ -212,8 +213,7 @@ type Lookup =
 ///     // Using 'Backward' the key of the second element is used
 ///     abc.Pairwise(direction=Direction.Backward)
 ///     [fsi:[ 2 => ("a", "b"); 3 => ("b", "c") ]]
-///
-///
+/// </example>
 /// <category>Parameters and results of various operations</category>
 type Direction =
   | Backward = 0
@@ -237,13 +237,14 @@ type Boundary =
 /// <category>Parameters and results of various operations</category>
 type DataSegmentKind = Complete | Incomplete
 
+/// <summary>
 /// Represents a segment of a series or sequence. The value is returned from
 /// various functions that aggregate data into chunks or floating windows. The
 /// `Complete` case represents complete segment (e.g. of the specified size) and
 /// `Boundary` represents segment at the boundary (e.g. smaller than the required
 /// size).
-///
-/// ## Example
+/// </summary>
+/// <example>
 ///
 /// For example (using internal `windowed` function):
 ///
@@ -257,6 +258,7 @@ type DataSegmentKind = Complete | Incomplete
 ///
 /// If you do not need to distinguish the two cases, you can use the `Data` property
 /// to get the array representing the segment data.
+/// </example>
 ///
 /// <category>Parameters and results of various operations</category>
 type DataSegment<'T> =

--- a/src/Deedle/Common/Common.fs
+++ b/src/Deedle/Common/Common.fs
@@ -447,9 +447,10 @@ open Deedle
 open System.Collections.Generic
 open System.Collections.ObjectModel
 
+/// <summary>
 /// An internal exception that is used to handle the case when comparison fails
 /// (even though the type implements IComparable and everything...)
-///
+/// </summary>
 /// <exclude />
 type ComparisonFailedException() =
   inherit Exception()

--- a/src/Deedle/Common/Deque.fs
+++ b/src/Deedle/Common/Deque.fs
@@ -10,11 +10,12 @@ open System.Collections.Generic
 open System.Diagnostics
 open System.Runtime.InteropServices
 
+/// <summary>
 /// Mutable double ended queue that holds elements in a circular array.
 /// The data structure provides O(1) RemoveFirst and RemoveLast. Add is
 /// O(1) when the deque has enough internal capacity, otherwise it extends
 /// the array 2x (so amortized cost is O(1) too).
-///
+/// </summary>
 /// <exclude />
 [<SerializableAttribute>]
 type Deque<'T>(initCapacity : int) =

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -346,8 +346,8 @@ open Deedle.Vectors.ArrayVector
 /// use this functionality to create series that represents e.g. an entire price history
 /// in a database, but only loads data that are actually needed. For more information
 /// see the [lazy data loading tutorial](../lazysource.html).
-///
-/// ## Example
+/// </summary>
+/// <example>
 ///
 /// Assuming we have a function `generate lo hi` that generates data in the specified
 /// `DateTime` range, we can create lazy series as follows:
@@ -360,48 +360,38 @@ open Deedle.Vectors.ArrayVector
 /// The arguments `min` and `max` specfify the complete range of the series. The
 /// function passed to `Create` is called with minimal and maximal required key
 /// (`lo` and `hi`) and with two values that specify boundary behaviour.
-///
+/// </example>
 /// <category>Specialized frame and series types</category>
 type DelayedSeries =
+  /// <summary>
   /// A C#-friendly function that creates lazily loaded series. The method requires
   /// the overall range of the series (smallest and greatest key) and a function that
   /// loads the data. In this overload, the function is a `Func` delegate taking
   /// information about the requested range and returning `Task<T>` that produces the data.
-  ///
-  /// ## Parameters
-  ///
-  ///  - `min` - The smallest key that should be present in the created series.
-  ///  - `min` - The greatests key that should be present in the created series.
-  ///  - `loader` - A delegate which returns a task that loads the data in a specified
-  ///    range. The delegate is called with four arguments specifying the minimal and
-  ///    maximal key and two `BoundaryBehavior` values specifying whether the low and
-  ///    high ranges are inclusive or exclusive.
-  ///
-  /// ## Remarks
-  ///
+  /// </summary>
+  /// <param name="min">The smallest key that should be present in the created series.</param>
+  /// <param name="max">The greatests key that should be present in the created series.</param>
+  /// <param name="loader">A delegate which returns a task that loads the data in a specified range. The delegate is called with four arguments specifying the minimal and maximal key and two `BoundaryBehavior` values specifying whether the low and high ranges are inclusive or exclusive.</param>
+  /// <remarks>
   /// For more information see the [lazy data loading tutorial](../lazysource.html).
   /// The operation calls `loader` (and so creates the tasks) on the thread that is
   /// requesting the result.
+  /// </remarks>
   static member FromValueLoader(min, max, loader:Func<_, _, _, _, Task<seq<KeyValuePair<'K, 'V>>>>) : Series<'K, 'V> =
     DelayedSeries.FromValueLoader(min, max, fun (l, lb) (h, hb)-> Async.AwaitTask (loader.Invoke(l,lb,h,hb)))
 
+  /// <summary>
   /// An F#-friendly function that creates lazily loaded series. The method requires
   /// the overall range of the series (smallest and greatest key) and a function that
   /// loads the data. The function is called with two tuples that specify lower and upper
   /// boundary. It returns an asynchronous workflow that produces the data.
-  ///
-  /// ## Parameters
-  ///
-  ///  - `min` - The smallest key that should be present in the created series.
-  ///  - `min` - The greatests key that should be present in the created series.
-  ///  - `loader` - A function which returns an asynchronous workflow that loads the data in a
-  ///    specified range. The function is called with two tuples consisting of key and
-  ///    `BoundaryBehavior` values. The keys specify lower and upper boundary and
-  ///    `BoundaryBehavior` values can be either `Inclusive` or `Exclusive`.
-  ///
-  /// ## Remarks
-  ///
+  /// </summary>
+  /// <param name="min">The smallest key that should be present in the created series.</param>
+  /// <param name="max">The greatests key that should be present in the created series.</param>
+  /// <param name="loader">A function which returns an asynchronous workflow that loads the data in a specified range. The function is called with two tuples consisting of key and `BoundaryBehavior` values. The keys specify lower and upper boundary and `BoundaryBehavior` values can be either `Inclusive` or `Exclusive`.</param>
+  /// <remarks>
   /// For more information see the [lazy data loading tutorial](../lazysource.html).
+  /// </remarks>
   static member FromValueLoader(min, max, loader:_ -> _ -> Async<seq<KeyValuePair<'K, 'V>>>) : Series<'K, 'V> =
     let vectorBuilder = VectorBuilder.Instance
     let indexBuilder = IndexBuilder.Instance

--- a/src/Deedle/DelayedSeries.fs
+++ b/src/Deedle/DelayedSeries.fs
@@ -341,25 +341,25 @@ open Deedle.Indices
 open Deedle.Internal
 open Deedle.Vectors.ArrayVector
 
+/// <summary>
 /// This type exposes a single static method `DelayedSeries.Create` that can be used for
-/// constructing data series (of type `Series<K, V>`) with lazily loaded data. You can
+/// constructing data series (of type <c>Series&lt;K, V&gt;</c>) with lazily loaded data. You can
 /// use this functionality to create series that represents e.g. an entire price history
 /// in a database, but only loads data that are actually needed. For more information
 /// see the [lazy data loading tutorial](../lazysource.html).
 /// </summary>
 /// <example>
-///
-/// Assuming we have a function `generate lo hi` that generates data in the specified
-/// `DateTime` range, we can create lazy series as follows:
-///
-///     let ls = DelayedSeries.Create(min, max, fun (lo, lob) (hi, hib) ->
-///       async {
-///         printfn "Query: %A - %A" (lo, lob) (hi, hib)
-///         return generate lo hi })
-///
-/// The arguments `min` and `max` specfify the complete range of the series. The
-/// function passed to `Create` is called with minimal and maximal required key
-/// (`lo` and `hi`) and with two values that specify boundary behaviour.
+/// Assuming we have a function <c>generate lo hi</c> that generates data in the specified
+/// <c>DateTime</c> range, we can create lazy series as follows:
+/// <code>
+/// let ls = DelayedSeries.Create(min, max, fun (lo, lob) (hi, hib) -&gt;
+///   async {
+///     printfn "Query: %A - %A" (lo, lob) (hi, hib)
+///     return generate lo hi })
+/// </code>
+/// The arguments <c>min</c> and <c>max</c> specify the complete range of the series. The
+/// function passed to <c>Create</c> is called with minimal and maximal required key
+/// (<c>lo</c> and <c>hi</c>) and with two values that specify boundary behaviour.
 /// </example>
 /// <category>Specialized frame and series types</category>
 type DelayedSeries =
@@ -367,7 +367,7 @@ type DelayedSeries =
   /// A C#-friendly function that creates lazily loaded series. The method requires
   /// the overall range of the series (smallest and greatest key) and a function that
   /// loads the data. In this overload, the function is a `Func` delegate taking
-  /// information about the requested range and returning `Task<T>` that produces the data.
+  /// information about the requested range and returning <c>Task&lt;T&gt;</c> that produces the data.
   /// </summary>
   /// <param name="min">The smallest key that should be present in the created series.</param>
   /// <param name="max">The greatests key that should be present in the created series.</param>

--- a/src/Deedle/FSharp.Data/Csv/CsvExtensions.fs
+++ b/src/Deedle/FSharp.Data/Csv/CsvExtensions.fs
@@ -75,7 +75,6 @@ type StringExtensions =
     | Some g -> g
     | _ -> failwithf "Not a guid: %s" x
 
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 /// Provides the dynamic operator for getting column values by name from CSV rows
 module CsvExtensions =
 

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -22,9 +22,10 @@ open System.Collections.Specialized
 open Microsoft.FSharp.Quotations
 open VectorHelpers
 
+/// <summary>
 /// Represents the underlying (raw) data of the frame in a format that can
 /// be used for exporting data frame to other formats etc. (DataTable, CSV, Excel)
-///
+/// </summary>
 /// <category>Core frame and series types</category>
 type FrameData =
   { /// A sequence of keys for all column. Individual key is an array
@@ -40,20 +41,22 @@ type FrameData =
     /// represent missing data.
     Columns : seq<Type * IVector<obj>> }
 
-/// An empty interface that is implemented by `Frame<'R, 'C>`. The purpose of the
+/// <summary>
+/// An empty interface that is implemented by <c>Frame&lt;'R, 'C&gt;</c>. The purpose of the
 /// interface is to allow writing code that works on arbitrary data frames (you
-/// need to provide an implementation of the `IFrameOperation<'V>` which contains
+/// need to provide an implementation of the <c>IFrameOperation&lt;'V&gt;</c> which contains
 /// a generic method `Invoke` that will be called with the typed data frame).
-///
+/// </summary>
 /// <category>Specialized frame and series types</category>
 type IFrame =
   /// Calls the `Invoke` method of the specified interface `IFrameOperation<'V>`
   /// with the typed data frame as an argument
   abstract Apply : IFrameOperation<'V> -> 'V
 
-/// Represents an operation that can be invoked on `Frame<'R, 'C>`. The operation
+/// <summary>
+/// Represents an operation that can be invoked on <c>Frame&lt;'R, 'C&gt;</c>. The operation
 /// is generic in the type of row and column keys.
-///
+/// </summary>
 /// <category>Specialized frame and series types</category>
 and IFrameOperation<'V> =
   abstract Invoke : Frame<'R, 'C> -> 'V
@@ -192,7 +195,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Column keys are always matched using `Lookup.Exact`, but `lookup` determines lookup for rows.
   /// The parameter `pointwise` can be specified to determine the outcome of unmatched column.
   ///
-  /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
+  /// Once aligned, the call <c>df1.Zip&lt;T&gt;(df2, f)</c> applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
   /// </summary>
@@ -253,7 +256,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// on values of a specified type that are available in both data frames. This overload uses
   /// `JoinKind.Outer` for both columns and rows.
   ///
-  /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
+  /// Once aligned, the call <c>df1.Zip&lt;T&gt;(df2, f)</c> applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
   /// </summary>
@@ -432,8 +435,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let newData = vectorBuilder.Build(newColIndex.AddressingScheme, frameCmd, frameData)
     Frame(newRowIndex, newColIndex, newData, indexBuilder, vectorBuilder)
 
-  /// Piecewise concatenate two frames of string values
-  ///
+  /// <summary>Piecewise concatenate two frames of string values</summary>
   /// <category>Joining, merging and zipping</category>
   member frame.StrConcat(df: Frame<'TRowKey, 'TColumnKey>) =
      frame.Zip<string, string, string>(df, JoinKind.Outer, JoinKind.Outer, Lookup.Exact, true, fun a b -> (+) a b)
@@ -541,7 +543,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Returns a row of the data frame that is located at the specified int offset.
   /// This does not use the row key and directly accesses the frame data. This method
   /// is generic and returns the result as a series containing values of the specified type.
-  /// To get heterogeneous series of type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
+  /// To get heterogeneous series of type <c>ObjectSeries&lt;'TCol&gt;</c>, use the `frame.Rows` property.
   /// If the index is invalid, `ArgumentOutOfRangeException` is thrown. You can get the
   /// matching key at a specified index using `GetRowKeyAt`.
   /// </summary>
@@ -558,7 +560,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Returns a row with the specieifed key wrapped in `OptionalValue`. When the specified key
   /// is not found, the result is `OptionalValue.Missing`. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
-  /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
+  /// type <c>ObjectSeries&lt;'TCol&gt;</c>, use the `frame.Rows` property.
   /// </summary>
   /// <param name="rowKey">Specifies the key of the row to be returned</param>
   /// <category>Accessors and slicing</category>
@@ -573,7 +575,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Returns a row with the specieifed key wrapped in `OptionalValue`. When the specified key
   /// is not found, the result is `OptionalValue.Missing`. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
-  /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
+  /// type <c>ObjectSeries&lt;'TCol&gt;</c>, use the `frame.Rows` property.
   /// </summary>
   /// <param name="rowKey">Specifies the key of the row to be returned</param>
   /// <param name="lookup">Specifies how to find value in a frame with ordered rows when the key does not exactly match (look for nearest available value with the smaller/greater key).</param>
@@ -588,7 +590,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// <summary>
   /// Returns a row with the specieifed key. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
-  /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
+  /// type <c>ObjectSeries&lt;'TCol&gt;</c>, use the `frame.Rows` property.
   /// </summary>
   /// <param name="rowKey">Specifies the key of the row to be returned</param>
   /// <category>Accessors and slicing</category>
@@ -597,7 +599,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// <summary>
   /// Returns a row with the specieifed key. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
-  /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
+  /// type <c>ObjectSeries&lt;'TCol&gt;</c>, use the `frame.Rows` property.
   /// </summary>
   /// <param name="rowKey">Specifies the key of the row to be returned</param>
   /// <param name="lookup">Specifies how to find value in a frame with ordered rows when the key does not exactly match (look for nearest available value with the smaller/greater key).</param>
@@ -651,11 +653,12 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.ToArray2D<'R>(defaultValue) =
     toArray2D<'R> frame.RowCount frame.ColumnCount frame.Data (lazy defaultValue)
 
+  /// <summary>
   /// Returns data of the data frame as a 2D array. The method attempts to convert
   /// all values to the specified type 'R. If the specified type is 'float' or 'double'
   /// then the method automatically uses NaN. For other values, the default value has to
   /// be explicitly specified using another overload.
-  ///
+  /// </summary>
   /// <category>Fancy accessors</category>
   member frame.ToArray2D<'R>() =
     let defaultValue =
@@ -675,11 +678,12 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.ToJaggedArray<'R>(defaultValue) =
     toJaggedArray<'R> frame.RowCount frame.ColumnCount frame.Data (lazy defaultValue)
 
+  /// <summary>
   /// Returns data of the data frame as a jagged array. The method attempts to convert
   /// all values to the specified type 'R. If the specified type is 'float' or 'double'
   /// then the method automatically uses NaN. For other values, the default value has to
   /// be explicitly specified using another overload.
-  ///
+  /// </summary>
   /// <category>Fancy accessors</category>
   member frame.ToJaggedArray<'R>() =
     let defaultValue =
@@ -780,7 +784,6 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// frame columns. The operation throws if the column key is not found.
   /// </summary>
   /// <param name="column">The key (or name) to be dropped from the frame</param>
-  /// <param name="frame">Source data frame (which is not mutated by the operation)</param>
   /// <category>Series operations</category>
   member frame.DropColumn(column:'TColumnKey) =
     let newColumnIndex, colCmd = indexBuilder.DropItem( (columnIndex, Vectors.Return 0), column)
@@ -810,7 +813,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// frame with ordered indices.
   /// </summary>
   /// <param name="column">A key (or name) for the column to be replaced or added</param>
-  /// <param name="series">A data series to be used (the row key type has to match)</param>
+  /// <param name="data">A data series to be used (the row key type has to match)</param>
   /// <param name="lookup">Specify how to find value in the added series (look for nearest available value with the smaller/greater key).</param>
   /// <category>Series operations</category>
   member frame.ReplaceColumn(column, data:seq<'V>, lookup) =
@@ -834,7 +837,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// series is added.)
   /// </summary>
   /// <param name="column">A key (or name) for the column to be replaced or added</param>
-  /// <param name="series">A sequence of values to be added</param>
+  /// <param name="data">A sequence of values to be added</param>
   /// <category>Series operations</category>
   member frame.ReplaceColumn(column, data:seq<'V>) =
     frame.ReplaceColumn(column, data, Lookup.Exact)
@@ -1259,8 +1262,10 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
             yield Choice2Of3()
             for obs in ends.Rows.Observations do yield Choice1Of3(obs.Key, obs.Value) }
 
+  /// <summary>
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
+  /// </summary>
   /// <category>Formatting and raw data access</category>
   member frame.Format() =
     frame.Format(Formatting.RowStartItemCount, Formatting.RowEndItemCount, Formatting.ColumnStartItemCount, Formatting.ColumnEndItemCount)
@@ -1283,7 +1288,8 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
   /// </summary>
-  /// <param name="count">The maximal total number of rows to be printed</param>
+  /// <param name="rowCount">The maximal number of rows to be printed</param>
+  /// <param name="columnCount">The maximal number of columns to be printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(rowCount, columnCount) =
     let rowHalf = rowCount / 2
@@ -1294,8 +1300,10 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
   /// </summary>
-  /// <param name="startCount">The number of rows at the beginning to be printed</param>
-  /// <param name="endCount">The number of rows at the end of the frame to be printed</param>
+  /// <param name="rowStartCount">The number of rows at the beginning to be printed</param>
+  /// <param name="rowEndCount">The number of rows at the end of the frame to be printed</param>
+  /// <param name="columnStartCount">The number of columns at the beginning to be printed</param>
+  /// <param name="columnEndCount">The number of columns at the end of the frame to be printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(rowStartCount, rowEndCount, columnStartCount, columnEndCount) =
     frame.Format(rowStartCount, rowEndCount, columnStartCount, columnEndCount, false, false)
@@ -1402,9 +1410,12 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
   /// </summary>
-  /// <param name="startCount">The number of rows at the beginning to be printed</param>
-  /// <param name="endCount">The number of rows at the end of the frame to be printed</param>
+  /// <param name="rowStartCount">The number of rows at the beginning to be printed</param>
+  /// <param name="rowEndCount">The number of rows at the end of the frame to be printed</param>
+  /// <param name="columnStartCount">The number of columns at the beginning to be printed</param>
+  /// <param name="columnEndCount">The number of columns at the end of the frame to be printed</param>
   /// <param name="printTypes">When true, the types of vectors storing column data are printed</param>
+  /// <param name="showInfo">When true, additional information about the frame is printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(rowStartCount, rowEndCount, columnStartCount, columnEndCount, printTypes, showInfo) =
     try
@@ -1516,7 +1527,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 // ------------------------------------------------------------------------------------------------
 
 /// <exclude />
-/// Module with helper functions and operations that are needed by `Frame<R, C>`, but
+/// Module with helper functions and operations that are needed by <c>Frame&lt;R, C&gt;</c>, but
 /// are easier to write in a separate type (having them inside generic type
 /// can confuse the type inference in various ways).
 and FrameUtils =
@@ -1743,10 +1754,11 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 // with new ones that re-create frames so e.g. `frame.Rows.[x .. y]` is a frame.
 // ------------------------------------------------------------------------------------------------
 
+/// <summary>
 /// Represents a series of columns from a frame. The type inherits from a series of
-/// series representing individual columns (`Series<'TColumnKey, ObjectSeries<'TRowKey>>`) but
+/// series representing individual columns (<c>Series&lt;'TColumnKey, ObjectSeries&lt;'TRowKey&gt;&gt;</c>) but
 /// hides slicing operations with new versions that return frames.
-///
+/// </summary>
 /// <category>Specialized frame and series types</category>
 and ColumnSeries<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equality>(index, vector, vectorBuilder, indexBuilder) =
   inherit Series<'TColumnKey, ObjectSeries<'TRowKey>>(index, vector, vectorBuilder, indexBuilder)
@@ -1761,10 +1773,11 @@ and ColumnSeries<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey 
   member x.Item with get(level) = x.GetByLevel(level)
 
 
+/// <summary>
 /// Represents a series of rows from a frame. The type inherits from a series of
-/// series representing individual rows (`Series<'TRowKey, ObjectSeries<'TColumnKey>>`) but
+/// series representing individual rows (<c>Series&lt;'TRowKey, ObjectSeries&lt;'TColumnKey&gt;&gt;</c>) but
 /// hides slicing operations with new versions that return frames.
-///
+/// </summary>
 /// <category>Specialized frame and series types</category>
 and [<AbstractClass>] RowSeries<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equality>
     (index:IIndex<'TRowKey>, vector:IVector<ObjectSeries<'TColumnKey>>, vectorBuilder, indexBuilder) =

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -62,17 +62,20 @@ and IFrameOperation<'V> =
 // Data frame
 // --------------------------------------------------------------------------------------
 
+/// <summary>
 /// A frame is the key Deedle data structure (together with series). It represents a
 /// data table (think spreadsheet or CSV file) with multiple rows and columns. The frame
 /// consists of row index, column index and data. The indices are used for efficient
 /// lookup when accessing data by the row key `'TRowKey` or by the column key
 /// `'TColumnKey`. Deedle frames are optimized for the scenario when all values in a given
 /// column are of the same type (but types of different columns can differ).
-///
-/// ## Joining, zipping and appending
+/// </summary>
+/// <remarks>
+/// <para>Joining, zipping and appending:</para>
+/// <para>
 /// More info
-///
-///
+/// </para>
+/// </remarks>
 /// <category>Core frame and series types</category>
 and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equality>
     ( rowIndex:IIndex<'TRowKey>, columnIndex:IIndex<'TColumnKey>,
@@ -182,6 +185,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   // Note - this has to be actual member and not an extension so that C# callers can specify
   // generic type arguments using `df.Zip<double, double, double>(...)` (doesn't work for extensions)
 
+  /// <summary>
   /// Aligns two data frames using both column index and row index and apply the specified operation
   /// on values of a specified type that are available in both data frames. The parameters `columnKind`,
   /// and `rowKind` can be specified to determine how the alginment works (similarly to `Join`).
@@ -191,19 +195,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
-  ///
-  /// ## Parameters
-  ///  - `otherFrame` - Other frame to be aligned and zipped with the current instance
-  ///  - `columnKind` - Specifies how to align columns (inner, outer, left or right join)
-  ///  - `rowKind` - Specifies how to align rows (inner, outer, left or right join)
-  ///  - `lookup` - Specifies how to find matching value for a row (when using left or right join on rows)
-  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
-  ///  - `pointwise` - Specifies how to handle columns that are not matched. Set true to make unmatched
-  ///    column missing. Set false to left unmatched column unchanged.
-  ///  - `op` - A function that is applied to aligned values. The `Zip` operation is generic
-  ///    in the type of this function and the type of function is used to determine which
-  ///    values in the frames are zipped and which are left unchanged.
-  ///
+  /// </summary>
+  /// <param name="otherFrame">Other frame to be aligned and zipped with the current instance</param>
+  /// <param name="columnKind">Specifies how to align columns (inner, outer, left or right join)</param>
+  /// <param name="rowKind">Specifies how to align rows (inner, outer, left or right join)</param>
+  /// <param name="lookup">Specifies how to find matching value for a row (when using left or right join on rows) Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.</param>
+  /// <param name="pointwise">Specifies how to handle columns that are not matched. Set true to make unmatched column missing. Set false to left unmatched column unchanged.</param>
+  /// <param name="op">A function that is applied to aligned values. The `Zip` operation is generic in the type of this function and the type of function is used to determine which values in the frames are zipped and which are left unchanged.</param>
   /// <category>Joining, zipping and appending</category>
   member frame1.Zip<'V1, 'V2, 'V3>(otherFrame:Frame<'TRowKey, 'TColumnKey>, columnKind, rowKind, lookup, pointwise, op:Func<'V1, 'V2, 'V3>) =
 
@@ -250,6 +248,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
         | _ -> failwith "zipAlignInto: join failed." )
     Frame<_, _>(rowIndex, newColumns.Index, newColumns.Vector, indexBuilder, vectorBuilder)
 
+  /// <summary>
   /// Aligns two data frames using both column index and row index and apply the specified operation
   /// on values of a specified type that are available in both data frames. This overload uses
   /// `JoinKind.Outer` for both columns and rows.
@@ -257,34 +256,23 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
-  ///
-  /// ## Parameters
-  ///  - `otherFrame` - Other frame to be aligned and zipped with the current instance
-  ///  - `op` - A function that is applied to aligned values. The `Zip` operation is generic
-  ///    in the type of this function and the type of function is used to determine which
-  ///    values in the frames are zipped and which are left unchanged.
-  ///
+  /// </summary>
+  /// <param name="otherFrame">Other frame to be aligned and zipped with the current instance</param>
+  /// <param name="op">A function that is applied to aligned values. The `Zip` operation is generic in the type of this function and the type of function is used to determine which values in the frames are zipped and which are left unchanged.</param>
   /// <category>Joining, zipping and appending</category>
   member frame1.Zip<'V1, 'V2, 'V3>(otherFrame:Frame<'TRowKey, 'TColumnKey>, op:Func<'V1, 'V2, 'V3>) =
     frame1.Zip<'V1, 'V2, 'V3>(otherFrame, JoinKind.Outer, JoinKind.Outer, Lookup.Exact, false, op)
 
+  /// <summary>
   /// Join two data frames. The columns of the joined frames must not overlap and their
   /// rows are aligned and transformed according to the specified join kind.
   /// When the index of both frames is ordered, it is possible to specify `lookup`
   /// in order to align indices from other frame to the indices of the main frame
   /// (typically, to find the nearest key with available value for a key).
-  ///
-  /// ## Parameters
-  ///  - `otherFrame` - Other frame (right) to be joined with the current instance (left)
-  ///  - `kind` - Specifies the joining behavior on row indices. Use `JoinKind.Outer` and
-  ///    `JoinKind.Inner` to get the union and intersection of the row keys, respectively.
-  ///    Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right
-  ///    data frame.
-  ///  - `lookup` - When `kind` is `Left` or `Right` and the two frames have ordered row index,
-  ///    this parameter can be used to specify how to find value for a key when there is no
-  ///    exactly matching key or when there are missing values.
-  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
-  ///
+  /// </summary>
+  /// <param name="otherFrame">Other frame (right) to be joined with the current instance (left)</param>
+  /// <param name="kind">Specifies the joining behavior on row indices. Use `JoinKind.Outer` and `JoinKind.Inner` to get the union and intersection of the row keys, respectively. Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right data frame.</param>
+  /// <param name="lookup">When `kind` is `Left` or `Right` and the two frames have ordered row index, this parameter can be used to specify how to find value for a key when there is no exactly matching key or when there are missing values. Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Join(otherFrame:Frame<'TRowKey, 'TColumnKey>, kind, lookup) =
     // Union/intersect/align row indices and get transformations to apply to left/right vectors
@@ -302,82 +290,66 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let newData = vectorBuilder.Build(newColumnIndex.AddressingScheme, colCmd, [| newThisData; newOtherData |])
     Frame(newRowIndex, newColumnIndex, newData, indexBuilder, vectorBuilder)
 
+  /// <summary>
   /// Join two data frames. The columns of the joined frames must not overlap and their
   /// rows are aligned and transformed according to the specified join kind.
   /// For more alignment options on ordered frames, see overload taking `lookup`.
-  ///
-  /// ## Parameters
-  ///  - `otherFrame` - Other frame (right) to be joined with the current instance (left)
-  ///  - `kind` - Specifies the joining behavior on row indices. Use `JoinKind.Outer` and
-  ///    `JoinKind.Inner` to get the union and intersection of the row keys, respectively.
-  ///    Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right
-  ///    data frame.
-  ///
+  /// </summary>
+  /// <param name="otherFrame">Other frame (right) to be joined with the current instance (left)</param>
+  /// <param name="kind">Specifies the joining behavior on row indices. Use `JoinKind.Outer` and `JoinKind.Inner` to get the union and intersection of the row keys, respectively. Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right data frame.</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Join(otherFrame:Frame<'TRowKey, 'TColumnKey>, kind) =
     frame.Join(otherFrame, kind, Lookup.Exact)
 
+  /// <summary>
   /// Performs outer join on two data frames. The columns of the joined frames must not
   /// overlap and their rows are aligned. The unavailable values are marked as missing.
-  ///
-  /// ## Parameters
-  ///  - `otherFrame` - Other frame (right) to be joined with the current instance (left)
-  ///
+  /// </summary>
+  /// <param name="otherFrame">Other frame (right) to be joined with the current instance (left)</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Join(otherFrame:Frame<'TRowKey, 'TColumnKey>) =
     frame.Join(otherFrame, JoinKind.Outer, Lookup.Exact)
 
+  /// <summary>
   /// Join data frame and a series. The column key for the joined series must not occur in the
   /// current data frame. The rows are aligned and transformed according to the specified join kind.
   /// When the index of both objects is ordered, it is possible to specify `lookup`
   /// in order to align indices from other frame to the indices of the main frame
   /// (typically, to find the nearest key with available value for a key).
-  ///
-  /// ## Parameters
-  ///  - `colKey` - Column key to be used for the joined series
-  ///  - `series` - Series to be joined with the current data frame
-  ///  - `kind` - Specifies the joining behavior on row indices. Use `JoinKind.Outer` and
-  ///    `JoinKind.Inner` to get the union and intersection of the row keys, respectively.
-  ///    Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right
-  ///    data frame.
-  ///  - `lookup` - When `kind` is `Left` or `Right` and the two frames have ordered row index,
-  ///    this parameter can be used to specify how to find value for a key when there is no
-  ///    exactly matching key or when there are missing values.
-  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
-  ///
+  /// </summary>
+  /// <param name="colKey">Column key to be used for the joined series</param>
+  /// <param name="series">Series to be joined with the current data frame</param>
+  /// <param name="kind">Specifies the joining behavior on row indices. Use `JoinKind.Outer` and `JoinKind.Inner` to get the union and intersection of the row keys, respectively. Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right data frame.</param>
+  /// <param name="lookup">When `kind` is `Left` or `Right` and the two frames have ordered row index, this parameter can be used to specify how to find value for a key when there is no exactly matching key or when there are missing values. Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Join<'V>(colKey, series:Series<'TRowKey, 'V>, kind, lookup) =
     let otherFrame = Frame([colKey], [series])
     frame.Join(otherFrame, kind, lookup)
 
+  /// <summary>
   /// Join data frame and a series. The column key for the joined series must not occur in the
   /// current data frame. The rows are aligned and transformed according to the specified join kind.
-  ///
-  /// ## Parameters
-  ///  - `colKey` - Column key to be used for the joined series
-  ///  - `series` - Series to be joined with the current data frame
-  ///  - `kind` - Specifies the joining behavior on row indices. Use `JoinKind.Outer` and
-  ///    `JoinKind.Inner` to get the union and intersection of the row keys, respectively.
-  ///    Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right
-  ///    data frame.
-  ///
+  /// </summary>
+  /// <param name="colKey">Column key to be used for the joined series</param>
+  /// <param name="series">Series to be joined with the current data frame</param>
+  /// <param name="kind">Specifies the joining behavior on row indices. Use `JoinKind.Outer` and `JoinKind.Inner` to get the union and intersection of the row keys, respectively. Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right data frame.</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Join<'V>(colKey, series:Series<'TRowKey, 'V>, kind) =
     frame.Join(colKey, series, kind, Lookup.Exact)
 
+  /// <summary>
   /// Performs outer join on data frame and a series. The column key for the joined
   /// series must not occur in the current data frame. The rows are automatically aligned
   /// and unavailable values are marked as missing.
-  ///
-  /// ## Parameters
-  ///  - `colKey` - Column key to be used for the joined series
-  ///  - `series` - Series to be joined with the current data frame
-  ///
+  /// </summary>
+  /// <param name="colKey">Column key to be used for the joined series</param>
+  /// <param name="series">Series to be joined with the current data frame</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Join<'V>(colKey, series:Series<'TRowKey, 'V>) =
     frame.Join(colKey, series, JoinKind.Outer, Lookup.Exact)
 
 
+  /// <summary>
   /// Merge two data frames with non-overlapping values. The operation takes the union of columns
   /// and rows of the source data frames and then unions the values. An exception is thrown when
   /// both data frames define value for a column/row location, but the operation succeeds if one
@@ -386,14 +358,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Note that the rows are *not* automatically reindexed to avoid overlaps. This means that when
   /// a frame has rows indexed with ordinal numbers, you may need to explicitly reindex the row
   /// keys before calling append.
-  ///
-  /// ## Parameters
-  ///  - `otherFrame` - The other frame to be appended (combined) with the current instance
-  ///
+  /// </summary>
+  /// <param name="otherFrame">The other frame to be appended (combined) with the current instance</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Merge(otherFrame:Frame<'TRowKey, 'TColumnKey>) =
     frame.Merge([| otherFrame |])
 
+  /// <summary>
   /// Merge multiple data frames with non-overlapping values. The operation takes the union of columns
   /// and rows of the source data frames and then unions the values. An exception is thrown when
   /// both data frames define value for a column/row location, but the operation succeeds if one
@@ -402,15 +373,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Note that the rows are *not* automatically reindexed to avoid overlaps. This means that when
   /// a frame has rows indexed with ordinal numbers, you may need to explicitly reindex the row
   /// keys before calling append.
-  ///
-  /// ## Parameters
-  ///  - `otherFrames` - A collection containing other data frame to be appended
-  ///    (combined) with the current instance
-  ///
+  /// </summary>
+  /// <param name="otherFrames">A collection containing other data frame to be appended (combined) with the current instance</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Merge(otherFrames:seq<Frame<'TRowKey, 'TColumnKey>>) =
     frame.Merge(Array.ofSeq otherFrames)
 
+  /// <summary>
   /// Merge multiple data frames with non-overlapping values. The operation takes the union of columns
   /// and rows of the source data frames and then unions the values. An exception is thrown when
   /// both data frames define value for a column/row location, but the operation succeeds if one
@@ -419,11 +388,8 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Note that the rows are *not* automatically reindexed to avoid overlaps. This means that when
   /// a frame has rows indexed with ordinal numbers, you may need to explicitly reindex the row
   /// keys before calling append.
-  ///
-  /// ## Parameters
-  ///  - `otherFrames` - A collection containing other data frame to be appended
-  ///    (combined) with the current instance
-  ///
+  /// </summary>
+  /// <param name="otherFrames">A collection containing other data frame to be appended (combined) with the current instance</param>
   /// <category>Joining, zipping and appending</category>
   member frame.Merge([<ParamArray>] otherFrames:Frame<'TRowKey, 'TColumnKey>[]) =
 
@@ -561,27 +527,25 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   // Accessing frame rows
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns the row key that is located at the specified int offset.
   /// If the index is invalid, `ArgumentOutOfRangeException` is thrown.
   /// You can get the corresponding row using `GetRowAt`.
-  ///
-  /// ## Parameters
-  ///  - `index` - Offset (integer) of the row key to be returned
-  ///
+  /// </summary>
+  /// <param name="index">Offset (integer) of the row key to be returned</param>
   /// <category>Accessors and slicing</category>
   member frame.GetRowKeyAt(index) =
     frame.RowIndex.KeyAt(frame.RowIndex.AddressAt index)
 
+  /// <summary>
   /// Returns a row of the data frame that is located at the specified int offset.
   /// This does not use the row key and directly accesses the frame data. This method
   /// is generic and returns the result as a series containing values of the specified type.
   /// To get heterogeneous series of type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
   /// If the index is invalid, `ArgumentOutOfRangeException` is thrown. You can get the
   /// matching key at a specified index using `GetRowKeyAt`.
-  ///
-  /// ## Parameters
-  ///  - `index` - Offset (integer) of the row to be returned
-  ///
+  /// </summary>
+  /// <param name="index">Offset (integer) of the row to be returned</param>
   /// <category>Accessors and slicing</category>
   member frame.GetRowAt<'T>(index) : Series<_, 'T> =
     if index < 0 || int64 index >= rowIndex.KeyCount then
@@ -590,14 +554,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     let vector = createRowReader data vectorBuilder rowAddress columnIndex.AddressAt
     Series(columnIndex, vector, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Returns a row with the specieifed key wrapped in `OptionalValue`. When the specified key
   /// is not found, the result is `OptionalValue.Missing`. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
   /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
-  ///
-  /// ## Parameters
-  ///  - `rowKey` - Specifies the key of the row to be returned
-  ///
+  /// </summary>
+  /// <param name="rowKey">Specifies the key of the row to be returned</param>
   /// <category>Accessors and slicing</category>
   member frame.TryGetRow<'T>(rowKey) : OptionalValue<Series<_, 'T>> =
     let rowAddress = rowIndex.Locate(rowKey)
@@ -606,16 +569,14 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
       let vector = createRowReader data vectorBuilder rowAddress columnIndex.AddressAt
       OptionalValue(Series(columnIndex, vector, vectorBuilder, indexBuilder))
 
+  /// <summary>
   /// Returns a row with the specieifed key wrapped in `OptionalValue`. When the specified key
   /// is not found, the result is `OptionalValue.Missing`. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
   /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
-  ///
-  /// ## Parameters
-  ///  - `rowKey` - Specifies the key of the row to be returned
-  ///  - `lookup` - Specifies how to find value in a frame with ordered rows when the key does
-  ///               not exactly match (look for nearest available value with the smaller/greater key).
-  ///
+  /// </summary>
+  /// <param name="rowKey">Specifies the key of the row to be returned</param>
+  /// <param name="lookup">Specifies how to find value in a frame with ordered rows when the key does not exactly match (look for nearest available value with the smaller/greater key).</param>
   /// <category>Accessors and slicing</category>
   member frame.TryGetRow<'T>(rowKey, lookup) : OptionalValue<Series<_, 'T>> =
     let rowAddress = rowIndex.Lookup(rowKey, lookup, fun _ -> true)
@@ -624,37 +585,32 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
       let vector = createRowReader data vectorBuilder (snd rowAddress.Value) columnIndex.AddressAt
       OptionalValue(Series(columnIndex, vector, vectorBuilder, indexBuilder))
 
+  /// <summary>
   /// Returns a row with the specieifed key. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
   /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
-  ///
-  /// ## Parameters
-  ///  - `rowKey` - Specifies the key of the row to be returned
-  ///
+  /// </summary>
+  /// <param name="rowKey">Specifies the key of the row to be returned</param>
   /// <category>Accessors and slicing</category>
   member frame.GetRow<'T>(rowKey) : Series<_, 'T> = frame.TryGetRow(rowKey).Value
 
+  /// <summary>
   /// Returns a row with the specieifed key. This method is generic and returns the result
   /// as a series containing values of the specified type. To get heterogeneous series of
   /// type `ObjectSeries<'TCol>`, use the `frame.Rows` property.
-  ///
-  /// ## Parameters
-  ///  - `rowKey` - Specifies the key of the row to be returned
-  ///  - `lookup` - Specifies how to find value in a frame with ordered rows when the key does
-  ///               not exactly match (look for nearest available value with the smaller/greater key).
-  ///
+  /// </summary>
+  /// <param name="rowKey">Specifies the key of the row to be returned</param>
+  /// <param name="lookup">Specifies how to find value in a frame with ordered rows when the key does not exactly match (look for nearest available value with the smaller/greater key).</param>
   /// <category>Accessors and slicing</category>
   member frame.GetRow<'T>(rowKey, lookup) : Series<_, 'T> =  frame.TryGetRow(rowKey, lookup).Value
 
+  /// <summary>
   /// Try to find a row with the specified row key, or using the specified `lookup` parameter,
   /// and return the found row together with its actual key in case `lookup` was used. In case the
   /// row is not found, `OptionalValue.Missing` is returned.
-  ///
-  /// ## Parameters
-  ///  - `rowKey` - Specifies the key of the row to be returned
-  ///  - `lookup` - Specifies how to find value in a frame with ordered rows when the key does
-  ///               not exactly match (look for nearest available value with the smaller/greater key).
-  ///
+  /// </summary>
+  /// <param name="rowKey">Specifies the key of the row to be returned</param>
+  /// <param name="lookup">Specifies how to find value in a frame with ordered rows when the key does not exactly match (look for nearest available value with the smaller/greater key).</param>
   /// <category>Accessors and slicing</category>
   member frame.TryGetRowObservation<'T>(rowKey, lookup) : OptionalValue<KeyValuePair<_, Series<_, 'T>>> =
     let rowAddress = rowIndex.Lookup(rowKey, lookup, fun _ -> true)
@@ -685,13 +641,12 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.GetAllValues<'R>(strict) =
     seq { for (KeyValue(_, v)) in frame.GetAllColumns<'R>() do yield! v |> Series.values }
 
+  /// <summary>
   /// Returns data of the data frame as a 2D array. The method attempts to convert
   /// all values to the specified type 'R. When a value is missing, the specified
   /// `defaultValue` is used.
-  ///
-  /// ## Parameters
-  ///  - `defaultValue` - Default value used to fill all missing values
-  ///
+  /// </summary>
+  /// <param name="defaultValue">Default value used to fill all missing values</param>
   /// <category>Fancy accessors</category>
   member frame.ToArray2D<'R>(defaultValue) =
     toArray2D<'R> frame.RowCount frame.ColumnCount frame.Data (lazy defaultValue)
@@ -710,13 +665,12 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     toArray2D frame.RowCount frame.ColumnCount frame.Data defaultValue
 
 
+  /// <summary>
   /// Returns data of the data frame as a jagged array. The method attempts to convert
   /// all values to the specified type 'R. When a value is missing, the specified
   /// `defaultValue` is used.
-  ///
-  /// ## Parameters
-  ///  - `defaultValue` - Default value used to fill all missing values
-  ///
+  /// </summary>
+  /// <param name="defaultValue">Default value used to fill all missing values</param>
   /// <category>Fancy accessors</category>
   member frame.ToJaggedArray<'R>(defaultValue) =
     toJaggedArray<'R> frame.RowCount frame.ColumnCount frame.Data (lazy defaultValue)
@@ -738,44 +692,40 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   // Series related operations - add, drop, get, ?, ?<-, etc.
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Mutates the data frame by adding an additional data series
   /// as a new column with the specified column key. The sequence is
   /// aligned to the data frame based on ordering. If it is longer, it is
   /// trimmed and if it is shorter, missing values will be added.
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the newly added column
-  ///  - `series` - A sequence of values to be added
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the newly added column</param>
+  /// <param name="series">A sequence of values to be added</param>
   /// <category>Series operations</category>
   member frame.AddColumn(column:'TColumnKey, series:seq<_>) =
     frame.AddColumn(column, series, Lookup.Exact)
 
+  /// <summary>
   /// Mutates the data frame by adding an additional data series
   /// as a new column with the specified column key. The operation
   /// uses left join and aligns new series to the existing frame keys.
-  ///
-  /// ## Parameters
-  ///  - `series` - A data series to be added (the row key type has to match)
-  ///  - `column` - A key (or name) for the newly added column
-  ///
+  /// </summary>
+  /// <param name="series">A data series to be added (the row key type has to match)</param>
+  /// <param name="column">A key (or name) for the newly added column</param>
   /// <category>Series operations</category>
   member frame.AddColumn(column:'TColumnKey, series:ISeries<_>) =
     frame.AddColumn(column, series, Lookup.Exact)
 
+  /// <summary>
   /// Mutates the data frame by adding an additional data series
   /// as a new column with the specified column key. The sequence is
   /// aligned to the data frame based on ordering. If it is longer, it is
   /// trimmed and if it is shorter, missing values will be added.
   /// A parameter `lookup` can be used to specify how to find a value in the
   /// added series (if the sequence contains invalid values like `null` or `NaN`).
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the newly added column
-  ///  - `series` - A sequence of values to be added
-  ///  - `lookup` - Specify how to find value in the added series (look for
-  ///    nearest available value with the smaller/greater key).
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the newly added column</param>
+  /// <param name="series">A sequence of values to be added</param>
+  /// <param name="lookup">Specify how to find value in the added series (look for nearest available value with the smaller/greater key).</param>
   /// <category>Series operations</category>
   member frame.AddColumn(column:'TColumnKey, series:seq<'V>, lookup) =
     if isEmpty then
@@ -798,19 +748,17 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
       let series = Series(frame.RowIndex, vector, vectorBuilder, indexBuilder)
       frame.AddColumn(column, series, lookup)
 
+  /// <summary>
   /// Mutates the data frame by adding an additional data series
   /// as a new column with the specified column key. The operation
   /// uses left join and aligns new series to the existing frame keys.
   /// A parameter `lookup` can be used to specify how to find a value in the
   /// added series (if an exact key is not available). The `lookup` parameter
   /// can only be used with ordered indices.
-  ///
-  /// ## Parameters
-  ///  - `series` - A data series to be added (the row key type has to match)
-  ///  - `column` - A key (or name) for the newly added column
-  ///  - `lookup` - Specify how to find value in the added series (look for
-  ///    nearest available value with the smaller/greater key).
-  ///
+  /// </summary>
+  /// <param name="series">A data series to be added (the row key type has to match)</param>
+  /// <param name="column">A key (or name) for the newly added column</param>
+  /// <param name="lookup">Specify how to find value in the added series (look for nearest available value with the smaller/greater key).</param>
   /// <category>Series operations</category>
   member frame.AddColumn<'V>(column:'TColumnKey, series:ISeries<'TRowKey>, lookup) =
     if isEmpty then
@@ -827,73 +775,66 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
       data <- joined.Data
       frame.setColumnIndex joined.ColumnIndex
 
+  /// <summary>
   /// Mutates the data frame by removing the specified series from the
   /// frame columns. The operation throws if the column key is not found.
-  ///
-  /// ## Parameters
-  ///  - `column` - The key (or name) to be dropped from the frame
-  ///  - `frame` - Source data frame (which is not mutated by the operation)
-  ///
+  /// </summary>
+  /// <param name="column">The key (or name) to be dropped from the frame</param>
+  /// <param name="frame">Source data frame (which is not mutated by the operation)</param>
   /// <category>Series operations</category>
   member frame.DropColumn(column:'TColumnKey) =
     let newColumnIndex, colCmd = indexBuilder.DropItem( (columnIndex, Vectors.Return 0), column)
     data <- vectorBuilder.Build(newColumnIndex.AddressingScheme, colCmd, [| data |])
     frame.setColumnIndex newColumnIndex
 
+  /// <summary>
   /// Mutates the data frame by replacing the specified series with
   /// a new series. (If the series does not exist, only the new series is added.)
   /// When adding a series, the specified `lookup` parameter is used for matching
   /// keys. The parameter can only be used for frame with ordered indices.
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the column to be replaced or added
-  ///  - `series` - A data series to be used (the row key type has to match)
-  ///  - `lookup` - Specify how to find value in the added series (look for
-  ///    nearest available value with the smaller/greater key).
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the column to be replaced or added</param>
+  /// <param name="series">A data series to be used (the row key type has to match)</param>
+  /// <param name="lookup">Specify how to find value in the added series (look for nearest available value with the smaller/greater key).</param>
   /// <category>Series operations</category>
   member frame.ReplaceColumn(column:'TColumnKey, series:ISeries<_>, lookup) =
     if columnIndex.Lookup(column, Lookup.Exact, fun _ -> true).HasValue then
       frame.DropColumn(column)
     frame.AddColumn(column, series, lookup)
 
+  /// <summary>
   /// Mutates the data frame by replacing the specified series with
   /// a new data sequence. (If the series does not exist, only the new series is added.)
   /// When adding a series, the specified `lookup` parameter is used for filling
   /// missing values (e.g. `null` or `NaN`). The parameter can only be used for
   /// frame with ordered indices.
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the column to be replaced or added
-  ///  - `series` - A data series to be used (the row key type has to match)
-  ///  - `lookup` - Specify how to find value in the added series (look for
-  ///    nearest available value with the smaller/greater key).
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the column to be replaced or added</param>
+  /// <param name="series">A data series to be used (the row key type has to match)</param>
+  /// <param name="lookup">Specify how to find value in the added series (look for nearest available value with the smaller/greater key).</param>
   /// <category>Series operations</category>
   member frame.ReplaceColumn(column, data:seq<'V>, lookup) =
     let newSeries = Series(frame.RowIndex, Vector.ofValues data, vectorBuilder, indexBuilder)
     frame.ReplaceColumn(column, newSeries, lookup)
 
+  /// <summary>
   /// Mutates the data frame by replacing the specified series with
   /// a new series. (If the series does not exist, only the new
   /// series is added.)
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the column to be replaced or added
-  ///  - `series` - A data series to be used (the row key type has to match)
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the column to be replaced or added</param>
+  /// <param name="series">A data series to be used (the row key type has to match)</param>
   /// <category>Series operations</category>
   member frame.ReplaceColumn(column:'TColumnKey, series:ISeries<_>) =
     frame.ReplaceColumn(column, series, Lookup.Exact)
 
+  /// <summary>
   /// Mutates the data frame by replacing the specified series with
   /// a new data sequence . (If the series does not exist, only the new
   /// series is added.)
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the column to be replaced or added
-  ///  - `series` - A sequence of values to be added
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the column to be replaced or added</param>
+  /// <param name="series">A sequence of values to be added</param>
   /// <category>Series operations</category>
   member frame.ReplaceColumn(column, data:seq<'V>) =
     frame.ReplaceColumn(column, data, Lookup.Exact)
@@ -1324,13 +1265,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.Format() =
     frame.Format(Formatting.RowStartItemCount, Formatting.RowEndItemCount, Formatting.ColumnStartItemCount, Formatting.ColumnEndItemCount)
 
+  /// <summary>
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
-  ///
-  /// ## Parameters
-  ///  - `startCount` - The number of rows at the beginning to be printed
-  ///  - `endCount` - The number of rows at the end of the frame to be printed
-  ///  - `printTypes` - When true, the types of vectors storing column data are printed
+  /// </summary>
+  /// <param name="startCount">The number of rows at the beginning to be printed</param>
+  /// <param name="endCount">The number of rows at the end of the frame to be printed</param>
+  /// <param name="printTypes">When true, the types of vectors storing column data are printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(printTypes) =
     frame.Format(Formatting.RowStartItemCount, Formatting.RowEndItemCount, Formatting.ColumnStartItemCount, Formatting.ColumnEndItemCount, printTypes, false)
@@ -1338,25 +1279,23 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   member frame.Format(printTypes, showInfo) =
     frame.Format(Formatting.RowStartItemCount, Formatting.RowEndItemCount, Formatting.ColumnStartItemCount, Formatting.ColumnEndItemCount, printTypes, showInfo)
 
+  /// <summary>
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
-  ///
-  /// ## Parameters
-  ///  - `count` - The maximal total number of rows to be printed
-  ///
+  /// </summary>
+  /// <param name="count">The maximal total number of rows to be printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(rowCount, columnCount) =
     let rowHalf = rowCount / 2
     let colHalf = columnCount / 2
     frame.Format(rowHalf, rowHalf, colHalf, colHalf)
 
+  /// <summary>
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
-  ///
-  /// ## Parameters
-  ///  - `startCount` - The number of rows at the beginning to be printed
-  ///  - `endCount` - The number of rows at the end of the frame to be printed
-  ///
+  /// </summary>
+  /// <param name="startCount">The number of rows at the beginning to be printed</param>
+  /// <param name="endCount">The number of rows at the end of the frame to be printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(rowStartCount, rowEndCount, columnStartCount, columnEndCount) =
     frame.Format(rowStartCount, rowEndCount, columnStartCount, columnEndCount, false, false)
@@ -1459,14 +1398,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
               |> takeColSlices (columnStartCount + rowLevels + 1) columnEndCount
             |]
 
+  /// <summary>
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
-  ///
-  /// ## Parameters
-  ///  - `startCount` - The number of rows at the beginning to be printed
-  ///  - `endCount` - The number of rows at the end of the frame to be printed
-  ///  - `printTypes` - When true, the types of vectors storing column data are printed
-  ///
+  /// </summary>
+  /// <param name="startCount">The number of rows at the beginning to be printed</param>
+  /// <param name="endCount">The number of rows at the end of the frame to be printed</param>
+  /// <param name="printTypes">When true, the types of vectors storing column data are printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(rowStartCount, rowEndCount, columnStartCount, columnEndCount, printTypes, showInfo) =
     try
@@ -1732,14 +1670,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     else
         frame.GroupByLabels labels frame.RowCount
 
+  /// <summary>
   /// Returns a data frame whose rows are grouped by `groupBy` and whose columns specified
   /// in `aggBy` are aggregated according to `aggFunc`.
-  ///
-  /// ## Parameters
-  ///  - `groupBy` - sequence of columns to group by
-  ///  - `aggBy` - sequence of columns to apply aggFunc to
-  ///  - `aggFunc` - invoked in order to aggregate values
-  ///
+  /// </summary>
+  /// <param name="groupBy">sequence of columns to group by</param>
+  /// <param name="aggBy">sequence of columns to apply aggFunc to</param>
+  /// <param name="aggFunc">invoked in order to aggregate values</param>
   /// <category>Windowing, chunking and grouping</category>
   member frame.AggregateRowsBy(groupBy:seq<_>, aggBy:seq<_>, aggFunc:Func<_,_>) =
     let keySet = HashSet(groupBy)
@@ -1761,15 +1698,13 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
     |> Series.indexOrdinally
     |> FrameUtils.fromRows frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. The generic type parameter is (typically) needed to specify the type of the
   /// values in the required index column.
-  ///
-  /// ## Parameters
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///  - `keepColumn` - Specifies whether the column used as an index should be kept in the frame.
-  ///
+  /// </summary>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
+  /// <param name="keepColumn">Specifies whether the column used as an index should be kept in the frame.</param>
   /// <category>Indexing</category>
   member frame.IndexRows<'TNewRowIndex when 'TNewRowIndex : equality>(column, keepColumn) : Frame<'TNewRowIndex, _> =
     let columnVec = frame.GetColumn<'TNewRowIndex>(column)
@@ -1787,17 +1722,15 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
         .Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme rowCmd)
     Frame<'TNewRowIndex, 'TColumnKey>(newRowIndex, newColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. The generic type parameter is (typically) needed to specify the type of the
   /// values in the required index column.
   ///
   /// The resulting frame will *not* contain the specified column. If you want to preserve the
   /// column, use the overload that takes `keepColumn` parameter.
-  ///
-  /// ## Parameters
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///
+  /// </summary>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
   /// <category>Indexing</category>
   member frame.IndexRows<'TNewRowIndex when 'TNewRowIndex : equality>(column) : Frame<'TNewRowIndex, _> =
     frame.IndexRows<'TNewRowIndex>(column, false)

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -1274,8 +1274,6 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
   /// Shows the data frame content in a human-readable format. The resulting string
   /// shows all columns, but a limited number of rows.
   /// </summary>
-  /// <param name="startCount">The number of rows at the beginning to be printed</param>
-  /// <param name="endCount">The number of rows at the end of the frame to be printed</param>
   /// <param name="printTypes">When true, the types of vectors storing column data are printed</param>
   /// <category>Formatting and raw data access</category>
   member frame.Format(printTypes) =

--- a/src/Deedle/Frame.fs
+++ b/src/Deedle/Frame.fs
@@ -1578,7 +1578,7 @@ and Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equal
 // ------------------------------------------------------------------------------------------------
 
 /// <exclude />
-/// Module with helper functions and operations that are needed by Frame<R, C>, but
+/// Module with helper functions and operations that are needed by `Frame<R, C>`, but
 /// are easier to write in a separate type (having them inside generic type
 /// can confuse the type inference in various ways).
 and FrameUtils =

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -39,12 +39,13 @@ type Frame =
   /// <category>Configuration</category>
   static member NonExpandableInterfaces = Reflection.nonFlattenedTypes
 
+  /// <summary>
   /// Configures how reflection-based expansion behaves - see also `df.ExpandColumns`.
   /// This (mutable, non-thread-safe) collection lets you specify custom expansion behavior
   /// for any type. This is a dictionary with types as keys and functions that implement the
   /// expansion as values.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <example>
   /// For example, say you have a type `MyPair` with propreties `Item1` of type `int` and
   /// `Item2` of type `string` (and perhaps other properties which makes the default behavior
   /// inappropriate). You can register custom expander as:
@@ -53,7 +54,7 @@ type Frame =
   ///       let a = v :?> MyPair
   ///       [ "First", typeof<int>, box a.Item1;
   ///         "Second", typeof<string>, box a.Item2 ] :> seq<_> )
-  ///
+  /// </example>
   /// <category>Configuration</category>
   static member CustomExpanders = Reflection.customExpanders
 
@@ -61,29 +62,20 @@ type Frame =
   // Reading CSV files
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Load data frame from a CSV file. The operation automatically reads column names from the
   /// CSV file (if they are present) and infers the type of values for each column. Columns
   /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
   /// types (such as dates) are not converted automatically.
-  ///
-  /// ## Parameters
-  ///
-  ///  * `location` - Specifies a file name or an web location of the resource.
-  ///  * `hasHeaders` - Specifies whether the input CSV file has header row
-  ///     (when not set, the default value is `true`)
-  ///  * `inferTypes` - Specifies whether the method should attempt to infer types
-  ///    of columns automatically (set this to `false` if you want to specify schema)
-  ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-  ///    rows to use for type inference. The default value is 100.
-  ///  * `schema` - A string that specifies CSV schema. See the documentation for
-  ///    information about the schema format.
-  ///  * `separators` - A string that specifies one or more (single character) separators
-  ///    that are used to separate columns in the CSV file. Use for example `";"` to
-  ///    parse semicolon separated files.
-  ///  * `culture` - Specifies the name of the culture that is used when parsing
-  ///    values in the CSV file (such as `"en-US"`). The default is invariant culture.
-  ///  * `maxRows` - Specifies the maximum number of rows that will be read from the CSV file
-  ///
+  /// </summary>
+  /// <param name="location">Specifies a file name or an web location of the resource.</param>
+  /// <param name="hasHeaders">Specifies whether the input CSV file has header row (when not set, the default value is `true`)</param>
+  /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
+  /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100.</param>
+  /// <param name="schema">A string that specifies CSV schema. See the documentation for information about the schema format.</param>
+  /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV file. Use for example `";"` to parse semicolon separated files.</param>
+  /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
+  /// <param name="maxRows">Specifies the maximum number of rows that will be read from the CSV file</param>
   /// <category>Input and output</category>
   static member ReadCsv
     ( location:string, [<Optional>] hasHeaders:Nullable<bool>, [<Optional>] inferTypes:Nullable<bool>, [<Optional>] inferRows:Nullable<int>,
@@ -101,31 +93,21 @@ type Frame =
       (Some preferOptions)
 
 
+  /// <summary>
   /// Load data frame from a CSV file. The operation automatically reads column names from the
   /// CSV file (if they are present) and infers the type of values for each column. Columns
   /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
   /// types (such as dates) are not converted automatically.
-  ///
-  /// ## Parameters
-  ///
-  ///  * `stream` - Specifies the input stream, opened at the beginning of CSV data
-  ///  * `hasHeaders` - Specifies whether the input CSV file has header row
-  ///     (when not set, the default value is `true`)
-  ///  * `inferTypes` - Specifies whether the method should attempt to infer types
-  ///    of columns automatically (set this to `false` if you want to specify schema)
-  ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-  ///    rows to use for type inference. The default value is 100.
-  ///  * `schema` - A string that specifies CSV schema. See the documentation for
-  ///    information about the schema format.
-  ///  * `separators` - A string that specifies one or more (single character) separators
-  ///    that are used to separate columns in the CSV file. Use for example `";"` to
-  ///    parse semicolon separated files.
-  ///  * `culture` - Specifies the name of the culture that is used when parsing
-  ///    values in the CSV file (such as `"en-US"`). The default is invariant culture.
-  ///  * `maxRows` - The maximal number of rows that should be read from the CSV file.
-  ///  * `missingValues` - An array of strings that contains values which should be treated
-  ///    as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".
-  ///
+  /// </summary>
+  /// <param name="stream">Specifies the input stream, opened at the beginning of CSV data</param>
+  /// <param name="hasHeaders">Specifies whether the input CSV file has header row (when not set, the default value is `true`)</param>
+  /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
+  /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100.</param>
+  /// <param name="schema">A string that specifies CSV schema. See the documentation for information about the schema format.</param>
+  /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV file. Use for example `";"` to parse semicolon separated files.</param>
+  /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
+  /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
+  /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
   /// <category>Input and output</category>
   static member ReadCsv
     ( stream:Stream, [<Optional>] hasHeaders:Nullable<bool>, [<Optional>] inferTypes:Nullable<bool>, [<Optional>] inferRows:Nullable<int>,
@@ -220,15 +202,14 @@ type Frame =
   // Creating frame from values, records or from 2D array
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Create a data frame from a sequence of objects and functions that return
   /// row key, column key and value for each object in the input sequence.
-  ///
-  /// ## Parameters
-  ///  - `values` - Input sequence of objects
-  ///  - `colSel` - A function that returns the column key of an object
-  ///  - `rowSel` - A function that returns the row key of an object
-  ///  - `valSel` - A function that returns the value of an object
-  ///
+  /// </summary>
+  /// <param name="values">Input sequence of objects</param>
+  /// <param name="colSel">A function that returns the column key of an object</param>
+  /// <param name="rowSel">A function that returns the row key of an object</param>
+  /// <param name="valSel">A function that returns the value of an object</param>
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member FromValues(values:seq<'T>, colSel:Func<_, 'C>, rowSel:Func<_, 'R>, valSel:Func<_, 'V>) =
     FrameUtils.fromValues values colSel.Invoke rowSel.Invoke valSel.Invoke
@@ -249,11 +230,12 @@ type Frame =
     let frame = Reflection.convertRecordSequence<'R>(recordsToConvert)
     frame |> Frame.indexRowsWith (Seq.map fst keyValuePairs)
 
+  /// <summary>
   /// Creates a data frame from a sequence of any .NET objects. The method uses reflection
   /// over the specified type parameter `'T` and turns its properties to columns. The
   /// rows of the resulting frame are automatically indexed by `int`.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <example>
   /// The method can be nicely used to create a data frame using C# anonymous types
   /// (the result is a data frame with columns "A" and "B" containing two rows).
   ///
@@ -262,16 +244,17 @@ type Frame =
   ///      new { A = 1, B = "Test" },
   ///       new { A = 2, B = "Another"}
   ///    });
+  /// </example>
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member FromRecords (values:seq<'T>) =
     Reflection.convertRecordSequence<'T>(values)
 
+  /// <summary>
   /// Create data frame from a 2D array of values. The first dimension of the array
   /// is used as rows and the second dimension is treated as columns. Rows and columns
   /// of the returned frame are indexed with the element's offset in the array.
-  ///
-  /// ## Parameters
-  ///  - `array` - A two-dimensional array to be converted into a data frame
+  /// </summary>
+  /// <param name="array">A two-dimensional array to be converted into a data frame</param>
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member FromArray2D(array:'T[,]) =
     // Generate row index (int offsets) and column index (int offsets)
@@ -317,34 +300,42 @@ type Frame =
     Frame<_, string>(rowIndex, colIndex, FrameUtils.vectorBuilder.Create [||], IndexBuilder.Instance, VectorBuilder.Instance)
 
 
+/// <summary>
 /// This module contains F# functions and extensions for working with frames. This
 /// includes operations for creating frames such as the `frame` function, `=>` operator
 /// and `Frame.ofRows`, `Frame.ofColumns` and `Frame.ofRowKeys` functions. The module
 /// also provides additional F# extension methods including `ReadCsv`, `SaveCsv` and `PivotTable`.
-///
-/// ## Frame construction
+/// </summary>
+/// <remarks>
+/// <para>Frame construction:</para>
+/// <para>
 /// The functions and methods in this group can be used to create frames. If you are creating
 /// a frame from a number of sample values, you can use `frame` and the `=>` operator (or the
 /// `=?>` opreator which is useful if you have multiple series of distinct types):
-///
+/// </para>
+/// <para>
 ///     frame [ "Column 1" => series [ 1 => 1.0; 2 => 2.0 ]
 ///             "Column 2" => series [ 3 => 3.0 ] ]
-///
+/// </para>
+/// <para>
 /// Aside from this, the various type extensions let you write `Frame.ofXyz` to construct frames
 /// from data in various formats - `Frame.ofRows` and `Frame.ofColumns` create frame from a series
 /// or a sequence of rows or columns; `Frame.ofRecords` creates a frame from .NET objects using
 /// Reflection and `Frame.ofRowKeys` creates an empty frame with the specified keys.
-///
-/// ## Frame operations
+/// </para>
+/// <para>Frame operations:</para>
+/// <para>
 /// The group contains two overloads of the F#-friendly version of the `PivotTable` method.
-///
-/// ## Input and output
+/// </para>
+/// <para>Input and output:</para>
+/// <para>
 /// This group of extensions includes a number of overloads for the `ReadCsv` and `SaveCsv`
 /// methods. The methods here are designed to be used from F# and so they are F#-style extensions
 /// and they use F#-style optional arguments. In general, the overlads take either a path or
-/// `TextReader`/`TextWriter`. Also note that `ReadCsv<'R>(path, indexCol, ...)` lets you specify
+/// `TextReader`/`TextWriter`. Also note that `ReadCsv&lt;'R&gt;(path, indexCol, ...)` lets you specify
 /// the column to be used as the index.
-///
+/// </para>
+/// </remarks>
 /// <category>Frame and series operations</category>
 [<AutoOpen>]
 module ``F# Frame extensions`` =
@@ -367,15 +358,16 @@ module ``F# Frame extensions`` =
   /// <category>Frame construction</category>
   let (=?>) a (b:ISeries<_>) = a, b
 
+  /// <summary>
   /// A function for constructing data frame from a sequence of name - column pairs.
   /// This provides a nicer syntactic sugar for `Frame.ofColumns`.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <example>
   /// To create a simple frame with two columns, you can write:
   ///
   ///     frame [ "A" => series [ 1 => 30.0; 2 => 35.0 ]
   ///             "B" => series [ 1 => 30.0; 3 => 40.0 ] ]
-  ///
+  /// </example>
   /// <category>Frame construction</category>
   let frame columns =
     let names, values = columns |> Array.ofSeq |> Array.unzip
@@ -393,33 +385,22 @@ module ``F# Frame extensions`` =
   type Frame with
     // NOTE: When changing the parameters below, do not forget to update 'frame.fsx'!
 
+    /// <summary>
     /// Load data frame from a CSV file. The operation automatically reads column names from the
     /// CSV file (if they are present) and infers the type of values for each column. Columns
     /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
     /// types (such as dates) are not converted automatically.
-    ///
-    /// ## Parameters
-    ///
-    ///  * `path` - Specifies a file name or an web location of the resource.
-    ///  * `indexCol` - Specifies the column that should be used as an index in the
-    ///     resulting frame. The type is specified via a type parameter, e.g. use
-    ///     `Frame.ReadCsv<int>("file.csv", indexCol="Day")`.
-    ///  * `hasHeaders` - Specifies whether the input CSV file has header row
-    ///  * `inferTypes` - Specifies whether the method should attempt to infer types
-    ///    of columns automatically (set this to `false` if you want to specify schema)
-    ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-    ///    rows to use for type inference. The default value is 100. Value 0 means all rows.
-    ///  * `schema` - A string that specifies CSV schema. See the documentation for
-    ///    information about the schema format.
-    ///  * `separators` - A string that specifies one or more (single character) separators
-    ///    that are used to separate columns in the CSV file. Use for example `";"` to
-    ///    parse semicolon separated files.
-    ///  * `culture` - Specifies the name of the culture that is used when parsing
-    ///    values in the CSV file (such as `"en-US"`). The default is invariant culture.
-    ///  * `maxRows` - The maximal number of rows that should be read from the CSV file.
-    ///  * `missingValues` - An array of strings that contains values which should be treated
-    ///    as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".
-    ///
+    /// </summary>
+    /// <param name="path">Specifies a file name or an web location of the resource.</param>
+    /// <param name="indexCol">Specifies the column that should be used as an index in the resulting frame. The type is specified via a type parameter, e.g. use `Frame.ReadCsv<int>("file.csv", indexCol="Day")`.</param>
+    /// <param name="hasHeaders">Specifies whether the input CSV file has header row</param>
+    /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
+    /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100. Value 0 means all rows.</param>
+    /// <param name="schema">A string that specifies CSV schema. See the documentation for information about the schema format.</param>
+    /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV file. Use for example `";"` to parse semicolon separated files.</param>
+    /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
+    /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
+    /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
     /// <category>Input and output</category>
     static member ReadCsv<'R when 'R : equality>
         ( path:string, indexCol, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
@@ -428,30 +409,21 @@ module ``F# Frame extensions`` =
       FrameUtils.readCsv reader hasHeaders inferTypes inferRows schema missingValues separators culture maxRows preferOptions
       |> Frame.indexRows indexCol
 
+    /// <summary>
     /// Load data frame from a CSV file. The operation automatically reads column names from the
     /// CSV file (if they are present) and infers the type of values for each column. Columns
     /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
     /// types (such as dates) are not converted automatically.
-    ///
-    /// ## Parameters
-    ///
-    ///  * `path` - Specifies a file name or an web location of the resource.
-    ///  * `hasHeaders` - Specifies whether the input CSV file has header row
-    ///  * `inferTypes` - Specifies whether the method should attempt to infer types
-    ///    of columns automatically (set this to `false` if you want to specify schema)
-    ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-    ///    rows to use for type inference. The default value is 100.
-    ///  * `schema` - A string that specifies CSV schema. See the documentation for
-    ///    information about the schema format.
-    ///  * `separators` - A string that specifies one or more (single character) separators
-    ///    that are used to separate columns in the CSV file. Use for example `";"` to
-    ///    parse semicolon separated files.
-    ///  * `culture` - Specifies the name of the culture that is used when parsing
-    ///    values in the CSV file (such as `"en-US"`). The default is invariant culture.
-    ///  * `maxRows` - The maximal number of rows that should be read from the CSV file.
-    ///  * `missingValues` - An array of strings that contains values which should be treated
-    ///    as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".
-    ///
+    /// </summary>
+    /// <param name="path">Specifies a file name or an web location of the resource.</param>
+    /// <param name="hasHeaders">Specifies whether the input CSV file has header row</param>
+    /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
+    /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100.</param>
+    /// <param name="schema">A string that specifies CSV schema. See the documentation for information about the schema format.</param>
+    /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV file. Use for example `";"` to parse semicolon separated files.</param>
+    /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
+    /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
+    /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
     /// <category>Input and output</category>
     static member ReadCsv
         ( path:string, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
@@ -459,90 +431,63 @@ module ``F# Frame extensions`` =
       use reader = new StreamReader(path)
       FrameUtils.readCsv reader hasHeaders inferTypes inferRows schema missingValues separators culture maxRows preferOptions
 
+    /// <summary>
     /// Load data frame from a CSV file. The operation automatically reads column names from the
     /// CSV file (if they are present) and infers the type of values for each column. Columns
     /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
     /// types (such as dates) are not converted automatically.
-    ///
-    /// ## Parameters
-    ///
-    ///  * `stream` - Specifies the input stream, opened at the beginning of CSV data
-    ///  * `hasHeaders` - Specifies whether the input CSV file has header row
-    ///  * `inferTypes` - Specifies whether the method should attempt to infer types
-    ///    of columns automatically (set this to `false` if you want to specify schema)
-    ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-    ///    rows to use for type inference. The default value is 100.
-    ///  * `schema` - A string that specifies CSV schema. See the documentation for
-    ///    information about the schema format.
-    ///  * `separators` - A string that specifies one or more (single character) separators
-    ///    that are used to separate columns in the CSV file. Use for example `";"` to
-    ///    parse semicolon separated files.
-    ///  * `culture` - Specifies the name of the culture that is used when parsing
-    ///    values in the CSV file (such as `"en-US"`). The default is invariant culture.
-    ///  * `maxRows` - The maximal number of rows that should be read from the CSV file.
-    ///  * `missingValues` - An array of strings that contains values which should be treated
-    ///    as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".
-    ///
+    /// </summary>
+    /// <param name="stream">Specifies the input stream, opened at the beginning of CSV data</param>
+    /// <param name="hasHeaders">Specifies whether the input CSV file has header row</param>
+    /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
+    /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100.</param>
+    /// <param name="schema">A string that specifies CSV schema. See the documentation for information about the schema format.</param>
+    /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV file. Use for example `";"` to parse semicolon separated files.</param>
+    /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
+    /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
+    /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
     /// <category>Input and output</category>
     static member ReadCsv
         ( stream:Stream, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
           ?culture, ?maxRows, ?missingValues, ?preferOptions ) =
       FrameUtils.readCsv (new StreamReader(stream)) hasHeaders inferTypes inferRows schema missingValues separators culture maxRows preferOptions
 
+    /// <summary>
     /// Load data frame from a CSV file. The operation automatically reads column names from the
     /// CSV file (if they are present) and infers the type of values for each column. Columns
     /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
     /// types (such as dates) are not converted automatically.
-    ///
-    /// ## Parameters
-    ///
-    ///  * `reader` - Specifies the `TextReader`, positioned at the beginning of CSV data
-    ///  * `hasHeaders` - Specifies whether the input CSV file has header row
-    ///  * `inferTypes` - Specifies whether the method should attempt to infer types
-    ///    of columns automatically (set this to `false` if you want to specify schema)
-    ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-    ///    rows to use for type inference. The default value is 100.
-    ///  * `schema` - A string that specifies CSV schema. See the documentation for
-    ///    information about the schema format.
-    ///  * `separators` - A string that specifies one or more (single character) separators
-    ///    that are used to separate columns in the CSV file. Use for example `";"` to
-    ///    parse semicolon separated files.
-    ///  * `culture` - Specifies the name of the culture that is used when parsing
-    ///    values in the CSV file (such as `"en-US"`). The default is invariant culture.
-    ///  * `maxRows` - The maximal number of rows that should be read from the CSV file.
-    ///  * `missingValues` - An array of strings that contains values which should be treated
-    ///    as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".
-    ///
+    /// </summary>
+    /// <param name="reader">Specifies the `TextReader`, positioned at the beginning of CSV data</param>
+    /// <param name="hasHeaders">Specifies whether the input CSV file has header row</param>
+    /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
+    /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100.</param>
+    /// <param name="schema">A string that specifies CSV schema. See the documentation for information about the schema format.</param>
+    /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV file. Use for example `";"` to parse semicolon separated files.</param>
+    /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
+    /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
+    /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
     /// <category>Input and output</category>
     static member ReadCsv
         ( reader:TextReader, ?hasHeaders, ?inferTypes, ?inferRows, ?schema,
           ?separators, ?culture, ?maxRows, ?missingValues, ?preferOptions ) =
       FrameUtils.readCsv reader hasHeaders inferTypes inferRows schema missingValues separators culture maxRows preferOptions
 
+    /// <summary>
     /// Load data frame from a string representing a UTF8-encoded CSV file. The operation automatically
     /// reads column names from the string (if they are present) and infers the type of values for each column. Columns
     /// of primitive types (`int`, `float`, etc.) are converted to the right type. Columns of other
     /// types (such as dates) are not converted automatically.
-    ///
-    /// ## Parameters
-    ///
-    ///  * `csvString` - Specifies the input string containing the CSV
-    ///  * `hasHeaders` - Specifies whether the input CSV string has header row
-    ///  * `inferTypes` - Specifies whether the method should attempt to infer types
-    ///    of columns automatically (set this to `false` if you want to specify schema)
-    ///  * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-    ///    rows to use for type inference. The default value is 100.
-    ///  * `schema` - A string that specifies CSV schema. See the documentation for
-    ///    information about the schema format.
-    ///  * `separators` - A string that specifies one or more (single character) separators
-    ///    that are used to separate columns in the CSV string. Use for example `";"` to
-    ///    parse semicolon separated files.
-    ///  * `culture` - Specifies the name of the culture that is used when parsing
-    ///    values in the CSV string (such as `"en-US"`). The default is invariant culture.
-    ///  * `maxRows` - The maximal number of rows that should be read from the CSV string.
-    ///  * `missingValues` - An array of strings that contains values which should be treated
-    ///    as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".
-    ///
+    /// </summary>
+    /// <param name="csvString">Specifies the input string containing the CSV</param>
+    /// <param name="hasHeaders">Specifies whether the input CSV string has header row</param>
+    /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
+    /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100.</param>
+    /// <param name="schema">A string that specifies CSV schema. See the documentation for information about the schema format.</param>
+    /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV string. Use for example `";"` to parse semicolon separated files.</param>
+    /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV string (such as `"en-US"`). The default is invariant culture.</param>
+    /// <param name="maxRows">The maximal number of rows that should be read from the CSV string.</param>
+    /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
     /// <category>Input and output</category>
     static member ReadCsvString
         ( csvString:string, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
@@ -628,108 +573,98 @@ module ``F# Frame extensions`` =
     static member ofRecords<'R when 'R : equality> (values:System.Collections.IEnumerable, indexCol:string) =
       Reflection.convertRecordSequenceUntyped(values).IndexRows<'R>(indexCol)
 
+    /// <summary>
     /// Create data frame from a 2D array of values. The first dimension of the array
     /// is used as rows and the second dimension is treated as columns. Rows and columns
     /// of the returned frame are indexed with the element's offset in the array.
-    ///
-    /// ## Parameters
-    ///  - `array` - A two-dimensional array to be converted into a data frame
-    ///
+    /// </summary>
+    /// <param name="array">A two-dimensional array to be converted into a data frame</param>
     /// <category>Frame construction</category>
     static member ofArray2D (array:'T[,]) =
       Frame.FromArray2D(array)
 
+    /// <summary>
     /// Create data frame from a jagged array of values. The first dimension of the array
     /// is used as rows and the second dimension is treated as columns. Rows and columns
     /// of the returned frame are indexed with the element's offset in the array.
-    ///
+    /// </summary>
+    /// <remarks>
     /// Please note that this function will fail when the inner arrays of the input do not have the same lengths.
-    ///
-    /// ## Parameters
-    ///  - `array` - A jagged array to be converted into a data frame
-    ///
+    /// </remarks>
+    /// <param name="array">A jagged array to be converted into a data frame</param>
     /// <category>Frame construction</category>
     static member ofJaggedArray (jArray:'T[][]) =
       Frame.FromJaggedArray(jArray)
 
   type Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equality> with
+    /// <summary>
     /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data
     /// frame representing a table: column labels are field names & table values are observations
     /// of those fields. pivotTable buckets the rows along two axes, according to the values of
     /// the columns `r` and `c`; and then computes a value for the frame of rows that land in each
     /// bucket.
-    ///
-    /// ## Parameters
-    ///  - `r` - A column key to group on for the resulting row index
-    ///  - `c` - A column key to group on for the resulting col index
-    ///  - `op` - A function computing a value from the corresponding bucket frame
-    ///
+    /// </summary>
+    /// <param name="r">A column key to group on for the resulting row index</param>
+    /// <param name="c">A column key to group on for the resulting col index</param>
+    /// <param name="op">A function computing a value from the corresponding bucket frame</param>
     /// <category>Frame operations</category>
     member frame.PivotTable<'R, 'C, 'T when 'R : equality and 'C : equality>(r:'TColumnKey, c:'TColumnKey, op:Frame<'TRowKey,'TColumnKey> -> 'T) =
       frame |> Frame.pivotTable (fun k os -> os.GetAs<'R>(r)) (fun k os -> os.GetAs<'C>(c)) op
 
+    /// <summary>
     /// Save data frame to a CSV file or a `TextWriter`. When calling the operation,
     /// you can specify whether you want to save the row keys or not (and headers for the keys)
     /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
     /// file name ending with `.tsv`, the `\t` separator is used automatically.
-    ///
-    /// ## Parameters
-    ///  - `writer` - Specifies the TextWriter to which the CSV data should be written
-    ///  - `includeRowKeys` - When set to `true`, the row key is also written to the output file
-    ///  - `keyNames` - Can be used to specify the CSV headers for row key (or keys, for multi-level index)
-    ///  - `separator` - Specify the column separator in the file (the default is `\t` for
-    ///    TSV files and `,` for CSV files)
-    ///  - `culture` - Specify the `CultureInfo` object used for formatting numerical data
-    ///
+    /// </summary>
+    /// <param name="writer">Specifies the TextWriter to which the CSV data should be written</param>
+    /// <param name="includeRowKeys">When set to `true`, the row key is also written to the output file</param>
+    /// <param name="keyNames">Can be used to specify the CSV headers for row key (or keys, for multi-level index)</param>
+    /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
+    /// <param name="culture">Specify the `CultureInfo` object used for formatting numerical data</param>
     /// <category>Input and output</category>
     member frame.SaveCsv(writer:TextWriter, ?includeRowKeys, ?keyNames, ?separator, ?culture) =
       FrameUtils.writeCsv (writer) None separator culture includeRowKeys keyNames frame
 
+    /// <summary>
     /// Save data frame to a CSV file or a `TextWriter`. When calling the operation,
     /// you can specify whether you want to save the row keys or not (and headers for the keys)
     /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
     /// file name ending with `.tsv`, the `\t` separator is used automatically.
-    ///
-    /// ## Parameters
-    ///  - `path` - Specifies the output file name where the CSV data should be written
-    ///  - `includeRowKeys` - When set to `true`, the row key is also written to the output file
-    ///  - `keyNames` - Can be used to specify the CSV headers for row key (or keys, for multi-level index)
-    ///  - `separator` - Specify the column separator in the file (the default is `\t` for
-    ///    TSV files and `,` for CSV files)
-    ///  - `culture` - Specify the `CultureInfo` object used for formatting numerical data
-    ///
+    /// </summary>
+    /// <param name="path">Specifies the output file name where the CSV data should be written</param>
+    /// <param name="includeRowKeys">When set to `true`, the row key is also written to the output file</param>
+    /// <param name="keyNames">Can be used to specify the CSV headers for row key (or keys, for multi-level index)</param>
+    /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
+    /// <param name="culture">Specify the `CultureInfo` object used for formatting numerical data</param>
     /// <category>Input and output</category>
     member frame.SaveCsv(path:string, ?includeRowKeys, ?keyNames, ?separator, ?culture) =
       use writer = new StreamWriter(path)
       FrameUtils.writeCsv writer (Some path) separator culture includeRowKeys keyNames frame
 
+    /// <summary>
     /// Save data frame to a CSV file or to a `TextWriter`. When calling the operation,
     /// you can specify whether you want to save the row keys or not (and headers for the keys)
     /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
     /// file name ending with `.tsv`, the `\t` separator is used automatically.
-    ///
-    /// ## Parameters
-    ///  - `path` - Specifies the output file name where the CSV data should be written
-    ///  - `keyNames` - Specifies the CSV headers for row key (or keys, for multi-level index)
-    ///  - `separator` - Specify the column separator in the file (the default is `\t` for
-    ///    TSV files and `,` for CSV files)
-    ///  - `culture` - Specify the `CultureInfo` object used for formatting numerical data
-    ///
+    /// </summary>
+    /// <param name="path">Specifies the output file name where the CSV data should be written</param>
+    /// <param name="keyNames">Specifies the CSV headers for row key (or keys, for multi-level index)</param>
+    /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
+    /// <param name="culture">Specify the `CultureInfo` object used for formatting numerical data</param>
     /// <category>Input and output</category>
     member frame.SaveCsv(path:string, keyNames) =
       use writer = new StreamWriter(path)
       FrameUtils.writeCsv writer (Some path) None None (Some true) (Some keyNames) frame
 
+    /// <summary>
     /// Returns the data of the frame as a .NET `DataTable` object. The column keys are
     /// automatically converted to strings that are used as column names. The row index is
     /// turned into an additional column with the specified name (the function takes the name
     /// as a sequence to support hierarchical keys, but typically you can write just
     /// `frame.ToDataTable(["KeyName"])`.
-    ///
-    /// ## Parameters
-    ///  - `rowKeyNames` - Specifies the names of the row key components (or just a single
-    ///    row key name if the row index is not hierarchical).
-    ///
+    /// </summary>
+    /// <param name="rowKeyNames">Specifies the names of the row key components (or just a single row key name if the row index is not hierarchical).</param>
     /// <category>Input and output</category>
     member frame.ToDataTable(rowKeyNames) =
       FrameUtils.toDataTable rowKeyNames frame
@@ -740,11 +675,12 @@ module ``F# Frame extensions`` =
       use writer = new StreamWriter(stream)
       FrameUtils.writeCsv (writer) None separator culture includeRowKeys keyNames frame
 
+/// <summary>
 /// Type that can be used for creating frames using the C# collection initializer syntax.
 /// You can use `new FrameBuilder.Columns<...>` to create a new frame from columns or you
 /// can use `new FrameBuilder.Rows<...>` to create a new frame from rows.
-///
-/// ## Example
+/// </summary>
+/// <example>
 /// The following creates a new frame with columns `Foo` and `Bar`:
 ///
 ///     var sampleFrame =
@@ -752,7 +688,7 @@ module ``F# Frame extensions`` =
 ///         { "Foo", new SeriesBuilder<int> { {1,11.1}, {2,22.4} }.Series }
 ///         { "Bar", new SeriesBuilder<int> { {1,42.42} }.Series }
 ///       }.Frame;
-///
+/// </example>
 /// <category>Frame and series operations</category>
 module FrameBuilder =
   type Columns<'R, 'C when 'C : equality and 'R : equality>() =
@@ -785,19 +721,25 @@ type KeyValue =
   static member Create<'K, 'V>(key:'K, value:'V) = KeyValuePair(key, value)
 
 
-/// Contains C# and F# extension methods for the `Frame<'R, 'C>` type. The members are
+/// <summary>
+/// Contains C# and F# extension methods for the `Frame&lt;'R, 'C&gt;` type. The members are
 /// automatically available when you import the `Deedle` namespace. The type contains
 /// object-oriented counterparts to most of the functionality from the `Frame` module.
-///
-/// ## Data structure manipulation
+/// </summary>
+/// <remarks>
+/// <para>Data structure manipulation:</para>
+/// <para>
 /// Summary 1
-///
-/// ## Input and output
+/// </para>
+/// <para>Input and output:</para>
+/// <para>
 /// Summary 2
-///
-/// ## Missing values
+/// </para>
+/// <para>Missing values:</para>
+/// <para>
 /// Summary 3
-///
+/// </para>
+/// </remarks>
 /// <category>Frame and series operations</category>
 [<Extension>]
 type FrameExtensions =
@@ -805,168 +747,156 @@ type FrameExtensions =
   // Data structure manipulation
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Align the existing data to a specified collection of row keys. Values in the data frame
   /// that do not match any new key are dropped, new keys (that were not in the original data
   /// frame) are assigned missing values.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame that is to be realigned.
-  ///  - `keys` - A sequence of new row keys. The keys must have the same type as the original
-  ///    frame keys (because the rows are realigned).
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame that is to be realigned.</param>
+  /// <param name="keys">A sequence of new row keys. The keys must have the same type as the original frame keys (because the rows are realigned).</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member RealignRows(frame:Frame<'R, 'C>, keys) =
     frame |> Frame.realignRows keys
 
+  /// <summary>
   /// Replace the row index of the frame with ordinarilly generated integers starting from zero.
   /// The rows of the frame are assigned index according to the current order, or in a
   /// non-deterministic way, if the current row index is not ordered.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index are to be replaced.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index are to be replaced.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member IndexRowsOrdinally(frame:Frame<'TRowKey, 'TColumnKey>) =
     frame |> Frame.indexRowsOrdinally
 
+  /// <summary>
   /// Replace the row index of the frame with the provided sequence of row keys.
   /// The rows of the frame are assigned keys according to the current order, or in a
   /// non-deterministic way, if the current row index is not ordered.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index are to be replaced.
-  ///  - `keys` - A collection of new row keys.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index are to be replaced.</param>
+  /// <param name="keys">A collection of new row keys.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member IndexRowsWith(frame:Frame<'R, 'C>, keys:seq<'TNewRowIndex>) =
     frame |> Frame.indexRowsWith keys
 
+  /// <summary>
   /// Replace the row index of the frame with a sequence of row keys generated using
   /// a function invoked on each row.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index are to be replaced.
-  ///  - `f` - A function from row (as object series) to new row key value
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index are to be replaced.</param>
+  /// <param name="f">A function from row (as object series) to new row key value</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member IndexRowsUsing(frame:Frame<'R, 'C>, f:Func<ObjectSeries<'C>,'R2>) =
     frame |> Frame.indexRowsUsing f.Invoke
 
+  /// <summary>
   /// Replace the column index of the frame with the provided sequence of column keys.
   /// The columns of the frame are assigned keys according to the current order, or in a
   /// non-deterministic way, if the current column index is not ordered.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose column index are to be replaced.
-  ///  - `keys` - A collection of new column keys.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose column index are to be replaced.</param>
+  /// <param name="keys">A collection of new column keys.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member IndexColumnsWith(frame:Frame<'R, 'C>, keys:seq<'TNewRowIndex>) =
     frame |> Frame.indexColsWith keys
 
+  /// <summary>
   /// Returns a data frame that contains the same data as the input,
   /// but whose rows are an ordered series. This allows using operations that are
   /// only available on indexed series such as alignment and inexact lookup.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be ordered.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame to be ordered.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortRowsByKey(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortRowsByKey frame
 
+  /// <summary>
   /// Returns a data frame that contains the same data as the input,
   /// but whose columns are an ordered series. This allows using operations that are
   /// only available on indexed series such as alignment and inexact lookup.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be ordered.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame to be ordered.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortColumnsByKey(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.sortColsByKey frame
 
+  /// <summary>
   /// Returns a data frame that contains the same data as the input,
   /// but whose rows are sorted by some column.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be ordered.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame to be ordered.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortRows(frame:Frame<'TRowKey, 'TColumnKey>, key: 'TColumnKey) =
     frame |> Frame.sortRows key
 
+  /// <summary>
   /// Returns a data frame that contains the same data as the input,
   /// but whose rows are sorted by some column.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be ordered.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame to be ordered.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortRowsWith(frame:Frame<'TRowKey, 'TColumnKey>, key: 'TColumnKey, cmp: Comparer<'V>) =
     frame |> Frame.sortRowsWith key (fun a b -> cmp.Compare(a,b))
 
+  /// <summary>
   /// Returns a data frame that contains the same data as the input,
   /// but whose rows are sorted by some column.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be ordered.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame to be ordered.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortRowsBy(frame:Frame<'TRowKey, 'TColumnKey>, key: 'TColumnKey, f: Func<'V,'V2>) =
     frame |> Frame.sortRowsBy key f.Invoke
 
+  /// <summary>
   /// Returns a transposed data frame. The rows of the original data frame are used as the
   /// columns of the new one (and vice versa). Use this operation if you have a data frame
   /// and you mostly need to access its rows as a series (because accessing columns as a
   /// series is more efficient).
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame to be transposed.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame to be transposed.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member Transpose(frame:Frame<'TRowKey, 'TColumnKey>) =
     frame.Columns |> FrameUtils.fromRows frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Creates a new data frame where all columns are expanded based on runtime
   /// structure of the objects they store. The expansion is performed recrusively
   /// to the specified depth. A column can be expanded if it is `Series<string, T>`
   /// or `IDictionary<K, V>` or if it is any .NET object with readable
   /// properties.
-  ///
-  /// ## Parameters
-  ///  - `nesting` - The nesting level for expansion. When set to 0, nothing is done.
-  ///
+  /// </summary>
+  /// <param name="nesting">The nesting level for expansion. When set to 0, nothing is done.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member ExpandColumns(frame:Frame<'R, string>, nesting, [<Optional>] dynamic) =
     FrameUtils.expandVectors nesting dynamic frame
 
+  /// <summary>
   /// Creates a new data frame where the specified columns are expanded based on runtime
   /// structure of the objects they store. A column can be expanded if it is
   /// `Series<string, T>` or `IDictionary<K, V>` or if it is any .NET object with readable
   /// properties.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <param name="names">Names of columns in the original data frame to be expanded</param>
+  /// <param name="frame">Input data frame whose columns will be expanded</param>
+  /// <remarks>
+  /// <example>
   /// Given a data frame with a series that contains tuples, you can expand the
   /// tuple members and get a frame with columns `S.Item1` and `S.Item2`:
   ///
   ///     let df = frame [ "S" => series [ 1 => (1, "One"); 2 => (2, "Two") ] ]
   ///     df.ExpandColumns ["S"]
-  ///
-  /// ## Parameters
-  ///  - `names` - Names of columns in the original data frame to be expanded
-  ///  - `frame` - Input data frame whose columns will be expanded
-  ///
+  /// </example>
+  /// </remarks>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member ExpandColumns(frame:Frame<'R, string>, names) =
@@ -1004,19 +934,17 @@ type FrameExtensions =
   // Input and output
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Save data frame to a CSV file or to a `Stream`. When calling the operation,
   /// you can specify whether you want to save the row keys or not (and headers for the keys)
   /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
   /// file name ending with `.tsv`, the `\t` separator is used automatically.
-  ///
-  /// ## Parameters
-  ///  - `writer` - Specifies the text writer to which the CSV data should be written
-  ///  - `includeRowKeys` - When set to `true`, the row key is also written to the output file
-  ///  - `keyNames` - Can be used to specify the CSV headers for row key (or keys, for multi-level index)
-  ///  - `separator` - Specify the column separator in the file (the default is `\t` for
-  ///    TSV files and `,` for CSV files)
-  ///  - `culture` - Specify the `CultureInfo` object used for formatting numerical data
-  ///
+  /// </summary>
+  /// <param name="writer">Specifies the text writer to which the CSV data should be written</param>
+  /// <param name="includeRowKeys">When set to `true`, the row key is also written to the output file</param>
+  /// <param name="keyNames">Can be used to specify the CSV headers for row key (or keys, for multi-level index)</param>
+  /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
+  /// <param name="culture">Specify the `CultureInfo` object used for formatting numerical data</param>
   /// <category>Input and output</category>
   [<Extension>]
   static member SaveCsv(frame:Frame<'R, 'C>, writer: TextWriter, [<Optional>] includeRowKeys, [<Optional>] keyNames, [<Optional>] separator, [<Optional>] culture) =
@@ -1025,19 +953,17 @@ type FrameExtensions =
     let keyNames = if keyNames = Unchecked.defaultof<_> then None else Some keyNames
     FrameUtils.writeCsv (writer) None separator culture (Some includeRowKeys) keyNames frame
 
+  /// <summary>
   /// Save data frame to a CSV file or to a `Stream`. When calling the operation,
   /// you can specify whether you want to save the row keys or not (and headers for the keys)
   /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
   /// file name ending with `.tsv`, the `\t` separator is used automatically.
-  ///
-  /// ## Parameters
-  ///  - `path` - Specifies the output file name where the CSV data should be written
-  ///  - `includeRowKeys` - When set to `true`, the row key is also written to the output file
-  ///  - `keyNames` - Can be used to specify the CSV headers for row key (or keys, for multi-level index)
-  ///  - `separator` - Specify the column separator in the file (the default is `\t` for
-  ///    TSV files and `,` for CSV files)
-  ///  - `culture` - Specify the `CultureInfo` object used for formatting numerical data
-  ///
+  /// </summary>
+  /// <param name="path">Specifies the output file name where the CSV data should be written</param>
+  /// <param name="includeRowKeys">When set to `true`, the row key is also written to the output file</param>
+  /// <param name="keyNames">Can be used to specify the CSV headers for row key (or keys, for multi-level index)</param>
+  /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
+  /// <param name="culture">Specify the `CultureInfo` object used for formatting numerical data</param>
   /// <category>Input and output</category>
   [<Extension>]
   static member SaveCsv(frame:Frame<'R, 'C>, path:string, [<Optional>] includeRowKeys, [<Optional>] keyNames, [<Optional>] separator, [<Optional>] culture) =
@@ -1047,18 +973,16 @@ type FrameExtensions =
     use writer = new StreamWriter(path)
     FrameUtils.writeCsv writer (Some path) separator culture (Some includeRowKeys) keyNames frame
 
+  /// <summary>
   /// Save data frame to a CSV file or to a `Stream`. When calling the operation,
   /// you can specify whether you want to save the row keys or not (and headers for the keys)
   /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
   /// file name ending with `.tsv`, the `\t` separator is used automatically.
-  ///
-  /// ## Parameters
-  ///  - `path` - Specifies the output file name where the CSV data should be written
-  ///  - `keyNames` - Specifies the CSV headers for row key (or keys, for multi-level index)
-  ///  - `separator` - Specify the column separator in the file (the default is `\t` for
-  ///    TSV files and `,` for CSV files)
-  ///  - `culture` - Specify the `CultureInfo` object used for formatting numerical data
-  ///
+  /// </summary>
+  /// <param name="path">Specifies the output file name where the CSV data should be written</param>
+  /// <param name="keyNames">Specifies the CSV headers for row key (or keys, for multi-level index)</param>
+  /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
+  /// <param name="culture">Specify the `CultureInfo` object used for formatting numerical data</param>
   /// <category>Input and output</category>
   [<Extension>]
   static member SaveCsv(frame:Frame<'R, 'C>, path:string, keyNames, [<Optional>] separator, [<Optional>] culture) =
@@ -1067,32 +991,29 @@ type FrameExtensions =
     let culture = if culture = null then None else Some culture
     FrameUtils.writeCsv writer (Some path) separator culture (Some true) (Some keyNames) frame
 
+  /// <summary>
   /// Returns the data of the frame as a .NET `DataTable` object. The column keys are
   /// automatically converted to strings that are used as column names. The row index is
   /// turned into an additional column with the specified name (the function takes the name
   /// as a sequence to support hierarchical keys, but typically you can write just
   /// `frame.ToDataTable(["KeyName"])`.
-  ///
-  /// ## Parameters
-  ///  - `rowKeyNames` - Specifies the names of the row key components (or just a single
-  ///    row key name if the row index is not hierarchical).
-  ///
+  /// </summary>
+  /// <param name="rowKeyNames">Specifies the names of the row key components (or just a single row key name if the row index is not hierarchical).</param>
   /// <category>Input and output</category>
   [<Extension>]
   static member ToDataTable(frame:Frame<'R, 'C>, rowKeyNames) =
     FrameUtils.toDataTable rowKeyNames frame
 
+  /// <summary>
   /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data
   /// frame representing a table: column labels are field names & table values are observations
   /// of those fields. pivotTable buckets the rows along two axes, according to the values of
   /// the columns `r` and `c`; and then computes a value for the frame of rows that land in each
   /// bucket.
-  ///
-  /// ## Parameters
-  ///  - `r` - A column key to group on for the resulting row index
-  ///  - `c` - A column key to group on for the resulting col index
-  ///  - `op` - A function computing a value from the corresponding bucket frame
-  ///
+  /// </summary>
+  /// <param name="r">A column key to group on for the resulting row index</param>
+  /// <param name="c">A column key to group on for the resulting col index</param>
+  /// <param name="op">A function computing a value from the corresponding bucket frame</param>
   /// <category>Frame operations</category>
   [<Extension>]
   static member PivotTable<'R, 'C, 'RNew, 'CNew, 'T when 'R : equality and 'C : equality and 'RNew : equality and 'CNew : equality>(frame: Frame<'R, 'C>, r:'C, c:'C, op:Func<Frame<'R,'C>,'T>) =
@@ -1127,28 +1048,26 @@ type FrameExtensions =
   [<Extension; Obsolete("Use df.ColumnCount")>]
   static member CountColumns(frame:Frame<'R, 'C>) = frame.ColumnIndex.Mappings |> Seq.length
 
+  /// <summary>
   /// Filters frame rows using the specified condition. Returns a new data frame
   /// that contains rows for which the provided function returned false. The function
   /// is called with `KeyValuePair` containing the row key as the `Key` and `Value`
   /// gives access to the row series.
-  ///
-  /// ## Parameters
-  ///
-  ///  * `frame` - A data frame to invoke the filtering function on.
-  ///  * `condition` - A delegate that specifies the filtering condition.
+  /// </summary>
+  /// <param name="frame">A data frame to invoke the filtering function on.</param>
+  /// <param name="condition">A delegate that specifies the filtering condition.</param>
   [<Extension>]
   static member Where(frame:Frame<'TRowKey, 'TColumnKey>, condition:Func<_, _>) =
     frame.Rows.Where(condition) |> FrameUtils.fromRowsAndColumnKeys frame.IndexBuilder frame.VectorBuilder frame.ColumnIndex.Keys
 
+  /// <summary>
   /// Filters frame rows using the specified condtion. Returns a new data frame
   /// that contains rows for which the provided function returned false. The function
   /// is called with `KeyValuePair` containing the row key as the `Key` and `Value`
   /// gives access to the row series and a row index.
-  ///
-  /// ## Parameters
-  ///
-  ///  * `frame` - A data frame to invoke the filtering function on.
-  ///  * `condition` - A delegate that specifies the filtering condition.
+  /// </summary>
+  /// <param name="frame">A data frame to invoke the filtering function on.</param>
+  /// <param name="condition">A delegate that specifies the filtering condition.</param>
   [<Extension>]
   static member Where(frame:Frame<'TRowKey, 'TColumnKey>, condition:Func<_, _, _>) =
     frame.Rows.Where(condition) |> FrameUtils.fromRowsAndColumnKeys frame.IndexBuilder frame.VectorBuilder frame.ColumnIndex.Keys
@@ -1173,24 +1092,25 @@ type FrameExtensions =
   static member Merge(frame:Frame<'TRowKey, 'TColumnKey>, rowKey, row) =
     frame.Merge(Frame.ofRows [ rowKey => row ])
 
+  /// <summary>
   /// Returns a frame with columns shifted by the specified offset. When the offset is
   /// positive, the values are shifted forward and first `offset` keys are dropped. When the
   /// offset is negative, the values are shifted backwards and the last `offset` keys are dropped.
   /// Expressed in pseudo-code:
   ///
   ///     result[k] = series[k - offset]
-  ///
-  /// ## Parameters
-  ///  - `offset` - Can be both positive and negative number.
-  ///  - `frame` - The input frame whose columns are to be shifted.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="offset">Can be both positive and negative number.</param>
+  /// <param name="frame">The input frame whose columns are to be shifted.</param>
+  /// <remarks>
   /// If you want to calculate the difference, e.g. `df - (Frame.shift 1 df)`, you can
   /// use `Frame.diff` which will be a little bit faster.
+  /// </remarks>
   [<Extension>]
   static member Shift(frame:Frame<'TRowKey, 'TColumnKey>, offset) =
     frame |> Frame.shift offset
 
+  /// <summary>
   /// Returns a frame with columns containing difference between an original value and
   /// a value at the specified offset. For example, calling `Frame.diff 1 s` returns a
   /// frame where previous column values is subtracted from the current ones. In pseudo-code, the
@@ -1199,12 +1119,9 @@ type FrameExtensions =
   ///     result[k] = series[k] - series[k - offset]
   ///
   /// Columns that cannot be converted to `float` are left without a change.
-  ///
-  /// ## Parameters
-  ///  - `offset` - When positive, subtracts the past values from the current values;
-  ///    when negative, subtracts the future values from the current values.
-  ///  - `frame` - The input frame containing at least some `float` columns.
-  ///
+  /// </summary>
+  /// <param name="offset">When positive, subtracts the past values from the current values; when negative, subtracts the future values from the current values.</param>
+  /// <param name="frame">The input frame containing at least some `float` columns.</param>
   [<Extension>]
   static member Diff(frame:Frame<'TRowKey, 'TColumnKey>, offset) =
     frame |> Frame.diff offset
@@ -1276,39 +1193,35 @@ type FrameExtensions =
   // Missing values
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Fill missing values of a given type in the frame with a constant value.
   /// The operation is only applied to columns (series) that contain values of the
   /// same type as the provided filling value. The operation does not attempt to
   /// convert between numeric values (so a series containing `float` will not be
   /// converted to a series of `int`).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filled
-  ///  - `value` - A constant value that is used to fill all missing values
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filled</param>
+  /// <param name="value">A constant value that is used to fill all missing values</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member FillMissing(frame:Frame<'TRowKey, 'TColumnKey>, value:'T) =
     Frame.fillMissingWith value frame
 
+  /// <summary>
   /// Fill missing values in the data frame with the nearest available value
   /// (using the specified direction). Note that the frame may still contain
   /// missing values after call to this function (e.g. if the first value is not available
   /// and we attempt to fill series with previous values). This operation can only be
   /// used on ordered frames.
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filled
-  ///  - `direction` - Specifies the direction used when searching for
-  ///    the nearest available value. `Backward` means that we want to
-  ///    look for the first value with a smaller key while `Forward` searches
-  ///    for the nearest greater key.
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filled</param>
+  /// <param name="direction">Specifies the direction used when searching for the nearest available value. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member FillMissing(frame:Frame<'TRowKey, 'TColumnKey>, direction) =
     Frame.fillMissing direction frame
 
+  /// <summary>
   /// Fill missing values in the frame using the specified function. The specified
   /// function is called with all series and keys for which the frame does not
   /// contain value and the result of the call is used in place of the missing value.
@@ -1317,60 +1230,52 @@ type FrameExtensions =
   /// same type as the return type of the provided filling function. The operation
   /// does not attempt to convert between numeric values (so a series containing
   /// `float` will not be converted to a series of `int`).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filled
-  ///  - `f` - A function that takes a series `Series<R, T>` together with a key `K`
-  ///    in the series and generates a value to be used in a place where the original
-  ///    series contains a missing value.
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filled</param>
+  /// <param name="f">A function that takes a series `Series<R, T>` together with a key `K` in the series and generates a value to be used in a place where the original series contains a missing value.</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member FillMissing(frame:Frame<'TRowKey, 'TColumnKey>, f:Func<_, _, 'T>) =
     Frame.fillMissingUsing (fun s k -> f.Invoke(s, k)) frame
 
+  /// <summary>
   /// Creates a new data frame that contains only those rows of the original
   /// data frame that are _dense_, meaning that they have a value for each column.
   /// The resulting data frame has the same number of columns, but may have
   /// fewer rows (or no rows at all).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filtered
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filtered</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member DropSparseRows(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.dropSparseRows frame
 
+  /// <summary>
   /// Creates a new data frame that contains only those rows that are empty for each column.
   /// The resulting data frame has the same number of columns, but may have
   /// fewer rows (or no rows at all).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filtered
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filtered</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member DropEmptyRows(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.dropEmptyRows frame
 
+  /// <summary>
   /// Creates a new data frame that contains only those columns of the original
   /// data frame that are _dense_, meaning that they have a value for each row.
   /// The resulting data frame has the same number of rows, but may have
   /// fewer columns (or no columns at all).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filtered
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filtered</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member DropSparseColumns(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.dropSparseCols frame
 
+  /// <summary>
   /// Creates a new data frame that drops those columns that are empty for each row.
   /// The resulting data frame has the same number of rows, but may have
   /// fewer columns (or no columns at all).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filtered
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filtered</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member DropEmptyColumns(frame:Frame<'TRowKey, 'TColumnKey>) = Frame.dropEmptyCols frame

--- a/src/Deedle/FrameExtensions.fs
+++ b/src/Deedle/FrameExtensions.fs
@@ -14,9 +14,11 @@ open System.Runtime.CompilerServices
 open Deedle.Keys
 
 
+/// <summary>
 /// Provides static methods for creating frames, reading frame data
 /// from CSV files and database (via IDataReader). The type also provides
 /// global configuration for reflection-based expansion.
+/// </summary>
 ///
 /// <category>Frame and series operations</category>
 type Frame =
@@ -25,16 +27,20 @@ type Frame =
   // Configuration
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Configures how reflection-based expansion behaves - see also `df.ExpandColumns`.
   /// This (mutable, non-thread-safe) collection specifies additional primitive (but reference)
   /// types that should not be expaneded. By default, this includes DateTime, string, etc.
+  /// </summary>
   ///
   /// <category>Configuration</category>
   static member NonExpandableTypes = Reflection.additionalPrimitiveTypes
 
+  /// <summary>
   /// Configures how reflection-based expansion behaves - see also `df.ExpandColumns`.
   /// This (mutable, non-thread-safe) collection specifies interfaces whose implementations
   /// should not be expanded. By default, this includes collections such as IList.
+  /// </summary>
   ///
   /// <category>Configuration</category>
   static member NonExpandableInterfaces = Reflection.nonFlattenedTypes
@@ -49,11 +55,12 @@ type Frame =
   /// For example, say you have a type `MyPair` with propreties `Item1` of type `int` and
   /// `Item2` of type `string` (and perhaps other properties which makes the default behavior
   /// inappropriate). You can register custom expander as:
-  ///
-  ///     Frame.CustomExpanders.Add(typeof<MyPair>, fun v ->
-  ///       let a = v :?> MyPair
-  ///       [ "First", typeof<int>, box a.Item1;
-  ///         "Second", typeof<string>, box a.Item2 ] :> seq<_> )
+  /// <code>
+  /// Frame.CustomExpanders.Add(typeof&lt;MyPair&gt;, fun v -&gt;
+  ///   let a = v :?&gt; MyPair
+  ///   [ "First", typeof&lt;int&gt;, box a.Item1;
+  ///     "Second", typeof&lt;string&gt;, box a.Item2 ] :&gt; seq&lt;_&gt; )
+  /// </code>
   /// </example>
   /// <category>Configuration</category>
   static member CustomExpanders = Reflection.customExpanders
@@ -76,6 +83,8 @@ type Frame =
   /// <param name="separators">A string that specifies one or more (single character) separators that are used to separate columns in the CSV file. Use for example `";"` to parse semicolon separated files.</param>
   /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
   /// <param name="maxRows">Specifies the maximum number of rows that will be read from the CSV file</param>
+  /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
+  /// <param name="preferOptions">Specifies whether to prefer optional values when parsing CSV data.</param>
   /// <category>Input and output</category>
   static member ReadCsv
     ( location:string, [<Optional>] hasHeaders:Nullable<bool>, [<Optional>] inferTypes:Nullable<bool>, [<Optional>] inferRows:Nullable<int>,
@@ -108,6 +117,7 @@ type Frame =
   /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
   /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
   /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
+  /// <param name="preferOptions">Specifies whether to prefer optional values when parsing CSV data.</param>
   /// <category>Input and output</category>
   static member ReadCsv
     ( stream:Stream, [<Optional>] hasHeaders:Nullable<bool>, [<Optional>] inferTypes:Nullable<bool>, [<Optional>] inferRows:Nullable<int>,
@@ -125,10 +135,12 @@ type Frame =
 
   // Note: The following is also used from F#
 
+  /// <summary>
   /// Read data from `IDataReader`. The method reads all rows from the data reader
   /// and for each row, gets all the columns. When a value is `DBNull`, it is treated
   /// as missing. The types of created vectors are determined by the field types reported
   /// by the data reader.
+  /// </summary>
   ///
   /// <category>Input and output</category>
   static member ReadReader (reader) =
@@ -238,12 +250,12 @@ type Frame =
   /// <example>
   /// The method can be nicely used to create a data frame using C# anonymous types
   /// (the result is a data frame with columns "A" and "B" containing two rows).
-  ///
-  ///    [lang=csharp]
-  ///    var df = Frame.FromRecords(new[] {
-  ///      new { A = 1, B = "Test" },
-  ///       new { A = 2, B = "Another"}
-  ///    });
+  /// <code lang="csharp">
+  /// var df = Frame.FromRecords(new[] {
+  ///   new { A = 1, B = "Test" },
+  ///   new { A = 2, B = "Another"}
+  /// });
+  /// </code>
   /// </example>
   [<CompilerMessage("This method is not intended for use from F#.", 10001, IsHidden=true, IsError=false)>]
   static member FromRecords (values:seq<'T>) =
@@ -340,20 +352,24 @@ type Frame =
 [<AutoOpen>]
 module ``F# Frame extensions`` =
 
+  /// <summary>
   /// Custom operator that can be used when constructing series from observations
   /// or frames from key-row or key-column pairs. The operator simply returns a
   /// tuple, but it provides a more convenient syntax. For example:
   ///
   ///     series [ "k1" => 1; "k2" => 15 ]
+  /// </summary>
   ///
   /// <category>Frame construction</category>
   let (=>) a b = a, b
 
+  /// <summary>
   /// Custom operator that can be used when constructing a frame from observations
   /// of series. The operator simply returns a tuple, but it upcasts the series
   /// argument so you don't have to do manual casting. For example:
   ///
   ///     frame [ "k1" =?> series [0 => "a"]; "k2" =?> series ["x" => "y"] ]
+  /// </summary>
   ///
   /// <category>Frame construction</category>
   let (=?>) a (b:ISeries<_>) = a, b
@@ -364,9 +380,10 @@ module ``F# Frame extensions`` =
   /// </summary>
   /// <example>
   /// To create a simple frame with two columns, you can write:
-  ///
-  ///     frame [ "A" => series [ 1 => 30.0; 2 => 35.0 ]
-  ///             "B" => series [ 1 => 30.0; 3 => 40.0 ] ]
+  /// <code>
+  /// frame [ "A" =&gt; series [ 1 =&gt; 30.0; 2 =&gt; 35.0 ]
+  ///         "B" =&gt; series [ 1 =&gt; 30.0; 3 =&gt; 40.0 ] ]
+  /// </code>
   /// </example>
   /// <category>Frame construction</category>
   let frame columns =
@@ -392,7 +409,7 @@ module ``F# Frame extensions`` =
     /// types (such as dates) are not converted automatically.
     /// </summary>
     /// <param name="path">Specifies a file name or an web location of the resource.</param>
-    /// <param name="indexCol">Specifies the column that should be used as an index in the resulting frame. The type is specified via a type parameter, e.g. use `Frame.ReadCsv<int>("file.csv", indexCol="Day")`.</param>
+    /// <param name="indexCol">Specifies the column that should be used as an index in the resulting frame. The type is specified via a type parameter, e.g. use <c>Frame.ReadCsv&lt;int&gt;("file.csv", indexCol="Day")</c>.</param>
     /// <param name="hasHeaders">Specifies whether the input CSV file has header row</param>
     /// <param name="inferTypes">Specifies whether the method should attempt to infer types of columns automatically (set this to `false` if you want to specify schema)</param>
     /// <param name="inferRows">If `inferTypes=true`, this parameter specifies the number of rows to use for type inference. The default value is 100. Value 0 means all rows.</param>
@@ -401,6 +418,7 @@ module ``F# Frame extensions`` =
     /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
     /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
     /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
+    /// <param name="preferOptions">Specifies whether to prefer optional values when parsing CSV data.</param>
     /// <category>Input and output</category>
     static member ReadCsv<'R when 'R : equality>
         ( path:string, indexCol, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
@@ -424,6 +442,7 @@ module ``F# Frame extensions`` =
     /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
     /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
     /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
+    /// <param name="preferOptions">Specifies whether to prefer optional values when parsing CSV data.</param>
     /// <category>Input and output</category>
     static member ReadCsv
         ( path:string, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
@@ -446,6 +465,7 @@ module ``F# Frame extensions`` =
     /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
     /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
     /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
+    /// <param name="preferOptions">Specifies whether to prefer optional values when parsing CSV data.</param>
     /// <category>Input and output</category>
     static member ReadCsv
         ( stream:Stream, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
@@ -467,6 +487,7 @@ module ``F# Frame extensions`` =
     /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV file (such as `"en-US"`). The default is invariant culture.</param>
     /// <param name="maxRows">The maximal number of rows that should be read from the CSV file.</param>
     /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
+    /// <param name="preferOptions">Specifies whether to prefer optional values when parsing CSV data.</param>
     /// <category>Input and output</category>
     static member ReadCsv
         ( reader:TextReader, ?hasHeaders, ?inferTypes, ?inferRows, ?schema,
@@ -488,6 +509,7 @@ module ``F# Frame extensions`` =
     /// <param name="culture">Specifies the name of the culture that is used when parsing values in the CSV string (such as `"en-US"`). The default is invariant culture.</param>
     /// <param name="maxRows">The maximal number of rows that should be read from the CSV string.</param>
     /// <param name="missingValues">An array of strings that contains values which should be treated as missing when reading the file. The default value is: "NaN"; "NA"; "#N/A"; ":"; "-"; "TBA"; "TBD".</param>
+    /// <param name="preferOptions">Specifies whether to prefer optional values when parsing CSV data.</param>
     /// <category>Input and output</category>
     static member ReadCsvString
         ( csvString:string, ?hasHeaders, ?inferTypes, ?inferRows, ?schema, ?separators,
@@ -495,9 +517,11 @@ module ``F# Frame extensions`` =
       FrameUtils.readString csvString hasHeaders inferTypes inferRows schema missingValues separators culture maxRows preferOptions
 
 
+    /// <summary>
     /// Creates a frame with ordinal Integer index from a sequence of rows.
     /// The column indices of individual rows are unioned, so if a row has fewer
     /// columns, it will be successfully added, but there will be missing values.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofRowsOrdinal(rows:seq<#Series<'K, 'V>>) =
@@ -506,68 +530,86 @@ module ``F# Frame extensions`` =
       FrameUtils.fromRows IndexBuilder.Instance VectorBuilder.Instance (Series(index, vector, VectorBuilder.Instance, IndexBuilder.Instance))
 
 
+    /// <summary>
     /// Creates a frame from a sequence of row keys and row series pairs.
     /// The row series can contain values of any type, but it has to be the same
     /// for all the series - if you have heterogenously typed series, use `=?>`.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofRows(rows:seq<'R * #ISeries<'C>>) =
       let names, values = rows |> List.ofSeq |> List.unzip
       FrameUtils.fromRows IndexBuilder.Instance VectorBuilder.Instance (Series(names, values))
 
+    /// <summary>
     /// Creates a frame from a series that maps row keys to a nested series
     /// containing values for each row.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofRows(rows) : Frame<'R, 'C> =
       FrameUtils.fromRows IndexBuilder.Instance VectorBuilder.Instance rows
 
+    /// <summary>
     /// Creates a frame with the specified row keys, but no columns (and no data).
     /// This is useful if you want to build a frame gradually and restrict all the
     /// later added data to a sequence of row keys known in advance.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofRowKeys(keys:seq<'R>) =
       Frame.FromRowKeys(keys)
 
+    /// <summary>
     /// Creates a frame from a series that maps column keys to a nested series
     /// containing values for each column.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofColumns(cols) : Frame<'R, 'C> =
       FrameUtils.fromColumns IndexBuilder.Instance VectorBuilder.Instance cols
 
+    /// <summary>
     /// Creates a frame from a sequence of column keys and column series pairs.
     /// The column series can contain values of any type, but it has to be the same
     /// for all the series - if you have heterogenously typed series, use `=?>`.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofColumns(cols:seq<'C * #ISeries<'R>>) =
       let names, values = cols |> List.ofSeq |> List.unzip
       FrameUtils.fromColumns IndexBuilder.Instance VectorBuilder.Instance (Series(names, values))
 
+    /// <summary>
     /// Create a data frame from a sequence of tuples containing row key, column key and a value.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofValues(values:seq<'R * 'C * 'V>) =
       Frame.FromValues(values)
 
+    /// <summary>
     /// Creates a data frame from a series containing any .NET objects. The method uses reflection
     /// over the specified type parameter `'T` and turns its properties to columns.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofRecords (series:Series<'K, 'R>) =
       Frame.FromRecords(series)
 
+    /// <summary>
     /// Creates a data frame from a sequence of any .NET objects. The method uses reflection
     /// over the specified type parameter `'T` and turns its properties to columns.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofRecords (values:seq<'T>) =
       Reflection.convertRecordSequence<'T>(values)
 
+    /// <summary>
     /// Creates a data frame from a sequence of any .NET objects. The method uses reflection
     /// over the specified type parameter `'T` and turns its properties to columns.
+    /// </summary>
     ///
     /// <category>Frame construction</category>
     static member ofRecords<'R when 'R : equality> (values:System.Collections.IEnumerable, indexCol:string) =
@@ -591,7 +633,7 @@ module ``F# Frame extensions`` =
     /// <remarks>
     /// Please note that this function will fail when the inner arrays of the input do not have the same lengths.
     /// </remarks>
-    /// <param name="array">A jagged array to be converted into a data frame</param>
+    /// <param name="jArray">A jagged array to be converted into a data frame</param>
     /// <category>Frame construction</category>
     static member ofJaggedArray (jArray:'T[][]) =
       Frame.FromJaggedArray(jArray)
@@ -599,7 +641,7 @@ module ``F# Frame extensions`` =
   type Frame<'TRowKey, 'TColumnKey when 'TRowKey : equality and 'TColumnKey : equality> with
     /// <summary>
     /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data
-    /// frame representing a table: column labels are field names & table values are observations
+    /// frame representing a table: column labels are field names &amp; table values are observations
     /// of those fields. pivotTable buckets the rows along two axes, according to the values of
     /// the columns `r` and `c`; and then computes a value for the frame of rows that land in each
     /// bucket.
@@ -650,8 +692,6 @@ module ``F# Frame extensions`` =
     /// </summary>
     /// <param name="path">Specifies the output file name where the CSV data should be written</param>
     /// <param name="keyNames">Specifies the CSV headers for row key (or keys, for multi-level index)</param>
-    /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
-    /// <param name="culture">Specify the `CultureInfo` object used for formatting numerical data</param>
     /// <category>Input and output</category>
     member frame.SaveCsv(path:string, keyNames) =
       use writer = new StreamWriter(path)
@@ -677,16 +717,16 @@ module ``F# Frame extensions`` =
 
 /// <summary>
 /// Type that can be used for creating frames using the C# collection initializer syntax.
-/// You can use `new FrameBuilder.Columns<...>` to create a new frame from columns or you
-/// can use `new FrameBuilder.Rows<...>` to create a new frame from rows.
+/// You can use <c>new FrameBuilder.Columns&lt;...&gt;</c> to create a new frame from columns or you
+/// can use <c>new FrameBuilder.Rows&lt;...&gt;</c> to create a new frame from rows.
 /// </summary>
 /// <example>
 /// The following creates a new frame with columns `Foo` and `Bar`:
 ///
 ///     var sampleFrame =
-///       new FrameBuilder.Columns<int, string> {
-///         { "Foo", new SeriesBuilder<int> { {1,11.1}, {2,22.4} }.Series }
-///         { "Bar", new SeriesBuilder<int> { {1,42.42} }.Series }
+///       new <c>FrameBuilder.Columns&lt;int, string&gt;</c> {
+///         { "Foo", new <c>SeriesBuilder&lt;int&gt;</c> { {1,11.1}, {2,22.4} }.Series }
+///         { "Bar", new <c>SeriesBuilder&lt;int&gt;</c> { {1,42.42} }.Series }
 ///       }.Frame;
 /// </example>
 /// <category>Frame and series operations</category>
@@ -713,8 +753,10 @@ module FrameBuilder =
       member x.GetEnumerator() =
         (series |> List.rev |> Seq.map (fun (k, v) -> KeyValuePair(k, v))).GetEnumerator()
 
-/// A type with extension method for `KeyValuePair<'K, 'V>` that makes
+/// <summary>
+/// A type with extension method for <c>KeyValuePair&lt;'K, 'V&gt;</c> that makes
 /// it possible to create values using just `KeyValue.Create`.
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 type KeyValue =
@@ -830,6 +872,7 @@ type FrameExtensions =
   /// but whose rows are sorted by some column.
   /// </summary>
   /// <param name="frame">Source data frame to be ordered.</param>
+  /// <param name="key">The column key to sort by.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortRows(frame:Frame<'TRowKey, 'TColumnKey>, key: 'TColumnKey) =
@@ -840,6 +883,8 @@ type FrameExtensions =
   /// but whose rows are sorted by some column.
   /// </summary>
   /// <param name="frame">Source data frame to be ordered.</param>
+  /// <param name="key">The column key to sort by.</param>
+  /// <param name="cmp">The comparer to use for sorting values.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortRowsWith(frame:Frame<'TRowKey, 'TColumnKey>, key: 'TColumnKey, cmp: Comparer<'V>) =
@@ -850,6 +895,8 @@ type FrameExtensions =
   /// but whose rows are sorted by some column.
   /// </summary>
   /// <param name="frame">Source data frame to be ordered.</param>
+  /// <param name="key">The column key to sort by.</param>
+  /// <param name="f">A function to transform values before comparison.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortRowsBy(frame:Frame<'TRowKey, 'TColumnKey>, key: 'TColumnKey, f: Func<'V,'V2>) =
@@ -870,11 +917,13 @@ type FrameExtensions =
   /// <summary>
   /// Creates a new data frame where all columns are expanded based on runtime
   /// structure of the objects they store. The expansion is performed recrusively
-  /// to the specified depth. A column can be expanded if it is `Series<string, T>`
-  /// or `IDictionary<K, V>` or if it is any .NET object with readable
+  /// to the specified depth. A column can be expanded if it is <c>Series&lt;string, T&gt;</c>
+  /// or <c>IDictionary&lt;K, V&gt;</c> or if it is any .NET object with readable
   /// properties.
   /// </summary>
+  /// <param name="frame">Input data frame to be expanded.</param>
   /// <param name="nesting">The nesting level for expansion. When set to 0, nothing is done.</param>
+  /// <param name="dynamic">Specifies whether to use dynamic expansion.</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member ExpandColumns(frame:Frame<'R, string>, nesting, [<Optional>] dynamic) =
@@ -883,7 +932,7 @@ type FrameExtensions =
   /// <summary>
   /// Creates a new data frame where the specified columns are expanded based on runtime
   /// structure of the objects they store. A column can be expanded if it is
-  /// `Series<string, T>` or `IDictionary<K, V>` or if it is any .NET object with readable
+  /// <c>Series&lt;string, T&gt;</c> or <c>IDictionary&lt;K, V&gt;</c> or if it is any .NET object with readable
   /// properties.
   /// </summary>
   /// <param name="names">Names of columns in the original data frame to be expanded</param>
@@ -892,9 +941,10 @@ type FrameExtensions =
   /// <example>
   /// Given a data frame with a series that contains tuples, you can expand the
   /// tuple members and get a frame with columns `S.Item1` and `S.Item2`:
-  ///
-  ///     let df = frame [ "S" => series [ 1 => (1, "One"); 2 => (2, "Two") ] ]
-  ///     df.ExpandColumns ["S"]
+  /// <code>
+  /// let df = frame [ "S" =&gt; series [ 1 =&gt; (1, "One"); 2 =&gt; (2, "Two") ] ]
+  /// df.ExpandColumns ["S"]
+  /// </code>
   /// </example>
   /// </remarks>
   /// <category>Data structure manipulation</category>
@@ -902,28 +952,34 @@ type FrameExtensions =
   static member ExpandColumns(frame:Frame<'R, string>, names) =
     FrameUtils.expandColumns (set names) frame
 
+  /// <summary>
   /// Given a data frame whose row index has two levels, create a series
   /// whose keys are the unique first level keys, and whose values are
   /// those corresponding frames selected from the original data.
+  /// </summary>
   ///
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member Nest(frame:Frame<Tuple<'TRowKey1, 'TRowKey2>, 'TColumnKey>) =
     frame |> Frame.mapRowKeys (fun t -> t) |> Frame.nest
 
+  /// <summary>
   /// Given a data frame whose row index has two levels, create a series
   /// whose keys are the unique results of the keyselector projection, and
   /// whose values are those corresponding frames selected from the original
   /// data.
+  /// </summary>
   ///
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member NestBy(frame:Frame<'TRowKey1, 'TColumnKey>, keyselector:Func<'TRowKey1, 'TRowKey2>) =
     frame |> Frame.nestBy keyselector.Invoke
 
+  /// <summary>
   /// Given a series whose values are frames, create a frame resulting
   /// from the concatenation of all the frames' rows, with the resulting
   /// keys having two levels. This is the inverse operation to nest.
+  /// </summary>
   ///
   /// <category>Data structure manipulation</category>
   [<Extension>]
@@ -940,6 +996,7 @@ type FrameExtensions =
   /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
   /// file name ending with `.tsv`, the `\t` separator is used automatically.
   /// </summary>
+  /// <param name="frame">The input data frame to be saved.</param>
   /// <param name="writer">Specifies the text writer to which the CSV data should be written</param>
   /// <param name="includeRowKeys">When set to `true`, the row key is also written to the output file</param>
   /// <param name="keyNames">Can be used to specify the CSV headers for row key (or keys, for multi-level index)</param>
@@ -959,6 +1016,7 @@ type FrameExtensions =
   /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
   /// file name ending with `.tsv`, the `\t` separator is used automatically.
   /// </summary>
+  /// <param name="frame">The input data frame to be saved.</param>
   /// <param name="path">Specifies the output file name where the CSV data should be written</param>
   /// <param name="includeRowKeys">When set to `true`, the row key is also written to the output file</param>
   /// <param name="keyNames">Can be used to specify the CSV headers for row key (or keys, for multi-level index)</param>
@@ -979,6 +1037,7 @@ type FrameExtensions =
   /// and you can also specify the separator (use `\t` for writing TSV files). When specifying
   /// file name ending with `.tsv`, the `\t` separator is used automatically.
   /// </summary>
+  /// <param name="frame">The input data frame to be saved.</param>
   /// <param name="path">Specifies the output file name where the CSV data should be written</param>
   /// <param name="keyNames">Specifies the CSV headers for row key (or keys, for multi-level index)</param>
   /// <param name="separator">Specify the column separator in the file (the default is `\t` for TSV files and `,` for CSV files)</param>
@@ -998,6 +1057,7 @@ type FrameExtensions =
   /// as a sequence to support hierarchical keys, but typically you can write just
   /// `frame.ToDataTable(["KeyName"])`.
   /// </summary>
+  /// <param name="frame">The input data frame to be converted.</param>
   /// <param name="rowKeyNames">Specifies the names of the row key components (or just a single row key name if the row index is not hierarchical).</param>
   /// <category>Input and output</category>
   [<Extension>]
@@ -1006,11 +1066,12 @@ type FrameExtensions =
 
   /// <summary>
   /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data
-  /// frame representing a table: column labels are field names & table values are observations
+  /// frame representing a table: column labels are field names &amp; table values are observations
   /// of those fields. pivotTable buckets the rows along two axes, according to the values of
   /// the columns `r` and `c`; and then computes a value for the frame of rows that land in each
   /// bucket.
   /// </summary>
+  /// <param name="frame">The input data frame to pivot.</param>
   /// <param name="r">A column key to group on for the resulting row index</param>
   /// <param name="c">A column key to group on for the resulting col index</param>
   /// <param name="op">A function computing a value from the corresponding bucket frame</param>
@@ -1232,7 +1293,7 @@ type FrameExtensions =
   /// `float` will not be converted to a series of `int`).
   /// </summary>
   /// <param name="frame">An input data frame that is to be filled</param>
-  /// <param name="f">A function that takes a series `Series<R, T>` together with a key `K` in the series and generates a value to be used in a place where the original series contains a missing value.</param>
+  /// <param name="f">A function that takes a series <c>Series&lt;R, T&gt;</c> together with a key <c>K</c> in the series and generates a value to be used in a place where the original series contains a missing value.</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member FillMissing(frame:Frame<'TRowKey, 'TColumnKey>, f:Func<_, _, 'T>) =

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1,15 +1,16 @@
 namespace Deedle
 
+/// <summary>
 /// The `Frame` module provides an F#-friendly API for working with data frames.
 /// The module follows the usual desing for collection-processing in F#, so the
 /// functions work well with the pipelining operator (`|>`). For example, given
 /// a frame with two columns representing prices, we can use `Frame.diff` and
 /// numerical operators to calculate daily returns like this:
 ///
-///     let df = frame [ "MSFT" => prices1; "AAPL" => prices2 ]
-///     let past = df |> Frame.diff 1
+///     let df = frame [ "MSFT" =&gt; prices1; "AAPL" =&gt; prices2 ]
+///     let past = df |&gt; Frame.diff 1
 ///     let rets = past / df * 100.0
-///     rets |> Stats.mean
+///     rets |&gt; Stats.mean
 ///
 /// Note that the `Stats.mean` operation is overloaded and works both on series
 /// (returning a number) and on frames (returning a series).
@@ -48,7 +49,7 @@ namespace Deedle
 ///
 /// The basic grouping functions in this category can be used to group the rows of a
 /// data frame by a specified projection or column to create a frame with hierarchical
-/// index such as `Frame<'K1 * 'K2, 'C>`. The functions always aggregate rows, so if you
+/// index such as <c>Frame&lt;'K1 * 'K2, 'C&gt;</c>. The functions always aggregate rows, so if you
 /// want to group columns, you need to use `Frame.transpose` first.
 ///
 /// The function `groupRowsBy` groups rows by the value of a specified column. Use
@@ -72,52 +73,47 @@ namespace Deedle
 ///
 /// Sorting and index manipulation
 /// ------------------------------
-/// <summary>
+///
 /// A frame is indexed by row keys and column keys. Both of these indices can be sorted
 /// (by the keys). A frame that is sorted allows a number of additional operations (such
 /// as lookup using the `Lookp.ExactOrSmaller` lookup behavior). The functions in this
 /// category provide ways for manipulating the indices. It is expected that most operations
 /// are done on rows and so more functions are available in a row-wise way. A frame can
 /// alwyas be transposed using `Frame.transpose`.
-/// </summary>
-/// <remarks>
-/// <para>Index operations:</para>
-/// <para>
+///
+/// Index operations:
+///
 /// The existing row/column keys can be replaced by a sequence of new keys using the
 /// `indexColsWith` and `indexRowsWith` functions. Row keys can also be replaced by
 /// ordinal numbers using `indexRowsOrdinally`.
-/// </para>
-/// <para>
+///
 /// The function `indexRows` uses the specified column of the original frame as the
 /// index. It removes the column from the resulting frame (to avoid this, use overloaded
 /// `IndexRows` method). This function infers the type of row keys from the context, so it
 /// is usually more convenient to use `indexRows[Date|String|Int|...]` functions. Finally,
 /// if you want to calculate the index value based on multiple columns of the row, you
 /// can use `indexRowsUsing`.
-/// </para>
-/// <para>Sorting frame rows:</para>
-/// <para>
+///
+/// Sorting frame rows:
+///
 /// Frame rows can be sorted according to the value of a specified column using the
 /// `sortRows` function; `sortRowsBy` takes a projection function which lets you
 /// transform the value of a column (e.g. to project a part of the value).
-/// </para>
-/// <para>
+///
 /// The functions `sortRowsByKey` and `sortColsByKey` sort the rows or columns
 /// using the default ordering on the key values. The result is a frame with ordered
 /// index.
-/// </para>
-/// <para>Expanding columns:</para>
-/// <para>
+///
+/// Expanding columns:
+///
 /// When the frame contains a series with complex .NET objects such as F# records or
 /// C# classes, it can be useful to "expand" the column. This operation looks at the
 /// type of the objects, gets all properties of the objects (recursively) and
 /// generates multiple series representing the properties as columns.
-/// </para>
-/// <para>
+///
 /// The function `expandCols` expands the specified columns while `expandAllCols`
 /// applies the expansion to all columns of the data frame.
-/// </para>
-/// </remarks>
+///
 /// Frame transformations
 /// ---------------------
 ///
@@ -126,7 +122,7 @@ namespace Deedle
 /// using scanning and so on.
 ///
 /// Projection and filtering functions such as `[map|filter][Cols|Rows]` call the
-/// specified function with the column or row key and an `ObjectSeries<'K>` representing
+/// specified function with the column or row key and an <c>ObjectSeries&lt;'K&gt;</c> representing
 /// the column or row. You can use functions ending with `Values` (such as `mapRowValues`)
 /// when you do not require the row key, but only the row series; `mapRowKeys` and
 /// `mapColKeys` can be used to transform the keys.
@@ -150,11 +146,11 @@ namespace Deedle
 ///
 /// The functions in this group can be used to write computations over frames that may fail.
 /// They use the type `tryval<'T>` which is defined as a discriminated union:
-///
-///     type tryval<'T> =
+/// <code>
+///     type tryval&lt;'T&gt; =
 ///       | Success of 'T
 ///       | Error of exn
-///
+/// </code>
 /// Using `tryval<'T>` as a value in a data frame is not generally recommended, because
 /// the type of values cannot be tracked in the type. For this reason, it is better to use
 /// `tryval<'T>` with individual series. However, `tryValues` and `fillErrorsWith` functions
@@ -162,7 +158,7 @@ namespace Deedle
 ///
 /// The `tryMapRows` function is more useful. It can be used to write a transformation
 /// that applies a computation (which may fail) to each row of a data frame. The resulting
-/// series is of type `Series<'R, tryval<'T>>` and can be processed using the `Series` module
+/// series is of type <c>Series&lt;'R, tryval&lt;'T&gt;&gt;</c> and can be processed using the <c>Series</c> module
 /// functions.
 ///
 /// Missing values
@@ -201,19 +197,19 @@ namespace Deedle
 /// -----------------------------
 ///
 /// A data frame has a hierarchical row index if the row index is formed by a tuple, such as
-/// `Frame<'R1 * 'R2, 'C>`. Frames of this kind are returned, for example, by the grouping
-/// functions such as `Frame.groupRowsBy`. The functions in this category provide ways for
+/// <c>Frame&lt;'R1 * 'R2, 'C&gt;</c>. Frames of this kind are returned, for example, by the grouping
+/// functions such as <c>Frame.groupRowsBy</c>. The functions in this category provide ways for
 /// working with data frames that have hierarchical row keys.
 ///
-/// The functions `applyLevel` and `reduceLevel` can be used to reduce values according to
-/// one of the levels. The `applyLevel` function takes a reduction of type `Series<'K, 'T> -> 'T`
-/// while `reduceLevel` reduces individual values using a function of type `'T -> 'T -> 'T`.
+/// The functions <c>applyLevel</c> and <c>reduceLevel</c> can be used to reduce values according to
+/// one of the levels. The <c>applyLevel</c> function takes a reduction of type <c>Series&lt;'K, 'T&gt; -&gt; 'T</c>
+/// while <c>reduceLevel</c> reduces individual values using a function of type <c>'T -&gt; 'T -&gt; 'T</c>.
 ///
-/// The functions `nest` and `unnest` can be used to convert between frames with
-/// hierarchical indices (`Frame<'K1 * 'K2, 'C>`) and series of frames that represent
-/// individual groups (`Series<'K1, Frame<'K2, 'C>>`). The `nestBy` function can be
+/// The functions <c>nest</c> and <c>unnest</c> can be used to convert between frames with
+/// hierarchical indices (<c>Frame&lt;'K1 * 'K2, 'C&gt;</c>) and series of frames that represent
+/// individual groups (<c>Series&lt;'K1, Frame&lt;'K2, 'C&gt;&gt;</c>). The <c>nestBy</c> function can be
 /// used to perform group by operation and return the result as a series of frems.
-///
+/// </summary>
 /// <category>Frame and series operations</category>
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Frame =
@@ -226,61 +222,67 @@ module Frame =
   // Accessing frame data and lookup
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns the total number of row keys in the specified frame. This returns
   /// the total length of the row series, including keys for which there is no
   /// value available.
-  ///
+  /// </summary>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("CountRows")>]
   let countRows (frame:Frame<'R, 'C>) = frame.RowIndex.KeyCount |> int
 
+  /// <summary>
   /// Returns the total number of column keys in the specified frame. This returns
   /// the total length of columns, including keys for which there is no
   /// data available.
-  ///
+  /// </summary>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("CountColumns")>]
   let countCols (frame:Frame<'R, 'C>) = frame.ColumnIndex.KeyCount |> int
 
+  /// <summary>
   /// Returns a series with the total number of values in each column. This counts
   /// the number of actual values, excluding the missing values or not available
   /// values (such as `nan`, `null`, etc.)
-  ///
+  /// </summary>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("CountValues")>]
   let inline countValues (frame:Frame<'R, 'C>) =
     frame.Columns |> Series.map (fun _ -> Series.countValues)
 
+  /// <summary>
   /// Returns the columns of the data frame as a series (indexed by
   /// the column keys of the source frame) containing untyped series representing
   /// individual columns of the frame.
-  ///
+  /// </summary>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("Columns")>]
   let cols (frame:Frame<'R, 'C>) = frame.Columns
 
+  /// <summary>
   /// Returns a specified column from a data frame. This function uses exact matching
   /// semantics on the key. Use `lookupCol` if you want to use inexact
   /// matching (e.g. on dates)
-  ///
+  /// </summary>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("GetColumn")>]
   let getCol column (frame:Frame<'R, 'C>) : Series<'R, 'V> =
     frame.GetColumn(column)
 
+  /// <summary>
   /// Returns a series of columns of the data frame indexed by the column keys,
-  /// which contains those series whose values are convertible to `'T`, and with
+  /// which contains those series whose values are convertible to <c>'T</c>, and with
   /// missing values where the conversion fails.
   ///
   /// If you want to get numeric columns, you can use a simpler `numericCols` function
   /// instead. Note that this function typically requires a type annotation. This can
   /// be specified in various ways, for example by annotating the result value:
   ///
-  ///     let (res:Series<_, Series<_, string>>) = frame |> getCols
+  ///     let (res:<c>Series&lt;_, Series&lt;_, string&gt;&gt;</c>) = frame |&gt; getCols
   ///
   /// Here, the annotation on the values of the nested series specifies that we want
   /// to get columns containing `string` values.
-  ///
+  /// </summary>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("GetColumns")>]
   let getCols (frame:Frame<'R,'C>) : Series<'C,Series<'R,'T>> =
@@ -288,10 +290,11 @@ module Frame =
     |> Series.map(fun _ v -> v.TryAs<'T>() |> OptionalValue.asOption)
     |> Series.flatten
 
+  /// <summary>
   /// Returns a series of columns of the data frame indexed by the column keys,
   /// which contains those series whose values are convertible to float, and with
   /// missing values where the conversion fails.
-  ///
+  /// </summary>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("GetNumericColumns")>]
   let getNumericCols (frame:Frame<'R,'C>) : Series<'C,Series<'R,float>> =
@@ -457,21 +460,23 @@ module Frame =
   // Grouping, windowing and chunking
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Group rows of a data frame using the specified `selector`. The selector is called with
   /// a row key and object series representing the row and should return a new key. The result
   /// is a frame with multi-level index, where the first level is formed by the newly created
   /// keys.
-  ///
+  /// </summary>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("GroupRowsUsing")>]
   let groupRowsUsing (selector:_ -> _ -> 'K) (frame:Frame<'R, 'C>) =
     frame.GroupRowsUsing(Func<_,_,_>(selector))
 
+  /// <summary>
   /// Group rows of a data frame using the specified `column`. The type of the column is inferred
   /// from the usage of the resulting frame. The result is a frame with multi-level index, where
   /// the first level is formed by the newly created keys. Use `groupRowsBy[Int|String|...]` to
   /// explicitly specify the type of the column.
-  ///
+  /// </summary>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("GroupRowsBy")>]
   let groupRowsBy column (frame:Frame<'R, 'C>) : Frame<('K * _), _> =
@@ -521,6 +526,7 @@ module Frame =
   /// <param name="groupBy">sequence of columns to group by</param>
   /// <param name="aggBy">sequence of columns to apply aggFunc to</param>
   /// <param name="aggFunc">invoked in order to aggregate values</param>
+  /// <param name="frame">The input data frame to be aggregated</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("AggregateRowsBy")>]
   let aggregateRowsBy groupBy aggBy (aggFunc:Series<'R, 'V1> -> 'V2) (frame:Frame<'R,'C>) =
@@ -532,14 +538,15 @@ module Frame =
 
   /// <summary>
   /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data
-  /// frame representing a table: column labels are field names & table values are observations
+  /// frame representing a table: column labels are field names &amp; table values are observations
   /// of those fields. pivotTable buckets the rows along two axes, according to the results of
   /// the functions `rowGrp` and `colGrp`; and then computes a value for the frame of rows that
   /// land in each bucket.
   /// </summary>
-  /// <param name="rowGrp">A function from rowkey & row to group value for the resulting row index</param>
-  /// <param name="colGrp">A function from rowkey & row to group value for the resulting col index</param>
+  /// <param name="rowGrp">A function from rowkey &amp; row to group value for the resulting row index</param>
+  /// <param name="colGrp">A function from rowkey &amp; row to group value for the resulting col index</param>
   /// <param name="op">A function computing a value from the corresponding bucket frame</param>
+  /// <param name="frame">The input data frame to pivot</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("PivotTable")>]
   let pivotTable (rowGrp:'R -> ObjectSeries<'C> -> 'RNew) (colGrp:'R -> ObjectSeries<'C> -> 'CNew) (op:Frame<'R, 'C> -> 'T) (frame:Frame<'R, 'C>): Frame<'RNew, 'CNew> =
@@ -627,11 +634,12 @@ module Frame =
   [<CompiledName("Stack")>]
   let stack (frame:Frame<'R, 'C>) = melt frame
 
+  /// <summary>
   /// This function is the opposite of `melt`. It takes a data frame
   /// with three columns named `Row`, `Column` and `Value` and reconstructs
   /// a data frame by using `Row` and `Column` as row and column index keys,
   /// respectively.
-  ///
+  /// </summary>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("Unmelt")>]
   let unmelt (frame:Frame<'O, string>) : Frame<'R, 'C> =
@@ -640,11 +648,12 @@ module Frame =
       (fun row -> row.GetAs<'R>("Row"))
       (fun row -> row.GetAs<obj>("Value"))
 
+  /// <summary>
   /// This function is the opposite of `stack`. It takes a data frame
   /// with three columns named `Row`, `Column` and `Value` and reconstructs
   /// a data frame by using `Row` and `Column` as row and column index keys,
   /// respectively.
-  ///
+  /// </summary>
   /// <category>Grouping, windowing and chunking</category>
   [<Obsolete("The Frame.UnStack method has been renamed to Frame.Unmelt")>]
   [<CompiledName("UnStack")>]
@@ -790,11 +799,12 @@ module Frame =
   let indexRowsUsing (f: ObjectSeries<'C> -> 'R2) (frame:Frame<'R1,'C>) =
     indexRowsWith (frame.Rows |> Series.map (fun k v -> f v) |> Series.values) frame
 
+  /// <summary>
   /// Returns a transposed data frame. The rows of the original data frame are used as the
   /// columns of the new one (and vice versa). Use this operation if you have a data frame
   /// and you mostly need to access its rows as a series (because accessing columns as a
   /// series is more efficient).
-  ///
+  /// </summary>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("Transpose")>]
   let transpose (frame:Frame<'R, 'TColumnKey>) =
@@ -855,8 +865,8 @@ module Frame =
   /// <summary>
   /// Creates a new data frame where all columns are expanded based on runtime
   /// structure of the objects they store. The expansion is performed recrusively
-  /// to the specified depth. A column can be expanded if it is `Series<string, T>`
-  /// or `IDictionary<K, V>` or if it is any .NET object with readable
+  /// to the specified depth. A column can be expanded if it is <c>Series&lt;string, T&gt;</c>
+  /// or <c>IDictionary&lt;K, V&gt;</c> or if it is any .NET object with readable
   /// properties.
   /// </summary>
   /// <param name="nesting">The nesting level for expansion. When set to 0, nothing is done.</param>
@@ -869,7 +879,7 @@ module Frame =
   /// <summary>
   /// Creates a new data frame where the specified columns are expanded based on runtime
   /// structure of the objects they store. A column can be expanded if it is
-  /// `Series<string, T>` or `IDictionary<K, V>` or if it is any .NET object with readable
+  /// <c>Series&lt;string, T&gt;</c> or <c>IDictionary&lt;K, V&gt;</c> or if it is any .NET object with readable
   /// properties.
   /// </summary>
   /// <param name="names">Names of columns in the original data frame to be expanded</param>
@@ -878,9 +888,10 @@ module Frame =
   /// <example>
   /// Given a data frame with a series that contains tuples, you can expand the
   /// tuple members and get a frame with columns `S.Item1` and `S.Item2`:
-  ///
-  ///     let df = frame [ "S" => series [ 1 => (1, "One"); 2 => (2, "Two") ] ]
-  ///     df |> Frame.expandCols ["S"]
+  /// <code>
+  /// let df = frame [ "S" =&gt; series [ 1 =&gt; (1, "One"); 2 =&gt; (2, "Two") ] ]
+  /// df |&gt; Frame.expandCols ["S"]
+  /// </code>
   /// </example>
   /// </remarks>
   /// <category>Sorting and index manipulation</category>
@@ -1102,7 +1113,7 @@ module Frame =
   /// Builds a new data frame whose values are the results of applying the specified
   /// function on these values, but only for those columns which can be converted
   /// to the appropriate type for input to the mapping function (use `map` if you need
-  //// to access the row and column keys).
+  /// to access the row and column keys).
   /// </summary>
   /// <param name="frame">Input data frame to be transformed</param>
   /// <param name="f">Function that defines the mapping</param>
@@ -1129,29 +1140,32 @@ module Frame =
   /// <example>
   /// The following sums the values in each column that can be converted to
   /// `float` and returns the result as a new series:
-  ///
-  ///     df |> Frame.reduceValues (fun (a:float) b -> a + b)
+  /// <code>
+  /// df |&gt; Frame.reduceValues (fun (a:float) b -&gt; a + b)
+  /// </code>
   /// </example>
   /// <category>Frame transformations</category>
   [<CompiledName("ReduceValues")>]
   let reduceValues (op:'T -> 'T -> 'T) (frame:Frame<'R, 'C>) =
     frame.GetColumns<'T>() |> Series.map (fun _ -> Series.reduceValues op)
 
+  /// <summary>
   /// Returns a row of the data frame which has the greatest value of the
   /// specified `column`. The row is returned as an optional value (which is
   /// `None` for empty frame) and contains a key together with an object
   /// series representing the row.
-  ///
+  /// </summary>
   /// <category>Frame transformations</category>
   [<CompiledName("MaxRowBy")>]
   let inline maxRowBy column (frame:Frame<'R, 'C>) =
     frame.Rows |> Stats.maxBy (fun row -> row.GetAs<float>(column))
 
+  /// <summary>
   /// Returns a row of the data frame which has the smallest value of the
   /// specified `column`. The row is returned as an optional value (which is
   /// `None` for empty frame) and contains a key together with an object
   /// series representing the row.
-  ///
+  /// </summary>
   /// <category>Frame transformations</category>
   [<CompiledName("MinRowBy")>]
   let inline minRowBy column (frame:Frame<'R, 'C>) =
@@ -1292,17 +1306,18 @@ module Frame =
   /// `float` will not be converted to a series of `int`).
   /// </summary>
   /// <param name="frame">An input data frame that is to be filled</param>
-  /// <param name="f">A function that takes a series `Series<R, T>` together with a key `K` in the series and generates a value to be used in a place where the original series contains a missing value.</param>
+  /// <param name="f">A function that takes a series <c>Series&lt;R, T&gt;</c> together with a key `K` in the series and generates a value to be used in a place where the original series contains a missing value.</param>
   /// <category>Missing values</category>
   [<CompiledName("FillMissingUsing")>]
   let fillMissingUsing (f:Series<'R, 'T> -> 'R -> 'T) (frame:Frame<'R, 'C>) =
     frame.ColumnApply(ConversionKind.Safe, fun (s:Series<_, 'T>) -> Series.fillMissingUsing (f s) s :> ISeries<_>)
 
+  /// <summary>
   /// Creates a new data frame that contains only those rows of the original
   /// data frame that are _dense_, meaning that they have a value for each column.
   /// The resulting data frame has the same number of columns, but may have
   /// fewer rows (or no rows at all).
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("DropSparseRows")>]
   let dropSparseRows (frame:Frame<'R, 'C>) =
@@ -1319,11 +1334,12 @@ module Frame =
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme cmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Creates a new data frame that contains only those rows of the original
   /// data frame for which the given column has a value (i.e., is not missing).
   /// The resulting data frame has the same number of columns, but may have
   /// fewer rows (or no rows at all).
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("DropSparseRowsBy")>]
   let dropSparseRowsBy colKey (frame:Frame<'R, 'C>) =
@@ -1338,10 +1354,11 @@ module Frame =
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme cmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Creates a new data frame that contains only those rows that are empty for each column.
   /// The resulting data frame has the same number of columns, but may have
   /// fewer rows (or no rows at all).
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("DropEmptyRows")>]
   let dropEmptyRows (frame:Frame<'R, 'C>) =
@@ -1358,11 +1375,12 @@ module Frame =
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme cmd)
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Creates a new data frame that contains only those columns of the original
   /// data frame that are _dense_, meaning that they have a value for each row.
   /// The resulting data frame has the same number of rows, but may have
   /// fewer columns (or no columns at all).
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("DropSparseColumns")>]
   let dropSparseCols (frame:Frame<'R, 'C>) =
@@ -1375,10 +1393,11 @@ module Frame =
     let colIndex = frame.IndexBuilder.Create(ReadOnlyCollection.ofArray newColKeys, None)
     Frame(frame.RowIndex, colIndex, frame.VectorBuilder.Create(newData), frame.IndexBuilder, frame.VectorBuilder )
 
+  /// <summary>
   /// Creates a new data frame that drops those columns that are empty for each row.
   /// The resulting data frame has the same number of rows, but may have
   /// fewer columns (or no columns at all).
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("DropEmptyColumns")>]
   let dropEmptyCols (frame:Frame<'R, 'C>) =
@@ -1391,20 +1410,22 @@ module Frame =
     let colIndex = frame.IndexBuilder.Create(ReadOnlyCollection.ofArray newColKeys, None)
     Frame(frame.RowIndex, colIndex, frame.VectorBuilder.Create(newData), frame.IndexBuilder, frame.VectorBuilder )
 
+  /// <summary>
   /// Returns the columns of the data frame that do not have any missing values.
   /// The operation returns a series (indexed by the column keys of the source frame)
   /// containing _series_ representing individual columns of the frame. This is similar
   /// to `Columns`, but it skips columns that contain missing value in _any_ row.
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("DenseColumns")>]
   let denseCols (frame:Frame<'R, 'C>) = frame.ColumnsDense
 
+  /// <summary>
   /// Returns the rows of the data frame that do not have any missing values.
   /// The operation returns a series (indexed by the row keys of the source frame)
   /// containing _series_ representing individual row of the frame. This is similar
   /// to `Rows`, but it skips rows that contain missing value in _any_ column.
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("DenseRows")>]
   let denseRows (frame:Frame<'R, 'C>) = frame.RowsDense
@@ -1481,7 +1502,7 @@ module Frame =
   /// and `rowKind` can be specified to determine how the alginment works (similarly to `Join`).
   /// Column keys are always matched using `Lookup.Exact`, but `lookup` determines lookup for rows.
   ///
-  /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
+  /// Once aligned, the call <c>df1.Zip&lt;T&gt;(df2, f)</c> applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
   /// </summary>
@@ -1501,16 +1522,13 @@ module Frame =
   /// on values of a specified type that are available in both data frames. This overload uses
   /// `JoinKind.Outer` for both columns and rows.
   ///
-  /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
+  /// Once aligned, the call <c>df1.Zip&lt;T&gt;(df2, f)</c> applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
   /// </summary>
+  /// <param name="op">A function that is applied to aligned values. The `Zip` operation is generic in the type of this function and the type of function is used to determine which values in the frames are zipped and which are left unchanged.</param>
   /// <param name="frame1">First frame to be aligned and zipped with the other instance</param>
   /// <param name="frame2">Other frame to be aligned and zipped with the first  instance</param>
-  /// <param name="columnKind">Specifies how to align columns (inner, outer, left or right join)</param>
-  /// <param name="rowKind">Specifies how to align rows (inner, outer, left or right join)</param>
-  /// <param name="lookup">Specifies how to find matching value for a row (when using left or right join on rows)</param>
-  /// <param name="op">A function that is applied to aligned values. The `Zip` operation is generic in the type of this function and the type of function is used to determine which values in the frames are zipped and which are left unchanged.</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("ZipInto")>]
   let zip (op:'V1->'V2->'V) (frame1:Frame<'R, 'C>) (frame2:Frame<'R, 'C>) : Frame<'R, 'C> =
@@ -1537,8 +1555,9 @@ module Frame =
   /// <example>
   /// To sum the values in all numerical columns according to the first component of a two level
   /// row key `'K1 * 'K2`, you can use the following:
-  ///
-  ///     df |> Frame.reduceLevel fst (fun (a:float) b -> a + b)
+  /// <code>
+  /// df |&gt; Frame.reduceLevel fst (fun (a:float) b -&gt; a + b)
+  /// </code>
   /// </example>
   /// <remarks>
   /// This function reduces values using a function `'T -> 'T -> 'T`. If you want to process
@@ -1559,15 +1578,16 @@ module Frame =
   /// </summary>
   /// <example>
   /// To get the standard deviation of values in all numerical columns according to the first
-  /// component of a two level row key `'K1 * 'K2`, you can use the following:
-  ///
-  ///     df |> Frame.applyLevel fst Stats.stdDev
+  /// component of a two level row key <c>'K1 * 'K2</c>, you can use the following:
+  /// <code>
+  /// df |&gt; Frame.applyLevel fst Stats.stdDev
+  /// </code>
   /// </example>
   /// <remarks>
-  /// This function reduces a series of values using a function `Series<'R, 'T> -> 'T`. If
-  /// you want to reduce values using a simpler function `'T -> 'T -> 'T`, you can use
+  /// This function reduces a series of values using a function <c>Series&lt;'R, 'T&gt; -&gt; 'T</c>. If
+  /// you want to reduce values using a simpler function <c>'T -&gt; 'T -&gt; 'T</c>, you can use
   /// `Frame.reduceLevel` instead.
-  /// </remarks>/
+  /// </remarks>
   /// <category>Hierarchical index operations</category>
   [<CompiledName("ApplyLevel")>]
   let applyLevel (levelSel:_ -> 'K) (op:_ -> 'T) (frame:Frame<'R, 'C>) =
@@ -1575,11 +1595,12 @@ module Frame =
     |> Series.map (fun _ s -> Series.applyLevel levelSel op s)
     |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Given a frame with two-level row index, returns a series indexed by the first
   /// part of the key, containing frames representing individual groups. This function
   /// can be used if you want to perform a transformation individually on each group
   /// (e.g. using `Series.mapValues` after calling `Frame.nest`).
-  ///
+  /// </summary>
   /// <category>Hierarchical index operations</category>
   [<CompiledName("Nest")>]
   let nest (frame:Frame<'R1 * 'R2, 'C>) =

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -145,15 +145,12 @@ namespace Deedle
 /// ---------------------------------
 ///
 /// The functions in this group can be used to write computations over frames that may fail.
-/// They use the type `tryval<'T>` which is defined as a discriminated union:
-/// <code>
-///     type tryval&lt;'T&gt; =
-///       | Success of 'T
-///       | Error of exn
-/// </code>
-/// Using `tryval<'T>` as a value in a data frame is not generally recommended, because
+/// They use the type <c>tryval&lt;'T&gt;</c> which is defined as a discriminated union
+/// with two cases: Success containing a value, or Error containing an exception.
+///
+/// Using <c>tryval&lt;'T&gt;</c> as a value in a data frame is not generally recommended, because
 /// the type of values cannot be tracked in the type. For this reason, it is better to use
-/// `tryval<'T>` with individual series. However, `tryValues` and `fillErrorsWith` functions
+/// <c>tryval&lt;'T&gt;</c> with individual series. However, `tryValues` and `fillErrorsWith` functions
 /// can be used to get values, or fill failed values inside an entire data frame.
 ///
 /// The `tryMapRows` function is more useful. It can be used to write a transformation

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -72,47 +72,52 @@ namespace Deedle
 ///
 /// Sorting and index manipulation
 /// ------------------------------
-///
+/// <summary>
 /// A frame is indexed by row keys and column keys. Both of these indices can be sorted
 /// (by the keys). A frame that is sorted allows a number of additional operations (such
 /// as lookup using the `Lookp.ExactOrSmaller` lookup behavior). The functions in this
 /// category provide ways for manipulating the indices. It is expected that most operations
 /// are done on rows and so more functions are available in a row-wise way. A frame can
 /// alwyas be transposed using `Frame.transpose`.
-///
-/// ### Index operations
-///
+/// </summary>
+/// <remarks>
+/// <para>Index operations:</para>
+/// <para>
 /// The existing row/column keys can be replaced by a sequence of new keys using the
 /// `indexColsWith` and `indexRowsWith` functions. Row keys can also be replaced by
 /// ordinal numbers using `indexRowsOrdinally`.
-///
+/// </para>
+/// <para>
 /// The function `indexRows` uses the specified column of the original frame as the
 /// index. It removes the column from the resulting frame (to avoid this, use overloaded
 /// `IndexRows` method). This function infers the type of row keys from the context, so it
 /// is usually more convenient to use `indexRows[Date|String|Int|...]` functions. Finally,
 /// if you want to calculate the index value based on multiple columns of the row, you
 /// can use `indexRowsUsing`.
-///
-/// ### Sorting frame rows
-///
+/// </para>
+/// <para>Sorting frame rows:</para>
+/// <para>
 /// Frame rows can be sorted according to the value of a specified column using the
 /// `sortRows` function; `sortRowsBy` takes a projection function which lets you
 /// transform the value of a column (e.g. to project a part of the value).
-///
+/// </para>
+/// <para>
 /// The functions `sortRowsByKey` and `sortColsByKey` sort the rows or columns
 /// using the default ordering on the key values. The result is a frame with ordered
 /// index.
-///
-/// ### Expanding columns
-///
+/// </para>
+/// <para>Expanding columns:</para>
+/// <para>
 /// When the frame contains a series with complex .NET objects such as F# records or
 /// C# classes, it can be useful to "expand" the column. This operation looks at the
 /// type of the objects, gets all properties of the objects (recursively) and
 /// generates multiple series representing the properties as columns.
-///
+/// </para>
+/// <para>
 /// The function `expandCols` expands the specified columns while `expandAllCols`
 /// applies the expansion to all columns of the data frame.
-///
+/// </para>
+/// </remarks>
 /// Frame transformations
 /// ---------------------
 ///
@@ -395,43 +400,40 @@ module Frame =
     |> sliceCols columns
     |> sliceRows rows
 
+  /// <summary>
   /// Creates a new data frame that contains all data from
   /// the original data frame, together with an additional series.
   /// The operation uses left join and aligns new series to the
   /// existing frame keys.
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the newly added column
-  ///  - `series` - A data series to be added (the row key type has to match)
-  ///  - `frame` - Source data frame (which is not mutated by the operation)
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the newly added column</param>
+  /// <param name="series">A data series to be added (the row key type has to match)</param>
+  /// <param name="frame">Source data frame (which is not mutated by the operation)</param>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("AddColumn")>]
   let addCol column (series:Series<_, 'V>) (frame:Frame<'R, 'C>) =
     let f = frame.Clone() in f.AddColumn(column, series); f
 
+  /// <summary>
   /// Creates a new data frame that contains all data from the original
   /// data frame without the specified series (column). The operation throws
   /// if the column key is not found.
-  ///
-  /// ## Parameters
-  ///  - `column` - The key (or name) to be dropped from the frame
-  ///  - `frame` - Source data frame (which is not mutated by the operation)
-  ///
+  /// </summary>
+  /// <param name="column">The key (or name) to be dropped from the frame</param>
+  /// <param name="frame">Source data frame (which is not mutated by the operation)</param>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("DropColumn")>]
   let dropCol column (frame:Frame<'R, 'C>) =
     let f = frame.Clone() in f.DropColumn(column); f
 
+  /// <summary>
   /// Creates a new data frame where the specified column is replaced
   /// with a new series. (If the series does not exist, only the new
   /// series is added.)
-  ///
-  /// ## Parameters
-  ///  - `column` - A key (or name) for the column to be replaced or added
-  ///  - `series` - A data series to be used (the row key type has to match)
-  ///  - `frame` - Source data frame (which is not mutated by the operation)
-  ///
+  /// </summary>
+  /// <param name="column">A key (or name) for the column to be replaced or added</param>
+  /// <param name="series">A data series to be used (the row key type has to match)</param>
+  /// <param name="frame">Source data frame (which is not mutated by the operation)</param>
   /// <category>Accessing frame data and lookup</category>
   [<CompiledName("ReplaceColumn")>]
   let replaceCol column series (frame:Frame<'R, 'C>) =
@@ -512,14 +514,13 @@ module Frame =
   let groupRowsByIndex (keySelector:_ -> 'K) (frame:Frame<'R,'C>) =
     frame.GroupRowsByIndex (Func<_,_>(keySelector))
 
+  /// <summary>
   /// Returns a data frame whose rows are grouped by `groupBy` and whose columns specified
   /// in `aggBy` are aggregated according to `aggFunc`.
-  ///
-  /// ## Parameters
-  ///  - `groupBy` - sequence of columns to group by
-  ///  - `aggBy` - sequence of columns to apply aggFunc to
-  ///  - `aggFunc` - invoked in order to aggregate values
-  ///
+  /// </summary>
+  /// <param name="groupBy">sequence of columns to group by</param>
+  /// <param name="aggBy">sequence of columns to apply aggFunc to</param>
+  /// <param name="aggFunc">invoked in order to aggregate values</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("AggregateRowsBy")>]
   let aggregateRowsBy groupBy aggBy (aggFunc:Series<'R, 'V1> -> 'V2) (frame:Frame<'R,'C>) =
@@ -529,17 +530,16 @@ module Frame =
   // Pivot table
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Creates a new data frame resulting from a 'pivot' operation. Consider a denormalized data
   /// frame representing a table: column labels are field names & table values are observations
   /// of those fields. pivotTable buckets the rows along two axes, according to the results of
   /// the functions `rowGrp` and `colGrp`; and then computes a value for the frame of rows that
   /// land in each bucket.
-  ///
-  /// ## Parameters
-  ///  - `rowGrp` - A function from rowkey & row to group value for the resulting row index
-  ///  - `colGrp` - A function from rowkey & row to group value for the resulting col index
-  ///  - `op` - A function computing a value from the corresponding bucket frame
-  ///
+  /// </summary>
+  /// <param name="rowGrp">A function from rowkey & row to group value for the resulting row index</param>
+  /// <param name="colGrp">A function from rowkey & row to group value for the resulting col index</param>
+  /// <param name="op">A function computing a value from the corresponding bucket frame</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("PivotTable")>]
   let pivotTable (rowGrp:'R -> ObjectSeries<'C> -> 'RNew) (colGrp:'R -> ObjectSeries<'C> -> 'CNew) (op:Frame<'R, 'C> -> 'T) (frame:Frame<'R, 'C>): Frame<'RNew, 'CNew> =
@@ -550,29 +550,27 @@ module Frame =
     |> Series.mapValues (Series.mapValues (fromRows >> op))                       // -> Series<'CNew, Series<'RNew, 'T>>
     |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder              // -> Frame<'RNew, 'CNew, 'T>
 
+  /// <summary>
   /// Creates a sliding window using the specified size. The result is a series
   /// containing data frames that represent individual windows.
   /// This function skips incomplete chunks.
-  ///
-  /// ## Parameters
-  ///  - `size` - The size of the sliding window.
-  ///  - `frame` - The input frame to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="size">The size of the sliding window.</param>
+  /// <param name="frame">The input frame to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("Window")>]
   let window size (frame:Frame<'R, 'C>) =
     let fromRows rs = rs |> FrameUtils.fromRowsAndColumnKeys frame.IndexBuilder frame.VectorBuilder frame.ColumnIndex.Keys
     frame.Rows |> Series.windowInto size fromRows
 
+  /// <summary>
   /// Creates a sliding window using the specified size and then applies the provided
   /// value selector `f` on each window to produce the result which is returned as a new series.
   /// This function skips incomplete chunks.
-  ///
-  /// ## Parameters
-  ///  - `size` - The size of the sliding window.
-  ///  - `frame` - The input frame to be aggregated.
-  ///  - `f` - A function that is called on each created window.
-  ///
+  /// </summary>
+  /// <param name="size">The size of the sliding window.</param>
+  /// <param name="frame">The input frame to be aggregated.</param>
+  /// <param name="f">A function that is called on each created window.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowInto")>]
   let windowInto size f (frame:Frame<'R, 'C>) =
@@ -656,15 +654,13 @@ module Frame =
   // Sorting and index manipulation
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Align the existing data to a specified collection of row keys. Values in the data frame
   /// that do not match any new key are dropped, new keys (that were not in the original data
   /// frame) are assigned missing values.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame that is to be realigned.
-  ///  - `keys` - A sequence of new row keys. The keys must have the same type as the original
-  ///    frame keys (because the rows are realigned).
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame that is to be realigned.</param>
+  /// <param name="keys">A sequence of new row keys. The keys must have the same type as the original frame keys (because the rows are realigned).</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("RealignRows")>]
   let realignRows keys (frame:Frame<'R, 'C>) =
@@ -674,111 +670,97 @@ module Frame =
     let cmd v =  VectorHelpers.transformColumn frame.VectorBuilder newIdx.AddressingScheme relocs v
     Frame<_, _>(newIdx, frame.ColumnIndex, frame.Data.Select(cmd), frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. The generic type parameter is specifies the type of the values in the required
   /// index column (and usually needs to be specified using a type annotation). The specified
   /// column is removed from the resulting frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index is to be replaced.
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index is to be replaced.</param>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRows")>]
   let indexRows column (frame:Frame<'R1, 'C>) : Frame<'R2, _> = frame.IndexRows<'R2>(column)
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `obj`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
   /// The specified column is removed from the resulting frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index is to be replaced.
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index is to be replaced.</param>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRowsByObject")>]
   let indexRowsObj column (frame:Frame<'R1, 'C>) : Frame<obj, _> = indexRows column frame
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `int`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
   /// The specified column is removed from the resulting frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index is to be replaced.
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index is to be replaced.</param>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRowsByInt")>]
   let indexRowsInt column (frame:Frame<'R1, 'C>) : Frame<int, _> = indexRows column frame
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `DateTime`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
   /// The specified column is removed from the resulting frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index is to be replaced.
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index is to be replaced.</param>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRowsByDateTime")>]
   let indexRowsDate column (frame:Frame<'R1, 'C>) : Frame<DateTime, _> = indexRows column frame
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `DateTimeOffset`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
   /// The specified column is removed from the resulting frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index is to be replaced.
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index is to be replaced.</param>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRowsByDateTimeOffset")>]
   let indexRowsDateOffs column (frame:Frame<'R1, 'C>) : Frame<DateTimeOffset, _> = indexRows column frame
 
+  /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
   /// data frame. This function casts (or converts) the column key to values of type `string`
   /// (a generic variant that may require some type annotation is `Frame.indexRows`)
   /// The specified column is removed from the resulting frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index is to be replaced.
-  ///  - `column` - The name of a column in the original data frame that will be used for the new
-  ///    index. Note that the values in the column need to be unique.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index is to be replaced.</param>
+  /// <param name="column">The name of a column in the original data frame that will be used for the new index. Note that the values in the column need to be unique.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRowsByString")>]
   let indexRowsString column (frame:Frame<'R1, 'C>) : Frame<string, _> = indexRows column frame
 
+  /// <summary>
   /// Replace the column index of the frame with the provided sequence of column keys.
   /// The columns of the frame are assigned keys according to the provided order.
   /// The specified column is removed from the resulting frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose column index are to be replaced.
-  ///  - `keys` - A collection of new column keys.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose column index are to be replaced.</param>
+  /// <param name="keys">A collection of new column keys.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexColumnsWith")>]
   let indexColsWith (keys:seq<'C2>) (frame:Frame<'R, 'C1>) =
     if Seq.length frame.ColumnKeys <> Seq.length keys then invalidArg "keys" "New keys do not match current column index length"
     Frame<_, _>(frame.RowIndex, Index.ofKeys (ReadOnlyCollection.ofSeq keys), frame.Data, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Replace the row index of the frame with the provided sequence of row keys.
   /// The rows of the frame are assigned keys according to the provided order.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index are to be replaced.
-  ///  - `keys` - A collection of new row keys.
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index are to be replaced.</param>
+  /// <param name="keys">A collection of new row keys.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRowsWith")>]
   let indexRowsWith (keys:seq<'R2>) (frame:Frame<'R1, 'C>) =
@@ -797,13 +779,12 @@ module Frame =
   let indexRowsOrdinally (frame:Frame<'TRowKey, 'TColumnKey>) =
     frame |> indexRowsWith [0 .. frame.RowCount-1]
 
+  /// <summary>
   /// Replace the row index of the frame with a sequence of row keys generated using
   /// a function invoked on each row.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Source data frame whose row index are to be replaced.
-  ///  - `f` - A function from row (as object series) to new row key value
-  ///
+  /// </summary>
+  /// <param name="frame">Source data frame whose row index are to be replaced.</param>
+  /// <param name="f">A function from row (as object series) to new row key value</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexRowsUsing")>]
   let indexRowsUsing (f: ObjectSeries<'C> -> 'R2) (frame:Frame<'R1,'C>) =
@@ -871,37 +852,37 @@ module Frame =
     let newData = frame.VectorBuilder.Build(newColIndex.AddressingScheme, colCmd, [| frame.Data |])
     Frame<_, _>(frame.RowIndex, newColIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Creates a new data frame where all columns are expanded based on runtime
   /// structure of the objects they store. The expansion is performed recrusively
   /// to the specified depth. A column can be expanded if it is `Series<string, T>`
   /// or `IDictionary<K, V>` or if it is any .NET object with readable
   /// properties.
-  ///
-  /// ## Parameters
-  ///  - `nesting` - The nesting level for expansion. When set to 0, nothing is done.
-  ///  - `frame` - Input data frame whose columns will be expanded
-  ///
+  /// </summary>
+  /// <param name="nesting">The nesting level for expansion. When set to 0, nothing is done.</param>
+  /// <param name="frame">Input data frame whose columns will be expanded</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("ExpandAllColumns")>]
   let expandAllCols nesting (frame:Frame<'R, string>) =
     FrameUtils.expandVectors nesting false frame
 
+  /// <summary>
   /// Creates a new data frame where the specified columns are expanded based on runtime
   /// structure of the objects they store. A column can be expanded if it is
   /// `Series<string, T>` or `IDictionary<K, V>` or if it is any .NET object with readable
   /// properties.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <param name="names">Names of columns in the original data frame to be expanded</param>
+  /// <param name="frame">Input data frame whose columns will be expanded</param>
+  /// <remarks>
+  /// <example>
   /// Given a data frame with a series that contains tuples, you can expand the
   /// tuple members and get a frame with columns `S.Item1` and `S.Item2`:
   ///
   ///     let df = frame [ "S" => series [ 1 => (1, "One"); 2 => (2, "Two") ] ]
   ///     df |> Frame.expandCols ["S"]
-  ///
-  /// ## Parameters
-  ///  - `names` - Names of columns in the original data frame to be expanded
-  ///  - `frame` - Input data frame whose columns will be expanded
-  ///
+  /// </example>
+  /// </remarks>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("ExpandColumns")>]
   let expandCols names (frame:Frame<'R, string>) =
@@ -972,45 +953,40 @@ module Frame =
       invalidArg "count" "Must be greater than zero and less than the number of keys."
     getRange (frame.RowIndex.AddressAt(0L)) (frame.RowIndex.AddressAt((frame.RowCount-1-count) |> int64))  frame
 
+  /// <summary>
   /// Returns a new data frame containing only the rows of the input frame
   /// for which the specified predicate returns `true`. The predicate is called
   /// with the row key and object series that represents the row data.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of two arguments that defines the predicate
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of two arguments that defines the predicate</param>
   /// <category>Frame transformations</category>
   [<CompiledName("WhereRows")>]
   let filterRows f (frame:Frame<'R, 'C>) =
     frame.Rows |> Series.filter f |> FrameUtils.fromRowsAndColumnKeys frame.IndexBuilder frame.VectorBuilder frame.ColumnIndex.Keys
 
+  /// <summary>
   /// Returns a new data frame containing only the rows of the input frame
   /// for which the specified predicate returns `true`. The predicate is called
   /// with an object series that represents the row data (use `filterRows`
   /// if you need to access the row key).
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of one argument that defines the predicate
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of one argument that defines the predicate</param>
   /// <category>Frame transformations</category>
   [<CompiledName("WhereRowValues")>]
   let filterRowValues f (frame:Frame<'R, 'C>) =
     frame.Rows |> Series.filterValues f |> FrameUtils.fromRowsAndColumnKeys frame.IndexBuilder frame.VectorBuilder frame.ColumnIndex.Keys
 
 
+  /// <summary>
   /// Returns a new data frame containing only the rows of the input frame
   /// for which the specified `column` has the specified `value`. The operation
   /// may be implemented via an index for virtualized Deedle frames.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `column` - The name of the column to be matched
-  ///  - `value` - Required value of the column. Note that the function
-  ///    is generic and no conversions are performed, so the value has
-  ///    to match including the actual type.
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="column">The name of the column to be matched</param>
+  /// <param name="value">Required value of the column. Note that the function is generic and no conversions are performed, so the value has to match including the actual type.</param>
   /// <category>Frame transformations</category>
   [<CompiledName("WhereRowsBy")>]
   let filterRowsBy column (value:'V) (frame:Frame<'R, 'C>) =
@@ -1021,40 +997,37 @@ module Frame =
     Frame<_, _>(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
 
+  /// <summary>
   /// Builds a new data frame whose rows are the results of applying the specified
   /// function on the rows of the input data frame. The function is called
   /// with the row key and object series that represents the row data.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of two arguments that defines the row mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of two arguments that defines the row mapping</param>
   /// <category>Frame transformations</category>
   [<CompiledName("SelectRows")>]
   let inline mapRows (f:_ -> _ -> 'V) (frame:Frame<'R, 'C>) =
     frame.Rows |> Series.map f
 
+  /// <summary>
   /// Builds a new data frame whose rows are the results of applying the specified
   /// function on the rows of the input data frame. The function is called
   /// with an object series that represents the row data (use `mapRows`
   /// if you need to access the row key).
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of one argument that defines the row mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of one argument that defines the row mapping</param>
   /// <category>Frame transformations</category>
   [<CompiledName("SelectRowValues")>]
   let inline mapRowValues (f:_ -> 'V) (frame:Frame<'R, 'C>) =
     frame.Rows |> Series.mapValues f
 
+  /// <summary>
   /// Builds a new data frame whose row keys are the results of applying the
   /// specified function on the row keys of the original data frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of one argument that defines the row key mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of one argument that defines the row key mapping</param>
   /// <category>Frame transformations</category>
   [<CompiledName("SelectRowKeys")>]
   let mapRowKeys (f:'R1 -> 'R2) (frame:Frame<_, 'C>) =
@@ -1062,67 +1035,62 @@ module Frame =
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme (Vectors.Return 0))
     Frame(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Returns a new data frame containing only the columns of the input frame
   /// for which the specified predicate returns `true`. The predicate is called
   /// with the column key and object series that represents the column data.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of two arguments that defines the predicate
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of two arguments that defines the predicate</param>
   /// <category>Frame transformations</category>
   [<CompiledName("WhereColumns")>]
   let filterCols f (frame:Frame<'R, 'C>) =
     frame.Columns |> Series.filter f |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Returns a new data frame containing only the columns of the input frame
   /// for which the specified predicate returns `true`. The predicate is called
   /// with an object series that represents the column data (use `filterCols`
   /// if you need to access the column key).
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of one argument that defines the predicate
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of one argument that defines the predicate</param>
   /// <category>Frame transformations</category>
   [<CompiledName("WhereColumnValues")>]
   let filterColValues f (frame:Frame<'R, 'C>) =
     frame.Columns |> Series.filterValues f |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Builds a new data frame whose columns are the results of applying the specified
   /// function on the columns of the input data frame. The function is called
   /// with the column key and object series that represents the column data.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of two arguments that defines the column mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of two arguments that defines the column mapping</param>
   /// <category>Frame transformations</category>
   [<CompiledName("SelectColumns")>]
   let mapCols f (frame:Frame<'R, 'C>) =
     frame.Columns |> Series.map f |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Builds a new data frame whose columns are the results of applying the specified
   /// function on the columns of the input data frame. The function is called
   /// with an object series that represents the column data (use `mapCols`
   /// if you need to access the column key).
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of one argument that defines the column mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of one argument that defines the column mapping</param>
   /// <category>Frame transformations</category>
   [<CompiledName("SelectColumnValues")>]
   let mapColValues f (frame:Frame<'R, 'C>) =
     frame.Columns |> Series.mapValues f |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Builds a new data frame whose column keys are the results of applying the
   /// specified function on the column keys of the original data frame.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function of one argument that defines the column key mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function of one argument that defines the column key mapping</param>
   /// <category>Frame transformations</category>
   [<CompiledName("SelectColumnKeys")>]
   let mapColKeys f (frame:Frame<'R, 'C>) =
@@ -1130,41 +1098,40 @@ module Frame =
     let newData = frame.VectorBuilder.Build(newColIndex.AddressingScheme, Vectors.Return 0, [| frame.Data |])
     Frame(frame.RowIndex, newColIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Builds a new data frame whose values are the results of applying the specified
   /// function on these values, but only for those columns which can be converted
   /// to the appropriate type for input to the mapping function (use `map` if you need
   //// to access the row and column keys).
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function that defines the mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function that defines the mapping</param>
   /// <category>Frame transformations</category>
   [<CompiledName("MapValues")>]
   let mapValues f (frame:Frame<'R, 'C>) = frame.SelectValues(Func<_,_>(f))
 
+  /// <summary>
   /// Builds a new data frame whose values are the results of applying the specified
   /// function on these values, but only for those columns which can be converted
   /// to the appropriate type for input to the mapping function.
-  ///
-  /// ## Parameters
-  ///  - `frame` - Input data frame to be transformed
-  ///  - `f` - Function that defines the mapping
-  ///
+  /// </summary>
+  /// <param name="frame">Input data frame to be transformed</param>
+  /// <param name="f">Function that defines the mapping</param>
   /// <category>Frame transformations</category>
   let map f (frame:Frame<'R, 'C>) = frame.Select(Func<_,_,_,_>(f))
 
+  /// <summary>
   /// Returns a series that contains the results of aggregating each column
   /// to a single value. The function takes columns that can be converted to
   /// the type expected by the specified `op` function and reduces the values
   /// in each column using `Series.reduceValues`.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <example>
   /// The following sums the values in each column that can be converted to
   /// `float` and returns the result as a new series:
   ///
   ///     df |> Frame.reduceValues (fun (a:float) b -> a + b)
-  ///
+  /// </example>
   /// <category>Frame transformations</category>
   [<CompiledName("ReduceValues")>]
   let reduceValues (op:'T -> 'T -> 'T) (frame:Frame<'R, 'C>) =
@@ -1190,21 +1157,20 @@ module Frame =
   let inline minRowBy column (frame:Frame<'R, 'C>) =
     frame.Rows |> Stats.minBy (fun row -> row.GetAs<float>(column))
 
+  /// <summary>
   /// Returns a frame with columns shifted by the specified offset. When the offset is
   /// positive, the values are shifted forward and first `offset` keys are dropped. When the
   /// offset is negative, the values are shifted backwards and the last `offset` keys are dropped.
   /// Expressed in pseudo-code:
   ///
   ///     result[k] = series[k - offset]
-  ///
-  /// ## Parameters
-  ///  - `offset` - Can be both positive and negative number.
-  ///  - `frame` - The input frame whose columns are to be shifted.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="offset">Can be both positive and negative number.</param>
+  /// <param name="frame">The input frame whose columns are to be shifted.</param>
+  /// <remarks>
   /// If you want to calculate the difference, e.g. `df - (Frame.shift 1 df)`, you can
   /// use `Frame.diff` which will be a little bit faster.
-  ///
+  /// </remarks>
   /// <category>Frame transformations</category>
   [<CompiledName("Shift")>]
   let shift offset (frame:Frame<'R, 'C>) =
@@ -1213,6 +1179,7 @@ module Frame =
     let newData = frame.Data.Select(VectorHelpers.transformColumn vectorBuilder newRowIndex.AddressingScheme cmd)
     Frame(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Returns a frame with columns containing difference between an original value and
   /// a value at the specified offset. For example, calling `Frame.diff 1 s` returns a
   /// frame where previous column values is subtracted from the current ones. In pseudo-code, the
@@ -1221,12 +1188,9 @@ module Frame =
   ///     result[k] = series[k] - series[k - offset]
   ///
   /// Columns that cannot be converted to `float` are left without a change.
-  ///
-  /// ## Parameters
-  ///  - `offset` - When positive, subtracts the past values from the current values;
-  ///    when negative, subtracts the future values from the current values.
-  ///  - `frame` - The input frame containing at least some `float` columns.
-  ///
+  /// </summary>
+  /// <param name="offset">When positive, subtracts the past values from the current values; when negative, subtracts the future values from the current values.</param>
+  /// <param name="frame">The input frame containing at least some `float` columns.</param>
   /// <category>Frame transformations</category>
   [<CompiledName("Diff")>]
   let diff offset (frame:Frame<'R, 'C>) =
@@ -1287,34 +1251,29 @@ module Frame =
   // Missing values
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Fill missing values of a given type in the frame with a constant value.
   /// The operation is only applied to columns (series) that contain values of the
   /// same type as the provided filling value. The operation does not attempt to
   /// convert between numeric values (so a series containing `float` will not be
   /// converted to a series of `int`).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filled
-  ///  - `value` - A constant value that is used to fill all missing values
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filled</param>
+  /// <param name="value">A constant value that is used to fill all missing values</param>
   /// <category>Missing values</category>
   [<CompiledName("FillMissingWith")>]
   let fillMissingWith (value:'T) (frame:Frame<'R, 'C>) =
     frame.ColumnApply(ConversionKind.Safe, fun (s:Series<_, 'T>) -> Series.fillMissingWith value s :> ISeries<_>)
 
+  /// <summary>
   /// Fill missing values in the data frame with the nearest available value
   /// (using the specified direction). Note that the frame may still contain
   /// missing values after call to this function (e.g. if the first value is not available
   /// and we attempt to fill series with previous values). This operation can only be
   /// used on ordered frames.
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filled
-  ///  - `direction` - Specifies the direction used when searching for
-  ///    the nearest available value. `Backward` means that we want to
-  ///    look for the first value with a smaller key while `Forward` searches
-  ///    for the nearest greater key.
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filled</param>
+  /// <param name="direction">Specifies the direction used when searching for the nearest available value. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
   /// <category>Missing values</category>
   [<CompiledName("FillMissing")>]
   let fillMissing direction (frame:Frame<'R, 'C>) =
@@ -1322,6 +1281,7 @@ module Frame =
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder frame.RowIndex.AddressingScheme fillCmd)
     Frame<_, _>(frame.RowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
+  /// <summary>
   /// Fill missing values in the frame using the specified function. The specified
   /// function is called with all series and keys for which the frame does not
   /// contain value and the result of the call is used in place of the missing value.
@@ -1330,13 +1290,9 @@ module Frame =
   /// same type as the return type of the provided filling function. The operation
   /// does not attempt to convert between numeric values (so a series containing
   /// `float` will not be converted to a series of `int`).
-  ///
-  /// ## Parameters
-  ///  - `frame` - An input data frame that is to be filled
-  ///  - `f` - A function that takes a series `Series<R, T>` together with a key `K`
-  ///    in the series and generates a value to be used in a place where the original
-  ///    series contains a missing value.
-  ///
+  /// </summary>
+  /// <param name="frame">An input data frame that is to be filled</param>
+  /// <param name="f">A function that takes a series `Series<R, T>` together with a key `K` in the series and generates a value to be used in a place where the original series contains a missing value.</param>
   /// <category>Missing values</category>
   [<CompiledName("FillMissingUsing")>]
   let fillMissingUsing (f:Series<'R, 'T> -> 'R -> 'T) (frame:Frame<'R, 'C>) =
@@ -1458,39 +1414,29 @@ module Frame =
   // Joining, merging and zipping
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Join two data frames. The columns of the joined frames must not overlap and their
   /// rows are aligned and transformed according to the specified join kind.
   /// For more alignment options on ordered frames, see `joinAlign`.
-  ///
-  /// ## Parameters
-  ///  - `frame1` - First data frame (left) to be used in the joining
-  ///  - `frame2` - Other frame (right) to be joined with `frame1`
-  ///  - `kind` - Specifies the joining behavior on row indices. Use `JoinKind.Outer` and
-  ///    `JoinKind.Inner` to get the union and intersection of the row keys, respectively.
-  ///    Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right
-  ///    data frame.
-  ///
+  /// </summary>
+  /// <param name="frame1">First data frame (left) to be used in the joining</param>
+  /// <param name="frame2">Other frame (right) to be joined with `frame1`</param>
+  /// <param name="kind">Specifies the joining behavior on row indices. Use `JoinKind.Outer` and `JoinKind.Inner` to get the union and intersection of the row keys, respectively. Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right data frame.</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Join")>]
   let join kind (frame1:Frame<'R, 'C>) frame2 = frame1.Join(frame2, kind)
 
+  /// <summary>
   /// Join two data frames. The columns of the joined frames must not overlap and their
   /// rows are aligned and transformed according to the specified join kind.
   /// When the index of both frames is ordered, it is possible to specify `lookup`
   /// in order to align indices from other frame to the indices of the main frame
   /// (typically, to find the nearest key with available value for a key).
-  ///
-  /// ## Parameters
-  ///  - `frame1` - First data frame (left) to be used in the joining
-  ///  - `frame2` - Other frame (right) to be joined with `frame1`
-  ///  - `kind` - Specifies the joining behavior on row indices. Use `JoinKind.Outer` and
-  ///    `JoinKind.Inner` to get the union and intersection of the row keys, respectively.
-  ///    Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right
-  ///    data frame.
-  ///  - `lookup` - When `kind` is `Left` or `Right` and the two frames have ordered row index,
-  ///    this parameter can be used to specify how to find value for a key when there is no
-  ///    exactly matching key or when there are missing values.
-  ///
+  /// </summary>
+  /// <param name="frame1">First data frame (left) to be used in the joining</param>
+  /// <param name="frame2">Other frame (right) to be joined with `frame1`</param>
+  /// <param name="kind">Specifies the joining behavior on row indices. Use `JoinKind.Outer` and `JoinKind.Inner` to get the union and intersection of the row keys, respectively. Use `JoinKind.Left` and `JoinKind.Right` to use the current key of the left/right data frame.</param>
+  /// <param name="lookup">When `kind` is `Left` or `Right` and the two frames have ordered row index, this parameter can be used to specify how to find value for a key when there is no exactly matching key or when there are missing values.</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("JoinAlign")>]
   let joinAlign kind lookup (frame1:Frame<'R, 'C>) frame2 = frame1.Join(frame2, kind, lookup)
@@ -1513,6 +1459,7 @@ module Frame =
       let head = frames |> Seq.head
       head.Merge(frames |> Seq.skip 1)
 
+  /// <summary>
   /// Append two data frames with non-overlapping values. The operation takes the union of columns
   /// and rows of the source data frames and then unions the values. An exception is thrown when
   /// both data frames define value for a column/row location, but the operation succeeds if one
@@ -1521,15 +1468,14 @@ module Frame =
   /// Note that the rows are *not* automatically reindexed to avoid overlaps. This means that when
   /// a frame has rows indexed with ordinal numbers, you may need to explicitly reindex the row
   /// keys before calling append.
-  ///
-  /// ## Parameters
-  ///  - `frame1` - First of the two frames to be merged (combined)
-  ///  - `frame2` - The other frame to be merged (combined) with the first instance
-  ///
+  /// </summary>
+  /// <param name="frame1">First of the two frames to be merged (combined)</param>
+  /// <param name="frame2">The other frame to be merged (combined) with the first instance</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Merge")>]
   let merge (frame1:Frame<'R, 'C>) frame2 = mergeAll [frame1; frame2]
 
+  /// <summary>
   /// Aligns two data frames using both column index and row index and apply the specified operation
   /// on values of a specified type that are available in both data frames. The parameters `columnKind`,
   /// and `rowKind` can be specified to determine how the alginment works (similarly to `Join`).
@@ -1538,22 +1484,19 @@ module Frame =
   /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
-  ///
-  /// ## Parameters
-  ///  - `frame1` - First frame to be aligned and zipped with the other instance
-  ///  - `frame2` - Other frame to be aligned and zipped with the first  instance
-  ///  - `columnKind` - Specifies how to align columns (inner, outer, left or right join)
-  ///  - `rowKind` - Specifies how to align rows (inner, outer, left or right join)
-  ///  - `lookup` - Specifies how to find matching value for a row (when using left or right join on rows)
-  ///  - `op` - A function that is applied to aligned values. The `Zip` operation is generic
-  ///    in the type of this function and the type of function is used to determine which
-  ///    values in the frames are zipped and which are left unchanged.
-  ///
+  /// </summary>
+  /// <param name="frame1">First frame to be aligned and zipped with the other instance</param>
+  /// <param name="frame2">Other frame to be aligned and zipped with the first  instance</param>
+  /// <param name="columnKind">Specifies how to align columns (inner, outer, left or right join)</param>
+  /// <param name="rowKind">Specifies how to align rows (inner, outer, left or right join)</param>
+  /// <param name="lookup">Specifies how to find matching value for a row (when using left or right join on rows)</param>
+  /// <param name="op">A function that is applied to aligned values. The `Zip` operation is generic in the type of this function and the type of function is used to determine which values in the frames are zipped and which are left unchanged.</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("ZipAlignInto")>]
   let zipAlign columnKind rowKind lookup (op:'V1->'V2->'V) (frame1:Frame<'R, 'C>) (frame2:Frame<'R, 'C>) : Frame<'R, 'C> =
     frame1.Zip<'V1, 'V2, 'V>(frame2, columnKind, rowKind, lookup, false, fun a b -> op a b)
 
+  /// <summary>
   /// Aligns two data frames using both column index and row index and apply the specified operation
   /// on values of a specified type that are available in both data frames. This overload uses
   /// `JoinKind.Outer` for both columns and rows.
@@ -1561,17 +1504,13 @@ module Frame =
   /// Once aligned, the call `df1.Zip<T>(df2, f)` applies the specifed function `f` on all `T` values
   /// that are available in corresponding locations in both frames. For values of other types, the
   /// value from `df1` is returned.
-  ///
-  /// ## Parameters
-  ///  - `frame1` - First frame to be aligned and zipped with the other instance
-  ///  - `frame2` - Other frame to be aligned and zipped with the first  instance
-  ///  - `columnKind` - Specifies how to align columns (inner, outer, left or right join)
-  ///  - `rowKind` - Specifies how to align rows (inner, outer, left or right join)
-  ///  - `lookup` - Specifies how to find matching value for a row (when using left or right join on rows)
-  ///  - `op` - A function that is applied to aligned values. The `Zip` operation is generic
-  ///    in the type of this function and the type of function is used to determine which
-  ///    values in the frames are zipped and which are left unchanged.
-  ///
+  /// </summary>
+  /// <param name="frame1">First frame to be aligned and zipped with the other instance</param>
+  /// <param name="frame2">Other frame to be aligned and zipped with the first  instance</param>
+  /// <param name="columnKind">Specifies how to align columns (inner, outer, left or right join)</param>
+  /// <param name="rowKind">Specifies how to align rows (inner, outer, left or right join)</param>
+  /// <param name="lookup">Specifies how to find matching value for a row (when using left or right join on rows)</param>
+  /// <param name="op">A function that is applied to aligned values. The `Zip` operation is generic in the type of this function and the type of function is used to determine which values in the frames are zipped and which are left unchanged.</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("ZipInto")>]
   let zip (op:'V1->'V2->'V) (frame1:Frame<'R, 'C>) (frame2:Frame<'R, 'C>) : Frame<'R, 'C> =
@@ -1590,20 +1529,21 @@ module Frame =
   // ----------------------------------------------------------------------------------------------
 
   /// Reduce the values in each series according to the specified level of a hierarchical row key.
+  /// <summary>
   /// For each group of rows as specified by `levelSel`, the function reduces the values in each series
   /// using the preovided function `op` by applying `Series.reduceLevel`. Columns that cannot be
   /// converted to a type required by `op` are skipped.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <example>
   /// To sum the values in all numerical columns according to the first component of a two level
   /// row key `'K1 * 'K2`, you can use the following:
   ///
   ///     df |> Frame.reduceLevel fst (fun (a:float) b -> a + b)
-  //
-  /// ## Remarks
+  /// </example>
+  /// <remarks>
   /// This function reduces values using a function `'T -> 'T -> 'T`. If you want to process
   /// an entire group of values at once, you can use `applyLevel` instead.
-  ///
+  /// </remarks>
   /// <category>Hierarchical index operations</category>
   [<CompiledName("ReduceLevel")>]
   let reduceLevel (levelSel:_ -> 'K) (op:'T -> 'T -> 'T) (frame:Frame<'R, 'C>) =
@@ -1611,22 +1551,23 @@ module Frame =
     |> Series.map (fun _ -> Series.reduceLevel levelSel op)
     |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
 
+  /// <summary>
   /// Apply a specified function to a group of values in each series according to the specified
   /// level of a hierarchical row key. For each group of rows as specified by `levelSel`, the function
   /// applies the specified function `op` to all columns. Columns that cannot be converted to a
   /// type required by `op` are skipped.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <example>
   /// To get the standard deviation of values in all numerical columns according to the first
   /// component of a two level row key `'K1 * 'K2`, you can use the following:
   ///
   ///     df |> Frame.applyLevel fst Stats.stdDev
-  //
-  /// ## Remarks
+  /// </example>
+  /// <remarks>
   /// This function reduces a series of values using a function `Series<'R, 'T> -> 'T`. If
   /// you want to reduce values using a simpler function `'T -> 'T -> 'T`, you can use
   /// `Frame.reduceLevel` instead.
-  ///
+  /// </remarks>/
   /// <category>Hierarchical index operations</category>
   [<CompiledName("ApplyLevel")>]
   let applyLevel (levelSel:_ -> 'K) (op:_ -> 'T) (frame:Frame<'R, 'C>) =

--- a/src/Deedle/FrameStatsExtensions.fs
+++ b/src/Deedle/FrameStatsExtensions.fs
@@ -3,9 +3,11 @@
 open System
 open System.Runtime.CompilerServices
 
+/// <summary>
 /// The type implements C# and F# extension methods that add numerical operations
 /// to Deedle series. With a few exceptions, the methods are only available for
-/// series containing floating-point values, that is `Series<'K, float>`.
+/// series containing floating-point values, that is <c>Series&lt;'K, float&gt;</c>.
+/// </summary>
 ///
 /// <category>Frame and series operations</category>
 [<Extension>]
@@ -15,77 +17,97 @@ type FrameStatsExtensions =
   // Statistics
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// For each numerical column, returns the sum of the values in the column.
   /// The function skips over missing values and `NaN` values. When there are no
   /// available values, the result is 0.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Sum(df:Frame<'R, 'C>) = Stats.sum df
 
+  /// <summary>
   /// For each numerical column, returns the minimal values as a series.
   /// The function skips over missing and `NaN` values. When there are no values,
   /// the result is `NaN`.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Min(df:Frame<'R, 'C>) = Stats.min df
 
+  /// <summary>
   /// For each numerical column, returns the maximal values as a series.
   /// The function skips over missing and `NaN` values. When there are no values,
   /// the result is `NaN`.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Max(df:Frame<'R, 'C>) = Stats.max df
 
+  /// <summary>
   /// For each numerical column, returns the mean of the values in the column.
   /// The function skips over missing values and `NaN` values. When there are
   /// no available values, the result is NaN.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Mean(df:Frame<'R, 'C>) = Stats.mean df
 
+  /// <summary>
   /// For each numerical column, returns the standard deviation of the values in the column.
   /// The function skips over missing values and `NaN` values. When there are less than 2 values,
   /// the result is NaN.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member StdDev(df:Frame<'R, 'C>) = Stats.stdDev df
 
+  /// <summary>
   /// For each numerical column, returns the variance of the values in the column.
   /// The function skips over missing values and `NaN` values. When there are less
   /// than 2 values, the result is NaN.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Variance(df:Frame<'R, 'C>) = Stats.variance df
 
+  /// <summary>
   /// For each numerical column, returns the skewness of the values in a series.
   /// The function skips over missing values and `NaN` values. When there are less than 3 values,
   /// the result is NaN.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Skewness(df:Frame<'R, 'C>) = Stats.skew df
 
+  /// <summary>
   /// For each numerical column, returns the kurtosis of the values in a series.
   /// The function skips over missing values and `NaN` values. When there are less than 4 values,
   /// the result is NaN.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Kurtosis(df:Frame<'R, 'C>) = Stats.kurt df
 
+  /// <summary>
   /// For each numerical column, returns the median of the values in the column.
+  /// </summary>
   ///
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member Median(df:Frame<'R, 'C>) = Stats.median df
 
+  /// <summary>
   /// For each column, returns the number of unique values.
+  /// </summary>
   /// <category>Frame Statistics</category>
   [<Extension>]
   static member UniqueCount(df:Frame<'R, 'C>) = Stats.uniqueCount df

--- a/src/Deedle/FrameUtils.fs
+++ b/src/Deedle/FrameUtils.fs
@@ -22,7 +22,7 @@ module internal Reflection =
   let createTypedVectorHelper<'T> (input:seq<OptionalValue<obj>>) =
     input |> Seq.map (OptionalValue.map unbox<'T>) |> Vector.ofOptionalValues :> IVector
 
-  /// Helper function that returns contents of IDictionary<'K, 'V>
+  /// Helper function that returns contents of <c>IDictionary&lt;'K, 'V&gt;</c>
   let getDictionaryValues<'K, 'V> (input:IDictionary<'K, 'V>) =
     seq { for (KeyValue(k, v)) in input -> k.ToString(), (v.GetType(), box v) }
 
@@ -112,7 +112,7 @@ module internal Reflection =
                 if obj.HasValue then
                   yield key, (obj.Value.GetType(), obj.Value) } |> Some
     | _ ->
-    /// Get type arguments of the IDictionary<T1, T2> implementation or None
+    /// Get type arguments of the <c>IDictionary&lt;T1, T2&gt;</c> implementation or None
     let optTyArgs =
       value.GetType().GetInterfaces() |> Seq.tryPick (fun ityp ->
         if ityp.IsGenericType && ityp.GetGenericTypeDefinition() = typedefof<IDictionary<_, _>>

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -40,49 +40,37 @@ type Aggregation<'K> =
 ///
 /// <category>Parameters and results of various operations</category>
 type Aggregation =
+  /// <summary>
   /// Aggregate data into floating windows of a specified size
   /// and the provided handling of boundary elements.
-  ///
-  /// ## Parameters
-  ///
-  ///  - `size` - Specifies the size of the floating window. Depending on the
-  ///    boundary behavior, the actual created windows may be smaller.
-  ///  - `boundary` - Specifies how to handle boundaries (when there is not
-  ///    enough data to create an entire window).
+  /// </summary>
+  /// <param name="size">Specifies the size of the floating window. Depending on the boundary behavior, the actual created windows may be smaller.</param>
+  /// <param name="boundary">Specifies how to handle boundaries (when there is not enough data to create an entire window).</param>
   static member WindowSize(size, boundary) = WindowSize(size, boundary)
 
+  /// <summary>
   /// Aggregate data into non-overlapping chunks of a specified size
   /// and the provided handling of boundary elements.
-  ///
-  /// ## Parameters
-  ///
-  ///  - `size` - Specifies the size of the floating window. Depending on the
-  ///    boundary behavior, the actual created windows may be smaller.
-  ///  - `boundary` - Specifies how to handle boundaries (when there is not
-  ///    enough data to create an entire window).
+  /// </summary>
+  /// <param name="size">Specifies the size of the floating window. Depending on the boundary behavior, the actual created windows may be smaller.</param>
+  /// <param name="boundary">Specifies how to handle boundaries (when there is not enough data to create an entire window).</param>
   static member ChunkSize(size, boundary) = ChunkSize(size, boundary)
 
+  /// <summary>
   /// Aggregate data into floating windows where each window ends as soon
   /// as the specified function returns `false` when called with the
   /// first key and the current key as arguments.
-  ///
-  /// ## Parameters
-  ///
-  ///  - `condition` - A delegate that specifies when to end the current window
-  ///    (e.g. `(k1, k2) => k2 - k1 < 10` means that the difference between keys
-  ///    in each window will be less than 10.
+  /// </summary>
+  /// <param name="condition">A delegate that specifies when to end the current window (e.g. `(k1, k2) => k2 - k1 < 10` means that the difference between keys in each window will be less than 10.</param>
   static member WindowWhile<'K>(condition:System.Func<'K, 'K, bool>) =
     WindowWhile(fun k1 k2 -> condition.Invoke(k1, k2))
 
+  /// <summary>
   /// Aggregate data into non-overlapping chunks where each chunk ends as soon
   /// as the specified function returns `false` when called with the
   /// first key and the current key as arguments.
-  ///
-  /// ## Parameters
-  ///
-  ///  - `condition` - A delegate that specifies when to end the current chunk
-  ///    (e.g. `(k1, k2) => k2 - k1 < 10` means that the difference between keys
-  ///    in each chunk will be less than 10.
+  /// </summary>
+  /// <param name="condition">A delegate that specifies when to end the current chunk (e.g. `(k1, k2) => k2 - k1 < 10` means that the difference between keys in each chunk will be less than 10.</param>
   static member ChunkWhile<'K>(condition:System.Func<'K, 'K, bool>) =
     ChunkWhile(fun k1 k2 -> condition.Invoke(k1, k2))
 
@@ -176,13 +164,14 @@ and SeriesConstruction<'K when 'K : equality> = IIndex<'K> * VectorConstruction
 /// the index, together with a construction to apply (asynchronously) on vectors
 and AsyncSeriesConstruction<'K when 'K : equality> = Async<IIndex<'K>> * VectorConstruction
 
+/// <summary>
 /// A builder represents various ways of constructing index, either from keys or from
 /// other indices. The operations that build a new index from an existing index also
 /// build `VectorConstruction` which specifies how to transform vectors aligned with the
 /// previous index to match the new index. The methods generally take `VectorConstruction`
 /// as an input, apply necessary transformations to it and return a new `VectorConstruction`.
-///
-/// ## Example
+/// </summary>
+/// <example>
 ///
 /// For example, given `index`, we can say:
 ///
@@ -192,7 +181,7 @@ and AsyncSeriesConstruction<'K when 'K : equality> = Async<IIndex<'K>> * VectorC
 ///     // Now we can transform multiple vectors (e.g. all frame columns) using 'vectorCmd'
 ///     // (the integer '0' in `Return` is an offset in the array of vector arguments)
 ///     let newVector = vectorBuilder.Build(vectorCmd, [| vectorToTransform |])
-///
+/// </example>
 and IIndexBuilder =
 
   /// Create a new index using the specified keys. Optionally, the caller can specify
@@ -295,17 +284,13 @@ and IIndexBuilder =
   ///
   abstract Shift : SeriesConstruction<'K> * int -> SeriesConstruction<'K>
 
+  /// <summary>
   /// Aggregate an ordered index into floating windows or chunks.
-  ///
-  /// ## Parameters
-  ///
-  ///  - `index` - Specifies the index to be aggregated
-  ///  - `aggregation` - Defines the kind of aggregation to apply (the type
-  ///    is a discriminated union with a couple of cases)
-  ///  - `source` - Source vector construction to be transformed
-  ///  - `selector` - Given information about window/chunk (including
-  ///    vector construction that can be used to build the data chunk), return
-  ///    a new key, together with a new value for the returned vector.
+  /// </summary>
+  /// <param name="index">Specifies the index to be aggregated</param>
+  /// <param name="aggregation">Defines the kind of aggregation to apply (the type is a discriminated union with a couple of cases)</param>
+  /// <param name="source">Source vector construction to be transformed</param>
+  /// <param name="selector">Given information about window/chunk (including vector construction that can be used to build the data chunk), return a new key, together with a new value for the returned vector.</param>
   abstract Aggregate : index:IIndex<'K> * aggregation:Aggregation<'K> * source:VectorConstruction *
     selector:(DataSegmentKind * SeriesConstruction<'K> -> 'TNewKey * OptionalValue<'R>)
       -> IIndex<'TNewKey> * IVector<'R>

--- a/src/Deedle/Indices/Index.fs
+++ b/src/Deedle/Indices/Index.fs
@@ -7,11 +7,13 @@
 // Index is an interface and so you can define your own.
 // --------------------------------------------------------------------------------------
 
+/// <summary>
 /// Represents a strategy for aggregating data in an ordered series into data segments.
 /// To create a value of this type from C#, use the non-generic `Aggregation` type.
 /// Data can be aggregate using floating windows or chunks of a specified size or
 /// by specifying a condition on two keys (i.e. end a window/chunk when the condition
 /// no longer holds).
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 type Aggregation<'K> =
@@ -34,9 +36,11 @@ type Aggregation<'K> =
   | ChunkWhile of ('K -> 'K -> bool)
 
 
-/// A non-generic type that simplifies the construction of `Aggregation<K>` values
+/// <summary>
+/// A non-generic type that simplifies the construction of <c>Aggregation&lt;K&gt;</c> values
 /// from C#. It provides methods for constructing different kinds of aggregation
 /// strategies for ordered series.
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 type Aggregation =
@@ -61,7 +65,7 @@ type Aggregation =
   /// as the specified function returns `false` when called with the
   /// first key and the current key as arguments.
   /// </summary>
-  /// <param name="condition">A delegate that specifies when to end the current window (e.g. `(k1, k2) => k2 - k1 < 10` means that the difference between keys in each window will be less than 10.</param>
+  /// <param name="condition">A delegate that specifies when to end the current window (e.g. <c>(k1, k2) =&gt; k2 - k1 &lt; 10</c> means that the difference between keys in each window will be less than 10.</param>
   static member WindowWhile<'K>(condition:System.Func<'K, 'K, bool>) =
     WindowWhile(fun k1 k2 -> condition.Invoke(k1, k2))
 
@@ -70,7 +74,7 @@ type Aggregation =
   /// as the specified function returns `false` when called with the
   /// first key and the current key as arguments.
   /// </summary>
-  /// <param name="condition">A delegate that specifies when to end the current chunk (e.g. `(k1, k2) => k2 - k1 < 10` means that the difference between keys in each chunk will be less than 10.</param>
+  /// <param name="condition">A delegate that specifies when to end the current chunk (e.g. <c>(k1, k2) =&gt; k2 - k1 &lt; 10</c> means that the difference between keys in each chunk will be less than 10.</param>
   static member ChunkWhile<'K>(condition:System.Func<'K, 'K, bool>) =
     ChunkWhile(fun k1 k2 -> condition.Invoke(k1, k2))
 
@@ -172,15 +176,15 @@ and AsyncSeriesConstruction<'K when 'K : equality> = Async<IIndex<'K>> * VectorC
 /// as an input, apply necessary transformations to it and return a new `VectorConstruction`.
 /// </summary>
 /// <example>
-///
 /// For example, given `index`, we can say:
+/// <code>
+/// // Create an index that excludes the value 42
+/// let newIndex, vectorCmd = indexBuilder.DropItem(index, 42, VectorConstruction.Return(0))
 ///
-///     // Create an index that excludes the value 42
-///     let newIndex, vectorCmd = indexBuilder.DropItem(index, 42, VectorConstruction.Return(0))
-///
-///     // Now we can transform multiple vectors (e.g. all frame columns) using 'vectorCmd'
-///     // (the integer '0' in `Return` is an offset in the array of vector arguments)
-///     let newVector = vectorBuilder.Build(vectorCmd, [| vectorToTransform |])
+/// // Now we can transform multiple vectors (e.g. all frame columns) using 'vectorCmd'
+/// // (the integer '0' in `Return` is an offset in the array of vector arguments)
+/// let newVector = vectorBuilder.Build(vectorCmd, [| vectorToTransform |])
+/// </code>
 /// </example>
 and IIndexBuilder =
 

--- a/src/Deedle/Indices/IndexExtensions.fs
+++ b/src/Deedle/Indices/IndexExtensions.fs
@@ -4,7 +4,9 @@
 // F# friendly operations for creating vectors
 // ------------------------------------------------------------------------------------------------
 
+/// <summary>
 /// Set concrete IIndexBuilder implementation
+/// </summary>
 ///
 /// <category>Vectors and indices</category>
 [<AutoOpen>]

--- a/src/Deedle/Indices/LinearIndex.fs
+++ b/src/Deedle/Indices/LinearIndex.fs
@@ -647,9 +647,11 @@ open Deedle.Indices.Linear
 open System.Collections.Generic
 open System.Collections.ObjectModel
 
+/// <summary>
 /// Defines non-generic `Index` type that provides functions for building indices
 /// (hard-bound to `LinearIndexBuilder` type). In F#, the module is automatically opened
 /// using `AutoOpen`. The methods are not designed for the use from C#.
+/// </summary>
 ///
 /// <category>Vectors and indices</category>
 [<AutoOpen>]
@@ -686,7 +688,9 @@ module ``F# Index extensions`` =
     static member ofUnorderedKeys<'T when 'T : equality>(keys:'T list) =
       Index.ofUnorderedKeys(ReadOnlyCollection.ofSeq keys)
 
+/// <summary>
 /// Type that provides access to creating indices (represented as `LinearIndex` values)
+/// </summary>
 ///
 /// <category>Vectors and indices</category>
 type Index =

--- a/src/Deedle/Indices/MultiKey.fs
+++ b/src/Deedle/Indices/MultiKey.fs
@@ -4,9 +4,11 @@
 // Support for multi-key indexing
 // ------------------------------------------------------------------------------------------------
 
+/// <summary>
 /// Represents a special lookup. This can be used to support hierarchical or duplicate keys
-/// in an index. A key type `K` can come with associated `ICustomLookup<K>` to provide
+/// in an index. A key type `K` can come with associated <c>ICustomLookup&lt;K&gt;</c> to provide
 /// customized pattern matching (equality testing)
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 type ICustomLookup<'K> =
@@ -111,7 +113,9 @@ type SimpleLookup<'T>(patterns) =
 namespace Deedle
 open Deedle.Keys
 
+/// <summary>
 /// F#-friendly functions for creating multi-level keys and lookups
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 [<AutoOpen>]
@@ -163,7 +167,9 @@ module MultiKeyExtensions =
     SimpleLookup [| Option.map box k1; Option.map box k2; Option.map box k3; Option.map box k4 |] :> ICustomLookup<_>
 
 
+/// <summary>
 /// Module with helper functions for extracting values from hierarchical tuples
+/// </summary>
 ///
 /// <category>Primitive types and values</category>
 module Pair =

--- a/src/Deedle/JoinHelpers.fs
+++ b/src/Deedle/JoinHelpers.fs
@@ -8,10 +8,12 @@ open System
 open Deedle.Indices
 open Deedle.Vectors
 
+/// <summary>
 /// This enumeration specifies joining behavior for `Join` method provided
 /// by `Series` and `Frame`. Outer join unions the keys (and may introduce
 /// missing values), inner join takes the intersection of keys; left and
 /// right joins take the keys of the first or the second series/frame.
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 type JoinKind =

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -12,9 +12,11 @@ open Deedle.Keys
 open Deedle.Vectors
 open Deedle.VectorHelpers
 
+/// <summary>
 /// This enumeration specifies the behavior of `Union` operation on series when there are
 /// overlapping keys in two series that are being unioned. The options include preferring values
 /// from the left/right series or throwing an exception when both values are available.
+/// </summary>
 ///
 /// <category>Parameters and results of various operations</category>
 type UnionBehavior =
@@ -29,9 +31,11 @@ type UnionBehavior =
 // Series
 // ------------------------------------------------------------------------------------------------
 
+/// <summary>
 /// Represents an untyped series with keys of type `K` and values of some unknown type
 /// (This type should not generally be used directly, but it can be used when you need
 /// to write code that works on a sequence of series of heterogeneous types).
+/// </summary>
 ///
 /// <category>Core frame and series types</category>
 type ISeries<'K when 'K : equality> =
@@ -44,8 +48,10 @@ type ISeries<'K when 'K : equality> =
   /// Returns the vector builder associated with this series
   abstract VectorBuilder : IVectorBuilder
 
-/// The type `Series<K, V>` represents a data series consisting of values `V` indexed by
+/// <summary>
+/// The type <c>Series&lt;K, V&gt;</c> represents a data series consisting of values `V` indexed by
 /// keys `K`. The keys of a series may or may not be ordered
+/// </summary>
 ///
 /// <category>Core frame and series types</category>
 and
@@ -75,30 +81,38 @@ and
   // Series data
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns the index associated with this series. This member should not generally
   /// be accessed directly, because all functionality is exposed through series operations.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.Index = index
 
+  /// <summary>
   /// Returns the vector associated with this series. This member should not generally
   /// be accessed directly, because all functionality is exposed through series operations.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.Vector = vector
 
+  /// <summary>
   /// Returns a collection of keys that are defined by the index of this series.
   /// Note that the length of this sequence does not match the `Values` sequence
   /// if there are missing values. To get matching sequence, use the `Observations`
   /// property or `Series.observation`.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.Keys = seq { for kvp in index.Mappings -> kvp.Key }
 
+  /// <summary>
   /// Returns a collection of values that are available in the series data.
   /// Note that the length of this sequence does not match the `Keys` sequence
   /// if there are missing values. To get matching sequence, use the `Observations`
   /// property or `Series.observation`.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.Values =
@@ -107,8 +121,10 @@ and
         vector.GetValueAtLocation(KnownLocation(kvp.Value, idx))
         |> OptionalValue.asOption )
 
+  /// <summary>
   /// Returns a collection of values, including possibly missing values. Note that
   /// the length of this sequence matches the `Keys` sequence.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.ValuesAll =
@@ -116,9 +132,11 @@ and
     |> Seq.mapl (fun idx kvp ->
         vector.GetValueAtLocation(KnownLocation(kvp.Value, idx)).ValueOrDefault)
 
+  /// <summary>
   /// Returns a collection of observations that form this series. Note that this property
-  /// skips over all missing (or NaN) values. Observations are returned as `KeyValuePair<K, V>`
+  /// skips over all missing (or NaN) values. Observations are returned as <c>KeyValuePair&lt;K, V&gt;</c>
   /// objects. For an F# alternative that uses tuples, see `Series.observations`.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.Observations =
@@ -128,10 +146,12 @@ and
         |> OptionalValue.map (fun v -> KeyValuePair(kvp.Key, v))
         |> OptionalValue.asOption )
 
+  /// <summary>
   /// Returns a collection of observations that form this series. Note that this property
   /// includes all missing (or NaN) values. Observations are returned as
-  /// `KeyValuePair<K, OptionalValue<V>>` objects. For an F# alternative that uses tuples,
+  /// <c>KeyValuePair&lt;K, OptionalValue&lt;V&gt;&gt;</c> objects. For an F# alternative that uses tuples,
   /// see `Series.observationsAll`.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.ObservationsAll =
@@ -140,27 +160,41 @@ and
         let v = vector.GetValueAtLocation(KnownLocation(kvp.Value, idx))
         KeyValuePair(kvp.Key, v))
 
-  ///
+  /// <summary>
+  /// Gets a value indicating whether the series is empty.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.IsEmpty = Seq.isEmpty index.Mappings
 
+  /// <summary>
+  /// Gets a value indicating whether the series index is ordered.
+  /// </summary>
+  ///
   /// <category>Series data</category>
   member x.IsOrdered = index.IsOrdered
 
+  /// <summary>
+  /// Gets the range of keys in the series.
+  /// </summary>
+  ///
   /// <category>Series data</category>
   member x.KeyRange = index.KeyRange
 
+  /// <summary>
   /// Returns the total number of keys in the specified series. This returns
   /// the total length of the series, including keys for which there is no
   /// value available.
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.KeyCount = int index.KeyCount
 
+  /// <summary>
   /// Returns the total number of values in the specified series. This excludes
   /// missing values or not available values (such as values created from `null`,
   /// `Double.NaN`, or those that are missing due to outer join etc.).
+  /// </summary>
   ///
   /// <category>Series data</category>
   member x.ValueCount =
@@ -239,6 +273,9 @@ and
     let newVector = vectorBuilder.Build(newIndex.AddressingScheme, cmd, [| vector |])
     Series(newIndex, newVector, vectorBuilder, indexBuilder)
 
+  /// <summary>
+  /// Attempts to get the value and key at the specified lookup semantics.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.TryGetObservation(key, lookup) =
@@ -247,6 +284,9 @@ and
     | OptionalValue.Missing -> OptionalValue.Missing
     | OptionalValue.Present(key, addr) -> vector.GetValue(addr) |> OptionalValue.map (fun v -> KeyValuePair(key, v))
 
+  /// <summary>
+  /// Gets the value and key at the specified lookup semantics. Fails if not found.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.GetObservation(key, lookup) =
@@ -256,16 +296,25 @@ and
     if not value.HasValue then missingVal key
     KeyValuePair(fst mapping.Value, value.Value)
 
+  /// <summary>
+  /// Attempts to get the value at the specified key using the specified lookup semantics.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.TryGet(key, lookup) =
     x.TryGetObservation(key, lookup) |> OptionalValue.map (fun (KeyValue(_, v)) -> v)
 
+  /// <summary>
+  /// Gets the value at the specified key using the specified lookup semantics. Fails if not found.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.Get(key, lookup) =
     x.GetObservation(key, lookup).Value
 
+  /// <summary>
+  /// Performs a hierarchical lookup by applying a custom lookup on the series index.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.GetByLevel(key:ICustomLookup<'K>) =
@@ -273,7 +322,9 @@ and
     let newVector = vectorBuilder.Build(newIndex.AddressingScheme, levelCmd, [| vector |])
     Series(newIndex, newVector, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Attempts to get a value at the specified 'key'
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.TryGetObservation(key) =
@@ -283,6 +334,9 @@ and
       let value = vector.GetValue(addr)
       OptionalValue(KeyValuePair(key, value))
 
+  /// <summary>
+  /// Gets the value and key at the specified key. Fails if not found.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.GetObservation(key) =
@@ -292,6 +346,9 @@ and
     if not value.HasValue then missingVal key
     KeyValuePair(key, value.Value)
 
+  /// <summary>
+  /// Attempts to get the value at the specified key.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.TryGet(key) =
@@ -299,6 +356,9 @@ and
     if addr = Address.invalid then OptionalValue.Missing
     else x.Vector.GetValue(addr)
 
+  /// <summary>
+  /// Gets the value at the specified key. Fails if not found.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.Get(key) =
@@ -309,15 +369,24 @@ and
       | OptionalValue.Missing   -> missingVal key
       | OptionalValue.Present v -> v
 
+  /// <summary>
+  /// Attempts to get the value at the specified index position.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.TryGetAt(index : int) =
     x.Vector.GetValue(x.Index.AddressAt(int64 index))
 
+  /// <summary>
+  /// Gets the key at the specified index position.
+  /// </summary>
   /// <category>Accessors and slicing</category>
   member x.GetKeyAt(index : int) =
     x.Index.KeyAt(x.Index.AddressAt(int64 index))
 
+  /// <summary>
+  /// Gets the value at the specified index position.
+  /// </summary>
   /// <category>Accessors and slicing</category>
   member x.GetAt(index : int) =
     if x.Index.IsEmpty then
@@ -325,16 +394,28 @@ and
     else
       x.TryGetAt(index).Value
 
+  /// <summary>
+  /// Gets the value at the specified key.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.Item with get(a) = x.Get(a)
+  /// <summary>
+  /// Gets a series containing values at the specified keys.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.Item with get(items) = x.GetItems items
+  /// <summary>
+  /// Gets values by hierarchical level lookup.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   member x.Item with get(a) = x.GetByLevel(a)
 
+  /// <summary>
+  /// Dynamic operator for accessing series values by key using the `?` syntax.
+  /// </summary>
   ///
   /// <category>Accessors and slicing</category>
   static member (?) (series:Series<_, _>, name:string) = series.Get(name, Lookup.Exact)
@@ -454,8 +535,10 @@ and
     let newVector = vector.DataSequence |> Seq.scan (fun x y -> foldFunc.Invoke(x, y)) init |> Seq.skip 1 |> Seq.toArray
     Series(index, vectorBuilder.CreateMissing(newVector), vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Returns the current series with the same index but with values missing wherever the
   /// corresponding key exists in the other series index with an associated missing value.
+  /// </summary>
   ///
   /// <category>Projection and filtering</category>
   member x.WithMissingFrom(otherSeries: Series<'K, _>) =
@@ -700,12 +783,13 @@ and
   /// other than `Boundary.Skip`, then the key is included in the returned series,
   /// but its value is missing.
   /// </summary>
-  /// <param name="series">The input series to be aggregated.</param>
   /// <param name="boundary">Specifies the direction in which the series is aggregated and how the corner case is handled. If the value is `Boundary.AtEnding`, then the function returns value and its successor, otherwise it returns value and its predecessor.</param>
   /// <example>
-  ///     let input = series [ 1 => 'a'; 2 => 'b'; 3 => 'c']
-  ///     let res = input.Pairwise()
-  ///     res = series [2 => ('a', 'b'); 3 => ('b', 'c') ]
+  /// <code>
+  /// let input = series [ 1 =&gt; 'a'; 2 =&gt; 'b'; 3 =&gt; 'c']
+  /// let res = input.Pairwise()
+  /// res = series [2 =&gt; ('a', 'b'); 3 =&gt; ('b', 'c') ]
+  /// </code>
   /// </example>
   /// <category>Windowing, chunking and grouping</category>
   member x.Pairwise(boundary) =
@@ -736,23 +820,24 @@ and
   /// for the first one. The returned series is one key shorter (it does not contain a
   /// value for the first key).
   /// </summary>
-  /// <param name="series">The input series to be aggregated.</param>
   /// <example>
-  ///     let input = series [ 1 => 'a'; 2 => 'b'; 3 => 'c']
-  ///     let res = input.Pairwise()
-  ///     res = series [2 => ('a', 'b'); 3 => ('b', 'c') ]
+  /// <code>
+  /// let input = series [ 1 =&gt; 'a'; 2 =&gt; 'b'; 3 =&gt; 'c']
+  /// let res = input.Pairwise()
+  /// res = series [2 =&gt; ('a', 'b'); 3 =&gt; ('b', 'c') ]
+  /// </code>
   /// </example>
   /// <category>Windowing, chunking and grouping</category>
   member x.Pairwise() =
     x.Pairwise(Boundary.Skip).Select(fun (kvp:KeyValuePair<_, DataSegment<_>>) -> kvp.Value.Data)
 
   /// <summary>
-  /// Aggregates an ordered series using the method specified by `Aggregation<K>` and then
+  /// Aggregates an ordered series using the method specified by <c>Aggregation&lt;K&gt;</c> and then
   /// applies the provided `valueSelector` on each window or chunk to produce the result
   /// which is returned as a new series. A key for each window or chunk is
   /// selected using the specified `keySelector`.
   /// </summary>
-  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="aggregation">Specifies the aggregation method using <c>Aggregation&lt;K&gt;</c>. This is a discriminated union listing various chunking and windowing conditions.</param>
   /// <param name="keySelector">A function that is called on each chunk to obtain a key.</param>
   /// <param name="valueSelector">A value selector function that is called to aggregate each chunk or window.</param>
   /// <category>Windowing, chunking and grouping</category>
@@ -772,11 +857,11 @@ and
     Series<'TNewKey, 'R>(newIndex, newVector, vectorBuilder, indexBuilder)
 
   /// <summary>
-  /// Aggregates an ordered series using the method specified by `Aggregation<K>` and then
+  /// Aggregates an ordered series using the method specified by <c>Aggregation&lt;K&gt;</c> and then
   /// applies the provided `observationSelector` on each window or chunk to produce the result
   /// which is returned as a new series. The selector returns both the key and the value.
   /// </summary>
-  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="aggregation">Specifies the aggregation method using <c>Aggregation&lt;K&gt;</c>. This is a discriminated union listing various chunking and windowing conditions.</param>
   /// <param name="observationSelector">A function that is called on each chunk to obtain a key and a value.</param>
   /// <category>Windowing, chunking and grouping</category>
   member x.Aggregate<'TNewKey, 'R when 'TNewKey : equality>
@@ -843,9 +928,11 @@ and
     let newVector = findAll x.Vector.GetValue |> Vector.ofOptionalValues
     Series<_,_>(newIndex, newVector, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Replace the index of the series with ordinally generated integers starting from zero.
   /// The elements of the series are assigned index according to the current order, or in a
   /// non-deterministic way, if the current index is not ordered.
+  /// </summary>
   ///
   /// <category>Indexing</category>
   member x.IndexOrdinally() =
@@ -1207,10 +1294,12 @@ and
 // Untyped series
 // ------------------------------------------------------------------------------------------------
 
-/// Represents a series containing boxed values. This type is inherited from `Series<'K, obj>`
+/// <summary>
+/// Represents a series containing boxed values. This type is inherited from <c>Series&lt;'K, obj&gt;</c>
 /// and it adds additional operations for accessing values with unboxing. This includes operations
-/// such as `os.GetAs<'T>`, `os.TryGetAs<'T>` and `os.TryAs<'T>` which (attempt to) convert
+/// such as <c>os.GetAs&lt;'T&gt;</c>, <c>os.TryGetAs&lt;'T&gt;</c> and <c>os.TryAs&lt;'T&gt;</c> which (attempt to) convert
 /// values to the specified type `'T`.
+/// </summary>
 ///
 /// <category>Specialized frame and series types</category>
 type ObjectSeries<'K when 'K : equality> internal(index:IIndex<_>, vector, vectorBuilder, indexBuilder) =

--- a/src/Deedle/Series.fs
+++ b/src/Deedle/Series.fs
@@ -212,32 +212,26 @@ and
   member series.EndAt(upperInclusive) =
     series.GetSubrange( None, Some(upperInclusive, BoundaryBehavior.Inclusive) )
 
+  /// <summary>
   /// Returns a new series with an index containing the specified keys.
   /// When the key is not found in the current series, the newly returned
   /// series will contain a missing value. When the second parameter is not
   /// specified, the keys have to exactly match the keys in the current series
   /// (`Lookup.Exact`).
-  ///
-  /// ## Parameters
-  ///
-  ///  * `keys` - A collection of keys in the current series.
-  ///
+  /// </summary>
+  /// <param name="keys">A collection of keys in the current series.</param>
   /// <category>Accessors and slicing</category>
   member x.GetItems(keys) = x.GetItems(keys, Lookup.Exact)
 
+  /// <summary>
   /// Returns a new series with an index containing the specified keys.
   /// When the key is not found in the current series, the newly returned
   /// series will contain a missing value. When the second parameter is not
   /// specified, the keys have to exactly match the keys in the current series
   /// (`Lookup.Exact`).
-  ///
-  /// ## Parameters
-  ///
-  ///  * `keys` - A collection of keys in the current series.
-  ///  * `lookup` - Specifies the lookup behavior when searching for keys in
-  ///    the current series. `Lookup.NearestGreater` and `Lookup.NearestSmaller`
-  ///    can be used when the current series is ordered.
-  ///
+  /// </summary>
+  /// <param name="keys">A collection of keys in the current series.</param>
+  /// <param name="lookup">Specifies the lookup behavior when searching for keys in the current series. `Lookup.NearestGreater` and `Lookup.NearestSmaller` can be used when the current series is ordered.</param>
   /// <category>Accessors and slicing</category>
   member series.GetItems(keys, lookup) =
     let newIndex = indexBuilder.Create<_>((keys:seq<_>), None)
@@ -514,12 +508,11 @@ and
     Series(newIndex, newVec, vectorBuilder, indexBuilder)
 
 
+  /// <summary>
   /// Replace series values given in keys with value.
-  ///
-  /// ## Parameters
-  ///  - `keys` - An array of keys to be used for replacing of the series
-  ///  - `value` - A value to replace any values for `keys`
-  ///
+  /// </summary>
+  /// <param name="keys">An array of keys to be used for replacing of the series</param>
+  /// <param name="value">A value to replace any values for `keys`</param>
   /// <category>Merging, joining and zipping</category>
   member series.Replace(keys:'K[], value) =
     series.Select(fun kvp ->
@@ -529,12 +522,11 @@ and
         kvp.Value
     )
 
+  /// <summary>
   /// Replace series values given in keys with value.
-  ///
-  /// ## Parameters
-  ///  - `key` - A key to be used for replacing of the series
-  ///  - `value` - A value to replace value for `key`
-  ///
+  /// </summary>
+  /// <param name="key">A key to be used for replacing of the series</param>
+  /// <param name="value">A value to replace value for `key`</param>
   /// <category>Merging, joining and zipping</category>
   member series.Replace(key:'K, value) =
     series.Select(fun kvp ->
@@ -631,6 +623,7 @@ and
   // ----------------------------------------------------------------------------------------------
 
 
+  /// <summary>
   /// Resample the series based on a provided collection of keys. The values of the series
   /// are aggregated into chunks based on the specified keys. Depending on `direction`, the
   /// specified key is either used as the smallest or as the greatest key of the chunk (with
@@ -638,20 +631,15 @@ and
   ///
   /// Such chunks are then aggregated using the provided `valueSelector` and `keySelector`
   /// (an overload that does not take `keySelector` just selects the explicitly provided key).
-  ///
-  /// ## Parameters
-  ///  - `keys` - A collection of keys to be used for resampling of the series
-  ///  - `direction` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///  - `valueSelector` - A function that is used to collapse a generated chunk into a
-  ///    single value. Note that this function may be called with empty series.
-  ///  - `keySelector` - A function that is used to generate a new key for each chunk.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="keys">A collection of keys to be used for resampling of the series</param>
+  /// <param name="direction">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <param name="valueSelector">A function that is used to collapse a generated chunk into a single value. Note that this function may be called with empty series.</param>
+  /// <param name="keySelector">A function that is used to generate a new key for each chunk.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Resampling</category>
   member x.Resample<'TNewKey, 'R when 'TNewKey : equality>(keys, direction, valueSelector:Func<_, _, _>, keySelector:Func<_, _, _>) =
     let newIndex, newVector =
@@ -664,6 +652,7 @@ and
               newKey, OptionalValue(valueSelector.Invoke(newKey, window))) )
     Series<'TNewKey, 'R>(newIndex, newVector, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Resample the series based on a provided collection of keys. The values of the series
   /// are aggregated into chunks based on the specified keys. Depending on `direction`, the
   /// specified key is either used as the smallest or as the greatest key of the chunk (with
@@ -671,39 +660,31 @@ and
   ///
   /// Such chunks are then aggregated using the provided `valueSelector` and `keySelector`
   /// (an overload that does not take `keySelector` just selects the explicitly provided key).
-  ///
-  /// ## Parameters
-  ///  - `keys` - A collection of keys to be used for resampling of the series
-  ///  - `direction` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///  - `valueSelector` - A function that is used to collapse a generated chunk into a
-  ///    single value. Note that this function may be called with empty series.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="keys">A collection of keys to be used for resampling of the series</param>
+  /// <param name="direction">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <param name="valueSelector">A function that is used to collapse a generated chunk into a single value. Note that this function may be called with empty series.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
-  /// <category>Resampling</category>
+  /// </remarks>
+  /// <category>Resamping</category>
   member x.Resample(keys, direction, valueSelector) =
     x.Resample(keys, direction, valueSelector, fun nk _ -> nk)
 
+  /// <summary>
   /// Resample the series based on a provided collection of keys. The values of the series
   /// are aggregated into chunks based on the specified keys. Depending on `direction`, the
   /// specified key is either used as the smallest or as the greatest key of the chunk (with
   /// the exception of boundaries that are added to the first/last chunk). The chunks
   /// are then returned as a nested series.
-  ///
-  /// ## Parameters
-  ///  - `keys` - A collection of keys to be used for resampling of the series
-  ///  - `direction` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="keys">A collection of keys to be used for resampling of the series</param>
+  /// <param name="direction">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Resampling</category>
   member x.Resample(keys, direction) =
     x.Resample(keys, direction, (fun k v -> v), fun nk _ -> nk)
@@ -712,25 +693,20 @@ and
   // Aggregation
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns a series containing an element and its neighbor for each input.
   /// The returned series is one key shorter (it does not contain a
   /// value for the first or last key depending on `boundary`). If `boundary` is
   /// other than `Boundary.Skip`, then the key is included in the returned series,
   /// but its value is missing.
-  ///
-  /// ## Parameters
-  ///  - `series` - The input series to be aggregated.
-  ///  - `boundary` - Specifies the direction in which the series is aggregated and
-  ///    how the corner case is handled. If the value is `Boundary.AtEnding`, then the
-  ///    function returns value and its successor, otherwise it returns value and its
-  ///    predecessor.
-  ///
-  /// ## Example
-  ///
+  /// </summary>
+  /// <param name="series">The input series to be aggregated.</param>
+  /// <param name="boundary">Specifies the direction in which the series is aggregated and how the corner case is handled. If the value is `Boundary.AtEnding`, then the function returns value and its successor, otherwise it returns value and its predecessor.</param>
+  /// <example>
   ///     let input = series [ 1 => 'a'; 2 => 'b'; 3 => 'c']
   ///     let res = input.Pairwise()
   ///     res = series [2 => ('a', 'b'); 3 => ('b', 'c') ]
-  ///
+  /// </example>
   /// <category>Windowing, chunking and grouping</category>
   member x.Pairwise(boundary) =
     let dir = if boundary = Boundary.AtEnding then Direction.Forward else Direction.Backward
@@ -755,34 +731,30 @@ and
               newKey, newValue ))
     Series<'K, DataSegment<'V * 'V>>(newIndex, newVector, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Returns a series containing the predecessor and an element for each input, except
   /// for the first one. The returned series is one key shorter (it does not contain a
   /// value for the first key).
-  ///
-  /// ## Parameters
-  ///  - `series` - The input series to be aggregated.
-  ///
-  /// ## Example
-  ///
+  /// </summary>
+  /// <param name="series">The input series to be aggregated.</param>
+  /// <example>
   ///     let input = series [ 1 => 'a'; 2 => 'b'; 3 => 'c']
   ///     let res = input.Pairwise()
   ///     res = series [2 => ('a', 'b'); 3 => ('b', 'c') ]
-  ///
+  /// </example>
   /// <category>Windowing, chunking and grouping</category>
   member x.Pairwise() =
     x.Pairwise(Boundary.Skip).Select(fun (kvp:KeyValuePair<_, DataSegment<_>>) -> kvp.Value.Data)
 
+  /// <summary>
   /// Aggregates an ordered series using the method specified by `Aggregation<K>` and then
   /// applies the provided `valueSelector` on each window or chunk to produce the result
   /// which is returned as a new series. A key for each window or chunk is
   /// selected using the specified `keySelector`.
-  ///
-  /// ## Parameters
-  ///  - `aggregation` - Specifies the aggregation method using `Aggregation<K>`. This is
-  ///    a discriminated union listing various chunking and windowing conditions.
-  ///  - `keySelector` - A function that is called on each chunk to obtain a key.
-  ///  - `valueSelector` - A value selector function that is called to aggregate each chunk or window.
-  ///
+  /// </summary>
+  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="keySelector">A function that is called on each chunk to obtain a key.</param>
+  /// <param name="valueSelector">A value selector function that is called to aggregate each chunk or window.</param>
   /// <category>Windowing, chunking and grouping</category>
   member x.Aggregate<'TNewKey, 'R when 'TNewKey : equality>
         (aggregation, keySelector:Func<_, _>, valueSelector:Func<_, _>) =
@@ -799,15 +771,13 @@ and
               newKey, newValue ))
     Series<'TNewKey, 'R>(newIndex, newVector, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Aggregates an ordered series using the method specified by `Aggregation<K>` and then
   /// applies the provided `observationSelector` on each window or chunk to produce the result
   /// which is returned as a new series. The selector returns both the key and the value.
-  ///
-  /// ## Parameters
-  ///  - `aggregation` - Specifies the aggregation method using `Aggregation<K>`. This is
-  ///    a discriminated union listing various chunking and windowing conditions.
-  ///  - `observationSelector` - A function that is called on each chunk to obtain a key and a value.
-  ///
+  /// </summary>
+  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="observationSelector">A function that is called on each chunk to obtain a key and a value.</param>
   /// <category>Windowing, chunking and grouping</category>
   member x.Aggregate<'TNewKey, 'R when 'TNewKey : equality>
         (aggregation, observationSelector:Func<_, KeyValuePair<_, _>>) =
@@ -823,12 +793,10 @@ and
               newKey, newValue ))
     Series<'TNewKey, 'R>(newIndex, newVector, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Groups a series (ordered or unordered) using the specified key selector (`keySelector`)
-  ///
-  /// ## Parameters
-  ///  - `keySelector` - Generates a new key that is used for aggregation, based on the original
-  ///    key and value. The new key must support equality testing.
-  ///
+  /// </summary>
+  /// <param name="keySelector">Generates a new key that is used for aggregation, based on the original key and value. The new key must support equality testing.</param>
   /// <category>Windowing, chunking and grouping</category>
   member x.GroupBy(keySelector:Func<_, _>) =
     let index = x.Index
@@ -839,14 +807,13 @@ and
         Series(fst sc, vectorBuilder.Build(newIndex.AddressingScheme, snd sc, [| x.Vector |]), vectorBuilder, indexBuilder))
     Series<'TNewKey, _>(newIndex, Vector.ofValues newGroups, vectorBuilder, indexBuilder)
 
+  /// <summary>
   /// Interpolates an ordered series given a new sequence of keys. The function iterates through
   /// each new key, and invokes a function on the current key, the nearest smaller and larger valid
   /// observations from the series argument. The function must return a new valid float.
-  ///
-  /// ## Parameters
-  ///  - `keys` - Sequence of new keys that forms the index of interpolated results
-  ///  - `f` - Function to do the interpolating
-  ///
+  /// </summary>
+  /// <param name="keys">Sequence of new keys that forms the index of interpolated results</param>
+  /// <param name="f">Function to do the interpolating</param>
   /// <category>Windowing, chunking and grouping</category>
   member x.Interpolate(keys:'K seq, f:Func<'K, OptionalValue<KeyValuePair<'K,'V>>, OptionalValue<KeyValuePair<'K,'V>>, 'V>) =
     let newObs =
@@ -1138,22 +1105,21 @@ and
   member series.Format(showInfo) =
     series.Format(Formatting.RowStartItemCount, Formatting.RowEndItemCount, showInfo)
 
+  /// <summary>
   /// Shows the series content in a human-readable format. The resulting string
   /// shows a limited number of values from the series.
-  ///
-  /// ## Parameters
-  ///  - `itemCount` - The total number of items to show. The result will show
-  ///    at most `itemCount/2` items at the beginning and ending of the series.
+  /// </summary>
+  /// <param name="itemCount">The total number of items to show. The result will show at most `itemCount/2` items at the beginning and ending of the series.</param>
   member series.Format(itemCount) =
     let half = itemCount / 2
     series.Format(half, half, false)
 
+  /// <summary>
   /// Shows the series content in a human-readable format. The resulting string
   /// shows a limited number of values from the series.
-  ///
-  /// ## Parameters
-  ///  - `startCount` - The number of elements to show at the beginning of the series
-  ///  - `endCount` - The number of elements to show at the end of the series
+  /// </summary>
+  /// <param name="startCount">The number of elements to show at the beginning of the series</param>
+  /// <param name="endCount">The number of elements to show at the end of the series</param>
   member series.FormatStrings(startCount, endCount) : string [] [] =
     let getLevel ordered previous reset maxLevel level (key:'K) =
       let levelKey =

--- a/src/Deedle/SeriesExtensions.fs
+++ b/src/Deedle/SeriesExtensions.fs
@@ -52,15 +52,16 @@ module ``F# Series extensions`` =
       Series(Seq.map fst observations, Seq.map snd observations)
         .SelectOptional(fun kvp -> OptionalValue.bind OptionalValue.ofOption kvp.Value)
 
+  /// <summary>
   /// Create a series from a sequence of key-value pairs that represent
   /// the observations of the series. This function can be used together
   /// with the `=>` operator to create key-value pairs.
-  ///
-  /// ## Example
+  /// </summary>
+  /// <example>
   ///
   ///     // Creates a series with squares of numbers
   ///     let sqs = series [ 1 => 1.0; 2 => 4.0; 3 => 9.0 ]
-  ///
+  /// </example>
   let series observations = Series.ofObservations observations
 
 
@@ -95,10 +96,12 @@ type EnumerableExtensions =
 // Series builder
 // --------------------------------------------------------------------------------------
 
+/// <summary>
 /// The type can be used for creating series using mutation. You can add
 /// items using `Add` and get the resulting series using the `Series` property.
-///
-/// ## Using from C#
+/// </summary>
+/// <remarks>
+/// Using from C#:
 ///
 /// The type supports the C# collection builder pattern:
 ///
@@ -110,7 +113,7 @@ type EnumerableExtensions =
 ///     dynamic sb = new SeriesBuilder<string, obj>();
 ///     sb.ID = 1;
 ///     sb.Value = 3.4;
-///
+/// </remarks>
 /// <category>Specialized frame and series types</category>
 type SeriesBuilder<'K, 'V when 'K : equality and 'V : equality>() =
   let mutable keys = []
@@ -223,20 +226,20 @@ type SeriesExtensions =
   [<Extension>]
   static member Log(series:Series<'K, float>) = log series
 
+  /// <summary>
   /// Returns a series with values shifted by the specified offset. When the offset is
   /// positive, the values are shifted forward and first `offset` keys are dropped. When the
   /// offset is negative, the values are shifted backwards and the last `offset` keys are dropped.
   /// Expressed in pseudo-code:
   ///
   ///     result[k] = series[k - offset]
-  ///
-  /// ## Parameters
-  ///  - `offset` - Can be both positive and negative number.
-  ///  - `series` - The input series to be shifted.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="offset">Can be both positive and negative number.</param>
+  /// <param name="series">The input series to be shifted.</param>
+  /// <remarks>
   /// If you want to calculate the difference, e.g. `s - (Series.shift 1 s)`, you can
   /// use `Series.diff` which will be a little bit faster.
+  /// </remarks>
   [<Extension>]
   static member Shift(series:Series<'K, 'V>, offset) = Series.shift offset series
 
@@ -286,51 +289,43 @@ type SeriesExtensions =
   // static member Where(series:Series<'K, 'T>, f:System.Func<KeyValuePair<'K, 'V>, bool>) =
 
 
+  /// <summary>
   /// Returns a series containing difference between a value in the original series and
   /// a value at the specified offset. For example, calling `Series.diff 1 s` returns a
   /// series where previous value is subtracted from the current one.
-  ///
-  /// ## Parameters
-  ///  - `offset` - When positive, subtracts the past values from the current values;
-  ///    when negative, subtracts the future values from the current values.
-  ///  - `series` - The input series.
-  ///
+  /// </summary>
+  /// <param name="offset">When positive, subtracts the past values from the current values; when negative, subtracts the future values from the current values.</param>
+  /// <param name="series">The input series.</param>
   [<Extension>]
   static member Diff(series:Series<'K, float>, offset) = series |> Series.diff offset
 
+  /// <summary>
   /// Returns a series containing difference between a value in the original series and
   /// a value at the specified offset. For example, calling `Series.diff 1 s` returns a
   /// series where previous value is subtracted from the current one.
-  ///
-  /// ## Parameters
-  ///  - `offset` - When positive, subtracts the past values from the current values;
-  ///    when negative, subtracts the future values from the current values.
-  ///  - `series` - The input series.
-  ///
+  /// </summary>
+  /// <param name="offset">When positive, subtracts the past values from the current values; when negative, subtracts the future values from the current values.</param>
+  /// <param name="series">The input series.</param>
   [<Extension>]
   static member Diff(series:Series<'K, float32>, offset) = series |> Series.diff offset
 
+  /// <summary>
   /// Returns a series containing difference between a value in the original series and
   /// a value at the specified offset. For example, calling `Series.diff 1 s` returns a
   /// series where previous value is subtracted from the current one.
-  ///
-  /// ## Parameters
-  ///  - `offset` - When positive, subtracts the past values from the current values;
-  ///    when negative, subtracts the future values from the current values.
-  ///  - `series` - The input series.
-  ///
+  /// </summary>
+  /// <param name="offset">When positive, subtracts the past values from the current values; when negative, subtracts the future values from the current values.</param>
+  /// <param name="series">The input series.</param>
   [<Extension>]
   static member Diff(series:Series<'K, decimal>, offset) = series |> Series.diff offset
 
+  /// <summary>
   /// Returns a series containing difference between a value in the original series and
   /// a value at the specified offset. For example, calling `Series.diff 1 s` returns a
   /// series where previous value is subtracted from the current one.
-  ///
-  /// ## Parameters
-  ///  - `offset` - When positive, subtracts the past values from the current values;
-  ///    when negative, subtracts the future values from the current values.
-  ///  - `series` - The input series.
-  ///
+  /// </summary>
+  /// <param name="offset">When positive, subtracts the past values from the current values; when negative, subtracts the future values from the current values.</param>
+  /// <param name="series">The input series.</param>
   [<Extension>]
   static member Diff(series:Series<'K, int>, offset) = series |> Series.diff offset
 
@@ -386,41 +381,39 @@ type SeriesExtensions =
   // Missing values
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Drop missing values from the specified series. The returned series contains
   /// only those keys for which there is a value available in the original one.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be filtered
-  ///
-  /// ## Example
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be filtered</param>
+  /// <example>
   ///     let s = series [ 1 => 1.0; 2 => Double.NaN ]
   ///     s.DropMissing()
   ///     [fsi:val it : Series<int,float> = series [ 1 => 1]
-  ///
+  /// </example>
   /// <category>Missing values</category>
   [<Extension>]
   static member DropMissing(series:Series<'K, 'V>) =
     Series.dropMissing series
 
+  /// <summary>
   /// Fill missing values in the series with a constant value.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series that is to be filled
-  ///  - `value` - A constant value that is used to fill all missing values
-  ///
+  /// </summary>
+  /// <param name="series">An input series that is to be filled</param>
+  /// <param name="value">A constant value that is used to fill all missing values</param>
   /// <category>Missing values</category>
   [<Extension>]
   static member FillMissing(series:Series<'K, 'T>, value:'T) =
     Series.fillMissingWith value series
 
+  /// <summary>
   /// Fill missing values in the series with the nearest available value
   /// (using the specified direction). The default direction is `Direction.Backward`.
   /// Note that the series may still contain missing values after call to this
   /// function. This operation can only be used on ordered series.
-  ///
-  /// ## Example
-  ///
+  /// </summary>
+  /// <param name="direction">Specifies the direction used when searching for the nearest available value. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
+  /// <example>
   ///     let sample = Series.ofValues [ Double.NaN; 1.0; Double.NaN; 3.0 ]
   ///
   ///     // Returns a series consisting of [1; 1; 3; 3]
@@ -428,13 +421,7 @@ type SeriesExtensions =
   ///
   ///     // Returns a series consisting of [<missing>; 1; 1; 3]
   ///     sample.FillMissing(Direction.Forward)
-  ///
-  /// ## Parameters
-  ///  - `direction` - Specifies the direction used when searching for
-  ///    the nearest available value. `Backward` means that we want to
-  ///    look for the first value with a smaller key while `Forward` searches
-  ///    for the nearest greater key.
-  ///
+  /// </example>
   /// <category>Missing values</category>
   [<Extension>]
   static member FillMissing(series:Series<'K, 'T>, [<Optional>] direction) =
@@ -444,20 +431,18 @@ type SeriesExtensions =
   static member FillMissing(series:Series<'K, 'T>, startKey, endKey, [<Optional>] direction) =
     Series.fillMissingBetween (startKey, endKey) direction series
 
+  /// <summary>
   /// Fill missing values in the series using the specified function.
   /// The specified function is called with all keys for which the series
   /// does not contain value and the result of the call is used in place
   /// of the missing value.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series that is to be filled
-  ///  - `filler` - A function that takes key `K` and generates a value to be
-  ///    used in a place where the original series contains a missing value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series that is to be filled</param>
+  /// <param name="filler">A function that takes key `K` and generates a value to be used in a place where the original series contains a missing value.</param>
+  /// <remarks>
   /// This function can be used to implement more complex interpolation.
   /// For example see [handling missing values in the tutorial](../frame.html#missing)
-  ///
+  /// </remarks>
   /// <category>Missing values</category>
   [<Extension>]
   static member FillMissing(series:Series<'K, 'T>, filler:Func<_, _>) =
@@ -467,11 +452,10 @@ type SeriesExtensions =
   // Sorting
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns a new series whose entries are reordered according to index order
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be used
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be used</param>
   /// <category>Data structure manipulation</category>
   [<Extension>]
   static member SortByKey(series:Series<'K, 'T>) =
@@ -481,48 +465,44 @@ type SeriesExtensions =
   // Lookup, resampling and scaling
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys. A specified function
   /// `keyProj` is used to project keys to another space and the observations for which the
   /// projected keys are equivalent are grouped into chunks. The chunks are then returned
   /// as nested series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered. For unordered
   /// series, similar functionality can be implemented using `GroupBy`.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member ResampleEquivalence(series:Series<'K, 'V>, keyProj:Func<_, _>) =
     Series.resampleEquiv keyProj.Invoke series
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys. A specified function
   /// `keyProj` is used to project keys to another space and the observations for which the
   /// projected keys are equivalent are grouped into chunks. The chunks are then transformed
   /// to values using the provided function `f`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///  - `aggregate` - A function that is used to collapse a generated chunk into a
-  ///    single value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <param name="aggregate">A function that is used to collapse a generated chunk into a single value.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered. For unordered
   /// series, similar functionality can be implemented using `GroupBy`.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member ResampleEquivalence(series:Series<'K, 'V>, keyProj:Func<_, _>, aggregate:Func<_, _>) =
     Series.resampleEquivInto keyProj.Invoke aggregate.Invoke series
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys and also generate values
   /// for all keys of the target space that are between the minimal and maximal key of the
   /// specified series (e.g. generate value for all days in the range covered by the series).
@@ -532,22 +512,20 @@ type SeriesExtensions =
   ///
   /// When there are no values for a (generated) key, then the function attempts to get the
   /// greatest value from the previous smaller chunk (i.e. value for the previous date time).
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///  - `nextKey` - A function that gets the next key in the transformed space
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <param name="nextKey">A function that gets the next key in the transformed space</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member ResampleUniform(series:Series<'K, 'V>, keyProj:Func<_, _>, nextKey:Func<_, _>) =
     Series.resampleUniformInto Lookup.ExactOrSmaller keyProj.Invoke nextKey.Invoke Series.tryLastValue series |> Series.flatten
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys and also generate values
   /// for all keys of the target space that are between the minimal and maximal key of the
   /// specified series (e.g. generate value for all days in the range covered by the series).
@@ -556,203 +534,172 @@ type SeriesExtensions =
   ///
   /// When there are no values for a (generated) key, then the function attempts to get the
   /// greatest value from the previous smaller chunk (i.e. value for the previous date time).
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `fillMode` - When set to `Lookup.NearestSmaller` or `Lookup.NearestGreater`,
-  ///     the function searches for a nearest available observation in an neighboring chunk.
-  ///     Otherwise, the function `f` is called with an empty series as an argument.
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///  - `nextKey` - A function that gets the next key in the transformed space
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="fillMode">When set to `Lookup.NearestSmaller` or `Lookup.NearestGreater`, the function searches for a nearest available observation in an neighboring chunk. Otherwise, the function `f` is called with an empty series as an argument.</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <param name="nextKey">A function that gets the next key in the transformed space</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member ResampleUniform(series:Series<'K1, 'V>, keyProj:Func<'K1, 'K2>, nextKey:Func<'K2, 'K2>, fillMode:Lookup) =
     Series.resampleUniformInto fillMode keyProj.Invoke nextKey.Invoke Series.tryLastValue series |> Series.flatten
 
+  /// <summary>
   /// Sample an (ordered) series by finding the value at the exact or closest prior key
   /// for some new sequence of keys.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be sampled
-  ///  - `keys`   - The keys at which to sample
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be sampled</param>
+  /// <param name="keys">The keys at which to sample</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member Sample<'K, 'V when 'K : equality>(series:Series<'K, 'V>, keys) =
     series |> Series.sample keys
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting at the specified `start` time, using the specified `interval`
   /// and then finds nearest smaller values close to such keys according to `dir`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `start` - The initial time to be used for sampling
-  ///  - `interval` - The interval between the individual samples
-  ///  - `lookup` - Specifies how the lookup based on keys is performed. `Exact` means that the
-  ///    values at exact keys will be returned; `NearestGreater` returns the nearest greater key value
-  ///    (starting at the first key) and `NearestSmaller` returns the nearest smaller key value
-  ///    (starting at most `interval` after the end of the series)
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="start">The initial time to be used for sampling</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member Sample<'V>(series:Series<DateTime, 'V>, start:DateTime, interval:TimeSpan, dir) =
     series |> Series.Implementation.lookupTimeInternal (+) (Some start) interval dir Lookup.ExactOrSmaller
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting at the specified `start` time, using the specified `interval`
   /// and then finds nearest smaller values close to such keys according to `dir`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `start` - The initial time to be used for sampling
-  ///  - `interval` - The interval between the individual samples
-  ///  - `lookup` - Specifies how the lookup based on keys is performed. `Exact` means that the
-  ///    values at exact keys will be returned; `NearestGreater` returns the nearest greater key value
-  ///    (starting at the first key) and `NearestSmaller` returns the nearest smaller key value
-  ///    (starting at most `interval` after the end of the series)
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="start">The initial time to be used for sampling</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member Sample<'V>(series:Series<DateTimeOffset, 'V>, start:DateTimeOffset, interval:TimeSpan, dir) =
     series |> Series.Implementation.lookupTimeInternal (+) (Some start) interval dir Lookup.ExactOrSmaller
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`
   /// and then finds nearest smaller values close to such keys according to `dir`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///  - `lookup` - Specifies how the lookup based on keys is performed. `Exact` means that the
-  ///    values at exact keys will be returned; `NearestGreater` returns the nearest greater key value
-  ///    (starting at the first key) and `NearestSmaller` returns the nearest smaller key value
-  ///    (starting at most `interval` after the end of the series)
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member Sample<'V>(series:Series<DateTime, 'V>, interval:TimeSpan, dir) =
     series |> Series.Implementation.lookupTimeInternal (+) None interval dir Lookup.ExactOrSmaller
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`
   /// and then finds nearest smaller values close to such keys according to `dir`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - Specifies how the keys should be generated. `Direction.Forward` means that the
-  ///    key is the smallest value of each chunk (and so first key of the series is returned and
-  ///    the last is not, unless it matches exactly _start + k*interval_); `Direction.Backward`
-  ///    means that the first key is skipped and sample is generated at, or just before the end
-  ///    of interval and at the end of the series.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">Specifies how the keys should be generated. `Direction.Forward` means that the key is the smallest value of each chunk (and so first key of the series is returned and the last is not, unless it matches exactly _start + k*interval_); `Direction.Backward` means that the first key is skipped and sample is generated at, or just before the end of interval and at the end of the series.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member Sample<'V>(series:Series<DateTimeOffset, 'V>, interval:TimeSpan, dir) =
     series |> Series.Implementation.lookupTimeInternal (+) None interval dir Lookup.ExactOrSmaller
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`
   /// and then finds nearest smaller values close to such keys. The function generates samples
   /// at, or just before the end of an interval and at, or after, the end of the series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member Sample<'V>(series:Series<DateTime, 'V>, interval:TimeSpan) =
     SeriesExtensions.Sample(series, interval, Direction.Backward)
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`
   /// and then finds nearest smaller values close to such keys. The function generates samples
   /// at, or just before the end of an interval and at, or after, the end of the series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member Sample<'V>(series:Series<DateTimeOffset, 'V>, interval:TimeSpan) =
     SeriesExtensions.Sample(series, interval, Direction.Backward)
 
+  /// <summary>
   /// Performs sampling by time and aggregates chunks obtained by time-sampling into a single
   /// value using a specified function. The operation generates keys starting at the first
   /// key in the source series, using the specified `interval` and then obtains chunks based on
   /// these keys in a fashion similar to the `Series.resample` function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///  - `aggregate` - A function that is called to aggregate each chunk into a single value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <param name="aggregate">A function that is called to aggregate each chunk into a single value.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member SampleInto<'V>(series:Series<DateTime, 'V>, interval:TimeSpan, dir, aggregate:Func<_, _>) =
     series |> Series.Implementation.sampleTimeIntoInternal (+) None interval dir aggregate.Invoke
 
+  /// <summary>
   /// Performs sampling by time and aggregates chunks obtained by time-sampling into a single
   /// value using a specified function. The operation generates keys starting at the first
   /// key in the source series, using the specified `interval` and then obtains chunks based on
   /// these keys in a fashion similar to the `Series.resample` function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///  - `aggregate` - A function that is called to aggregate each chunk into a single value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <param name="aggregate">A function that is called to aggregate each chunk into a single value.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Lookup, resampling and scaling</category>
   [<Extension>]
   static member SampleInto<'V>(series:Series<DateTimeOffset, 'V>, interval:TimeSpan, dir, aggregate:Func<_, _>) =

--- a/src/Deedle/SeriesExtensions.fs
+++ b/src/Deedle/SeriesExtensions.fs
@@ -14,9 +14,11 @@ open Deedle.Internal
 // Functions and methods for creating series
 // --------------------------------------------------------------------------------------
 
-/// Contains extensions for creating values of type `Series<'K, 'V>` including
+/// <summary>
+/// Contains extensions for creating values of type <c>Series&lt;'K, 'V&gt;</c> including
 /// a type with functions such as `Series.ofValues` and the `series` function.
 /// The module is automatically opened for all F# code that references `Deedle`.
+/// </summary>
 ///
 /// <category>Core frame and series types</category>
 [<AutoOpen>]
@@ -65,10 +67,12 @@ module ``F# Series extensions`` =
   let series observations = Series.ofObservations observations
 
 
+/// <summary>
 /// Contains C#-friendly extension methods for various instances of `IEnumerable`
-/// that can be used for creating `Series<'K, 'V>` from the `IEnumerable` value.
-/// You can create an ordinal series from `IEnumerable<'T>` or an indexed series from
-/// `IEnumerable<KeyValuePair<'K, 'V>>` or from `IEnumerable<KeyValuePair<'K, OptionalValue<'V>>>`.
+/// that can be used for creating <c>Series&lt;'K, 'V&gt;</c> from the `IEnumerable` value.
+/// You can create an ordinal series from <c>IEnumerable&lt;'T&gt;</c> or an indexed series from
+/// <c>IEnumerable&lt;KeyValuePair&lt;'K, 'V&gt;&gt;</c> or from <c>IEnumerable&lt;KeyValuePair&lt;'K, OptionalValue&lt;'V&gt;&gt;&gt;</c>.
+/// </summary>
 ///
 /// <category>Frame and series operations</category>
 [<Extension>]
@@ -98,19 +102,19 @@ type EnumerableExtensions =
 
 /// <summary>
 /// The type can be used for creating series using mutation. You can add
-/// items using `Add` and get the resulting series using the `Series` property.
+/// items using `Add` and get the resulting series using the <c>Series</c> property.
 /// </summary>
 /// <remarks>
 /// Using from C#:
 ///
 /// The type supports the C# collection builder pattern:
 ///
-///    	var s = new SeriesBuilder<string, double>
+///    	var s = new <c>SeriesBuilder&lt;string, double&gt;</c>
 ///       { { "A", 1.0 }, { "B", 2.0 }, { "C", 3.0 } }.Series;
 ///
 /// The type also supports the `dynamic` operator:
 ///
-///     dynamic sb = new SeriesBuilder<string, obj>();
+///     dynamic sb = new <c>SeriesBuilder&lt;string, obj&gt;</c>();
 ///     sb.ID = 1;
 ///     sb.Value = 3.4;
 /// </remarks>
@@ -184,8 +188,10 @@ type SeriesBuilder<'K, 'V when 'K : equality and 'V : equality>() =
             let converted = Convert.convertType<'V> ConversionKind.Flexible value
             builder.Add(unbox<'K> name, converted))
 
-/// A simple class that inherits from `SeriesBuilder<'K, obj>` and can be
-/// used instead of writing `SeriesBuilder<'K, obj>` with two type arguments.
+/// <summary>
+/// A simple class that inherits from <c>SeriesBuilder&lt;'K, obj&gt;</c> and can be
+/// used instead of writing <c>SeriesBuilder&lt;'K, obj&gt;</c> with two type arguments.
+/// </summary>
 ///
 /// <category>Specialized frame and series types</category>
 type SeriesBuilder<'K when 'K : equality>() =
@@ -195,10 +201,12 @@ type SeriesBuilder<'K when 'K : equality>() =
 // Extensions providing nice C#-friendly API
 // --------------------------------------------------------------------------------------
 
-/// The type implements C# and F# extension methods for the `Series<'K, 'V>` type.
+/// <summary>
+/// The type implements C# and F# extension methods for the <c>Series&lt;'K, 'V&gt;</c> type.
 /// The members are automatically available when you import the `Deedle` namespace.
 /// The type contains object-oriented counterparts to most of the functionality
 /// from the `Series` module.
+/// </summary>
 ///
 /// <category>Frame and series operations</category>
 [<Extension>]
@@ -387,9 +395,11 @@ type SeriesExtensions =
   /// </summary>
   /// <param name="series">An input series to be filtered</param>
   /// <example>
-  ///     let s = series [ 1 => 1.0; 2 => Double.NaN ]
-  ///     s.DropMissing()
-  ///     [fsi:val it : Series<int,float> = series [ 1 => 1]
+  /// <code>
+  /// let s = series [ 1 =&gt; 1.0; 2 =&gt; Double.NaN ]
+  /// s.DropMissing()
+  /// // val it : Series&lt;int,float&gt; = series [ 1 =&gt; 1]
+  /// </code>
   /// </example>
   /// <category>Missing values</category>
   [<Extension>]
@@ -412,15 +422,18 @@ type SeriesExtensions =
   /// Note that the series may still contain missing values after call to this
   /// function. This operation can only be used on ordered series.
   /// </summary>
+  /// <param name="series">The input series to be filled</param>
   /// <param name="direction">Specifies the direction used when searching for the nearest available value. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
   /// <example>
-  ///     let sample = Series.ofValues [ Double.NaN; 1.0; Double.NaN; 3.0 ]
+  /// <code>
+  /// let sample = Series.ofValues [ Double.NaN; 1.0; Double.NaN; 3.0 ]
   ///
-  ///     // Returns a series consisting of [1; 1; 3; 3]
-  ///     sample.FillMissing(Direction.Backward)
+  /// // Returns a series consisting of [1; 1; 3; 3]
+  /// sample.FillMissing(Direction.Backward)
   ///
-  ///     // Returns a series consisting of [<missing>; 1; 1; 3]
-  ///     sample.FillMissing(Direction.Forward)
+  /// // Returns a series consisting of [&lt;missing&gt;; 1; 1; 3]
+  /// sample.FillMissing(Direction.Forward)
+  /// </code>
   /// </example>
   /// <category>Missing values</category>
   [<Extension>]
@@ -571,7 +584,7 @@ type SeriesExtensions =
   /// <param name="series">An input series to be resampled</param>
   /// <param name="start">The initial time to be used for sampling</param>
   /// <param name="interval">The interval between the individual samples</param>
-  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <param name="dir">Specifies the direction. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
   /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
@@ -589,7 +602,7 @@ type SeriesExtensions =
   /// <param name="series">An input series to be resampled</param>
   /// <param name="start">The initial time to be used for sampling</param>
   /// <param name="interval">The interval between the individual samples</param>
-  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <param name="dir">Specifies the direction. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
   /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
@@ -606,7 +619,7 @@ type SeriesExtensions =
   /// </summary>
   /// <param name="series">An input series to be resampled</param>
   /// <param name="interval">The interval between the individual samples</param>
-  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <param name="dir">Specifies the direction. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
   /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -226,33 +226,30 @@ module Series =
     series.Index.Mappings |> Seq.mapl (fun idx kvp ->
       kvp.Key, OptionalValue.asOption (series.Vector.GetValueAtLocation(KnownLocation(kvp.Value, idx))))
 
+  /// <summary>
   /// Create a new series that contains values for all provided keys.
   /// Use the specified lookup semantics - for exact matching, use `getAll`
-  ///
-  /// ## Parameters
-  ///  - `keys` - A sequence of keys that will form the keys of the retunred sequence
-  ///  - `lookup` - Lookup behavior to use when the value at the specified key does not exist
-  ///
+  /// </summary>
+  /// <param name="keys">A sequence of keys that will form the keys of the retunred sequence</param>
+  /// <param name="lookup">Lookup behavior to use when the value at the specified key does not exist</param>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("LookupAll")>]
   let lookupAll keys lookup (series:Series<'K, 'T>) = series.GetItems(keys, lookup)
 
+  /// <summary>
   /// Sample an (ordered) series by finding the value at the exact or closest prior key
   /// for some new sequence of keys.
-  ///
-  /// ## Parameters
-  ///  - `keys` - A sequence of keys that will form the keys of the retunred sequence
-  ///
+  /// </summary>
+  /// <param name="keys">A sequence of keys that will form the keys of the retunred sequence</param>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("Sample")>]
   let sample keys (series:Series<'K, 'T>) = series |> lookupAll keys Lookup.ExactOrSmaller
 
+  /// <summary>
   /// Create a new series that contains values for all provided keys.
   /// Uses exact lookup semantics for key lookup - use `lookupAll` for more options
-  ///
-  /// ## Parameters
-  ///  - `keys` - A sequence of keys that will form the keys of the retunred sequence
-  ///
+  /// </summary>
+  /// <param name="keys">A sequence of keys that will form the keys of the retunred sequence</param>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetObservations")>]
   let getAll keys (series:Series<'K, 'T>) = series.GetItems(keys)
@@ -480,19 +477,19 @@ module Series =
   let mapKeys (f:'K -> 'R) (series:Series<'K, 'T>) =
     series.SelectKeys(fun kvp -> f kvp.Key)
 
+  /// <summary>
   /// Retruns a new series whose values are converted using the specified conversion function.
   /// This operation is like `mapValues`, but it requires a pair of function that converts
   /// the values in _both ways_.
-  ///
-  /// ## Parameters
-  ///  - `forward` - Function that converts original values to the new
-  ///  - `backward` - Function that converts new values back to the original
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="forward">Function that converts original values to the new</param>
+  /// <param name="backward">Function that converts new values back to the original</param>
+  /// <remarks>
   /// This operation is only interesting when working with virtualized data sources. Using the
   /// `convert` function makes it possible to perfom additional operations on the resulting
   /// series - for example lookup - by converting the new value back and using the lookup of
   /// the underlying virtualized source.
+  /// </remarks>
   [<CompiledName("Convert")>]
   let convert (forward:'T -> 'R) (backward:'R -> 'T) (series:Series<'K, 'T>) =
     series.Convert(Func<_, _>(forward), Func<_, _>(backward))
@@ -506,12 +503,11 @@ module Series =
   let flatten (series:Series<'K, 'T option>) =
     series |> mapAll (fun _ v -> match v with Some x -> x | _ -> None)
 
+  /// <summary>
   /// Returns a series that contains the specified number of keys from the original series.
-  ///
-  /// ## Parameters
-  ///  - `count` - Number of keys to take; must be smaller or equal to the original number of keys
-  ///  - `series` - Input series from which the keys are taken
-  ///
+  /// </summary>
+  /// <param name="count">Number of keys to take; must be smaller or equal to the original number of keys</param>
+  /// <param name="series">Input series from which the keys are taken</param>
   /// <category>Series transformations</category>
   [<CompiledName("Take")>]
   let take count (series:Series<'K, 'T>) =
@@ -519,13 +515,12 @@ module Series =
       invalidArg "count" "Must be greater than zero and less than the number of keys."
     series.GetAddressRange(RangeRestriction.Start(int64 count))
 
+  /// <summary>
   /// Returns a series that contains the specified number of keys from the
   /// original series. The keys are taken from the end of the series.
-  ///
-  /// ## Parameters
-  ///  - `count` - Number of keys to take; must be smaller or equal to the original number of keys
-  ///  - `series` - Input series from which the keys are taken
-  ///
+  /// </summary>
+  /// <param name="count">Number of keys to take; must be smaller or equal to the original number of keys</param>
+  /// <param name="series">Input series from which the keys are taken</param>
   /// <category>Series transformations</category>
   [<CompiledName("TakeLast")>]
   let takeLast count (series:Series<'K, 'T>) =
@@ -533,13 +528,12 @@ module Series =
       invalidArg "count" "Must be greater than zero and less than the number of keys."
     series.GetAddressRange(RangeRestriction.End(int64 count))
 
+  /// <summary>
   /// Returns a series that contains the data from the original series,
   /// except for the first `count` keys.
-  ///
-  /// ## Parameters
-  ///  - `count` - Number of keys to skip; must be smaller or equal to the original number of keys
-  ///  - `series` - Input series from which the keys are taken
-  ///
+  /// </summary>
+  /// <param name="count">Number of keys to skip; must be smaller or equal to the original number of keys</param>
+  /// <param name="series">Input series from which the keys are taken</param>
   /// <category>Series transformations</category>
   [<CompiledName("Skip")>]
   let skip count (series:Series<'K, 'T>) =
@@ -547,13 +541,12 @@ module Series =
       invalidArg "count" "Must be greater than zero and less than the number of keys."
     series.GetAddressRange(RangeRestriction.Fixed(series.Index.AddressAt(count |> int64), series.Index.AddressAt (series.KeyCount - 1 |> int64)))
 
+  /// <summary>
   /// Returns a series that contains the data from the original series,
   /// except for the last `count` keys.
-  ///
-  /// ## Parameters
-  ///  - `count` - Number of keys to skip; must be smaller or equal to the original number of keys
-  ///  - `series` - Input series from which the keys are taken
-  ///
+  /// </summary>
+  /// <param name="count">Number of keys to skip; must be smaller or equal to the original number of keys</param>
+  /// <param name="series">Input series from which the keys are taken</param>
   /// <category>Series transformations</category>
   [<CompiledName("SkipLast")>]
   let skipLast count (series:Series<'K, 'T>) =
@@ -572,43 +565,40 @@ module Series =
 
   // Scanning
 
+  /// <summary>
   /// Applies a folding function starting with some initial value and the first value of the series,
   /// and continues to "scan" along the series, saving all values produced from the first function
   /// application, and yielding a new series having the original index and newly produced values.
   /// Any application involving a missing value yields a missing value.
-  ///
-  /// ## Parameters
-  ///  - `foldFunc` - A folding function
-  ///  - `init` - An initial value
-  ///  - `series` - The series over whose values to scan
-  ///
+  /// </summary>
+  /// <param name="foldFunc">A folding function</param>
+  /// <param name="init">An initial value</param>
+  /// <param name="series">The series over whose values to scan</param>
   /// <category>Series transformations</category>
   [<CompiledName("ScanValues")>]
   let scanValues foldFunc (init:'R) (series:Series<'K,'T>) =
     series.ScanValues(Func<_,_,_>(foldFunc), init)
 
+  /// <summary>
   /// Applies a folding function starting with some initial optional value and the first optional value of
   /// the series, and continues to "scan" along the series, saving all values produced from the first function
   /// application, and yielding a new series having the original index and newly produced values.
-  ///
-  /// ## Parameters
-  ///  - `foldFunc` - A folding function
-  ///  - `init` - An initial value
-  ///  - `series` - The series over whose values to scan
-  ///
+  /// </summary>
+  /// <param name="foldFunc">A folding function</param>
+  /// <param name="init">An initial value</param>
+  /// <param name="series">The series over whose values to scan</param>
   /// <category>Series transformations</category>
   [<CompiledName("ScanAllValues")>]
   let scanAllValues foldFunc (init:'R option) (series:Series<'K,'T>) =
     let liftedFunc a b = foldFunc (OptionalValue.asOption a) (OptionalValue.asOption b) |> OptionalValue.ofOption
     series.ScanAllValues(Func<_,_,_>(liftedFunc), OptionalValue.ofOption init)
 
+  /// <summary>
   /// Aggregates the values of the specified series using a function that can combine
   /// individual values. Fails if the series contains no values.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be aggregated
-  ///  - `op` - A function that is used to aggregate elements of the series
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be aggregated</param>
+  /// <param name="op">A function that is used to aggregate elements of the series</param>
   /// <category>Series transformations</category>
   [<CompiledName("ReduceValues")>]
   let reduceValues op (series:Series<'K, 'T>) =
@@ -617,14 +607,13 @@ module Series =
     | VectorData.SparseList list -> (ReadOnlyCollection.reduceOptional op list) |> OptionalValue.get
     | VectorData.Sequence seq -> Seq.reduce op (Seq.choose OptionalValue.asOption seq)
 
+  /// <summary>
   /// Aggregates the values of the specified series using a function that can combine
   /// individual values. The folding starts with the specified initial value.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be aggregated
-  ///  - `init` - An initial value for the aggregation
-  ///  - `op` - A function that is used to aggregate elements of the series with the current state
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be aggregated</param>
+  /// <param name="init">An initial value for the aggregation</param>
+  /// <param name="op">A function that is used to aggregate elements of the series with the current state</param>
   /// <category>Series transformations</category>
   [<CompiledName("FoldValues")>]
   let foldValues op init (series:Series<'K, 'T>) =
@@ -633,18 +622,16 @@ module Series =
     | VectorData.SparseList list -> ReadOnlyCollection.foldOptional op init list
     | VectorData.Sequence seq -> Seq.fold op init (Seq.choose OptionalValue.asOption seq)
 
+  /// <summary>
   /// Returns a series containing difference between a value in the original series and
   /// a value at the specified offset. For example, calling `Series.diff 1 s` returns a
   /// series where previous value is subtracted from the current one. In pseudo-code, the
   /// function behaves as follows:
   ///
   ///     result[k] = series[k] - series[k - offset]
-  ///
-  /// ## Parameters
-  ///  - `offset` - When positive, subtracts the past values from the current values;
-  ///    when negative, subtracts the future values from the current values.
-  ///  - `series` - The input series, containing values that support the `-` operator.
-  ///
+  /// </summary>
+  /// <param name="offset">When positive, subtracts the past values from the current values; when negative, subtracts the future values from the current values.</param>
+  /// <param name="series">The input series, containing values that support the `-` operator.</param>
   /// <category>Series transformations</category>
   [<CompiledName("Diff")>]
   let inline diff offset (series:Series<'K, ^T>) =
@@ -655,21 +642,20 @@ module Series =
     let newVector = vectorBuilder.Build(newIndex.AddressingScheme, cmd, [| series.Vector |])
     Series(newIndex, newVector, vectorBuilder, series.Index.Builder)
 
+  /// <summary>
   /// Returns a series with values shifted by the specified offset. When the offset is
   /// positive, the values are shifted forward and first `offset` keys are dropped. When the
   /// offset is negative, the values are shifted backwards and the last `offset` keys are dropped.
   /// Expressed in pseudo-code:
   ///
   ///     result[k] = series[k - offset]
-  ///
-  /// ## Parameters
-  ///  - `offset` - Can be both positive and negative number.
-  ///  - `series` - The input series to be shifted.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="offset">Can be both positive and negative number.</param>
+  /// <param name="series">The input series to be shifted.</param>
+  /// <remarks>
   /// If you want to calculate the difference, e.g. `s - (Series.shift 1 s)`, you can
   /// use `Series.diff` which will be a little bit faster.
-  ///
+  /// </remarks>
   /// <category>Series transformations</category>
   [<CompiledName("Shift")>]
   let shift offset (series:Series<'K, 'T>) =
@@ -736,23 +722,23 @@ module Series =
   // Hierarchical index operations
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `level` and then aggregates series representing each group
   /// using the specified function `op`. The result is a new series containing
   /// the aggregates of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../frame.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be aggregated
-  ///  - `op` - A function that takes a series and produces an aggregated result
-  ///  - `level` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be aggregated</param>
+  /// <param name="op">A function that takes a series and produces an aggregated result</param>
+  /// <param name="level">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Hierarchical index operations</category>
   [<CompiledName("ApplyLevel")>]
   let inline applyLevel (level:'K1 -> 'K2) op (series:Series<_, 'V>) : Series<_, 'R> =
     series.GroupBy(fun kvp -> level kvp.Key) |> mapValues op
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `level` and then aggregates series representing each group
   /// using the specified function `op`. The result is a new series containing
@@ -760,29 +746,26 @@ module Series =
   /// case the group will have no representation in the resulting series.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../frame.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be aggregated
-  ///  - `op` - A function that takes a series and produces an optional aggregated result
-  ///  - `level` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be aggregated</param>
+  /// <param name="op">A function that takes a series and produces an optional aggregated result</param>
+  /// <param name="level">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Hierarchical index operations</category>
   [<CompiledName("ApplyLevelOptional")>]
   let inline applyLevelOptional (level:'K1 -> 'K2) op (series:Series<_, 'V>) : Series<_, 'R> =
     series.GroupBy(fun kvp -> level kvp.Key) |> mapValues op |> flatten
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `level` and then aggregates elements in each group
   /// using the specified function `op`. The result is a new series containing
   /// the aggregates of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../frame.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be aggregated
-  ///  - `op` - A function that is used to aggregate elements of each group
-  ///  - `level` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be aggregated</param>
+  /// <param name="op">A function that is used to aggregate elements of each group</param>
+  /// <param name="level">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Hierarchical index operations</category>
   [<CompiledName("ReduceLevel")>]
   let reduceLevel (level:'K1 -> 'K2) op (series:Series<_, 'T>) =
@@ -792,53 +775,45 @@ module Series =
   // Grouping, windowing and chunking
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Aggregates an ordered series using the method specified by `Aggregation<K>` and
   /// returns the windows or chunks as nested series. A key for each window or chunk is
   /// selected using the specified `keySelector`.
-  ///
-  /// ## Parameters
-  ///  - `aggregation` - Specifies the aggregation method using `Aggregation<K>`. This is
-  ///    a discriminated union listing various chunking and windowing conditions.
-  ///  - `keySelector` - A function that is called on each chunk to obtain a key.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="keySelector">A function that is called on each chunk to obtain a key.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("Aggregate")>]
   let aggregate aggregation keySelector (series:Series<'K, 'T>) : Series<'TNewKey, _> =
     series.Aggregate
       ( aggregation, System.Func<_, _>(keySelector), System.Func<_, _>(fun v -> OptionalValue(v)))
 
+  /// <summary>
   /// Aggregates an ordered series using the method specified by `Aggregation<K>` and then
   /// applies the provided value selector `f` on each window or chunk to produce the result
   /// which is returned as a new series. A key for each window or chunk is
   /// selected using the specified `keySelector`.
-  ///
-  /// ## Parameters
-  ///  - `aggregation` - Specifies the aggregation method using `Aggregation<K>`. This is
-  ///    a discriminated union listing various chunking and windowing conditions.
-  ///  - `keySelector` - A function that is called on each chunk to obtain a key.
-  ///  - `f` - A value selector function that is called to aggregate each chunk or window.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="keySelector">A function that is called on each chunk to obtain a key.</param>
+  /// <param name="f">A value selector function that is called to aggregate each chunk or window.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("AggregateInto")>]
   let aggregateInto aggregation keySelector f (series:Series<'K, 'T>) : Series<'TNewKey, 'R> =
     series.Aggregate
       ( aggregation, System.Func<_, _>(keySelector), System.Func<_, _>(f))
 
+  /// <summary>
   /// Creates a sliding window using the specified size and boundary behavior and then
   /// applies the provided value selector `f` on each window to produce the result
   /// which is returned as a new series. The key is the last key of the window, unless
   /// boundary behavior is `Boundary.AtEnding` (in which case it is the first key).
-  ///
-  /// ## Parameters
-  ///  - `bounds` - Specifies the window size and bounary behavior. The boundary behavior
-  ///    can be `Boundary.Skip` (meaning that no incomplete windows are produced),
-  ///    `Boundary.AtBeginning` (meaning that incomplete windows are produced at the beginning)
-  ///    or `Boundary.AtEnding` (to produce incomplete windows at the end of series)
-  ///  - `f` - A value selector that is called to aggregate each window.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="bounds">Specifies the window size and bounary behavior. The boundary behavior can be `Boundary.Skip` (meaning that no incomplete windows are produced), `Boundary.AtBeginning` (meaning that incomplete windows are produced at the beginning) or `Boundary.AtEnding` (to produce incomplete windows at the end of series)</param>
+  /// <param name="f">A value selector that is called to aggregate each window.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowSizeInto")>]
   let windowSizeInto bounds f (series:Series<'K, 'T>) : Series<'K, 'R> =
@@ -848,17 +823,13 @@ module Series =
       else data.Data.Index.KeyRange |> fst )
     series.Aggregate(WindowSize(bounds), keySel, (fun ds -> OptionalValue(f ds)))
 
+  /// <summary>
   /// Creates a sliding window using the specified size and boundary behavior and returns
   /// the produced windows as a nested series. The key is the last key of the window, unless
   /// boundary behavior is `Boundary.AtEnding` (in which case it is the first key).
-  ///
-  /// ## Parameters
-  ///  - `bounds` - Specifies the window size and bounary behavior. The boundary behavior
-  ///    can be `Boundary.Skip` (meaning that no incomplete windows are produced),
-  ///    `Boundary.AtBeginning` (meaning that incomplete windows are produced at the beginning)
-  ///    or `Boundary.AtEnding` (to produce incomplete windows at the end of series)
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="bounds">Specifies the window size and bounary behavior. The boundary behavior can be `Boundary.Skip` (meaning that no incomplete windows are produced), `Boundary.AtBeginning` (meaning that incomplete windows are produced at the beginning) or `Boundary.AtEnding` (to produce incomplete windows at the end of series)</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowSize")>]
   let inline windowSize bounds (series:Series<'K, 'T>) =
@@ -866,18 +837,15 @@ module Series =
 
   // Based on distance
 
+  /// <summary>
   /// Creates a sliding window based on distance between keys. A window is started at each
   /// input element and ends once the distance between the first and the last key is greater
   /// than the specified `distance`. Each window is then aggregated into a value using the
   /// specified function `f`. The key of each window is the key of the first element in the window.
-  ///
-  /// ## Parameters
-  ///  - `distance` - The maximal allowed distance between keys of a window. Note that this
-  ///    is an inline function - there must be `-` operator defined between `distance` and the
-  ///    keys of the series.
-  ///  - `f` - A function that is used to aggregate each window into a single value.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="distance">The maximal allowed distance between keys of a window. Note that this is an inline function - there must be `-` operator defined between `distance` and the keys of the series.</param>
+  /// <param name="f">A function that is used to aggregate each window into a single value.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowDistanceInto")>]
   let inline windowDistInto distance f (series:Series<'K, 'T>) =
@@ -885,17 +853,14 @@ module Series =
       ( WindowWhile(fun skey ekey -> (ekey - skey) < distance),
         (fun d -> d.Data.Keys |> Seq.head), fun ds -> OptionalValue(f ds.Data))
 
+  /// <summary>
   /// Creates a sliding window based on distance between keys. A window is started at each
   /// input element and ends once the distance between the first and the last key is greater
   /// than the specified `distance`. The windows are then returned as a nested series.
   /// The key of each window is the key of the first element in the window.
-  ///
-  /// ## Parameters
-  ///  - `distance` - The maximal allowed distance between keys of a window. Note that this
-  ///    is an inline function - there must be `-` operator defined between `distance` and the
-  ///    keys of the series.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="distance">The maximal allowed distance between keys of a window. Note that this is an inline function - there must be `-` operator defined between `distance` and the keys of the series.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowDistance")>]
   let inline windowDist (distance:'D) (series:Series<'K, 'T>) =
@@ -903,32 +868,28 @@ module Series =
 
   // Window using while
 
+  /// <summary>
   /// Creates a sliding window based on a condition on keys. A window is started at each
   /// input element and ends once the specified `cond` function returns `false` when called on
   /// the first and the last key of the window. Each window is then aggregated into a value using the
   /// specified function `f`. The key of each window is the key of the first element in the window.
-  ///
-  /// ## Parameters
-  ///  - `cond` - A function that is called on the first and the last key of a window
-  ///    to determine when a window should end.
-  ///  - `f` - A function that is used to aggregate each window into a single value.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="cond">A function that is called on the first and the last key of a window to determine when a window should end.</param>
+  /// <param name="f">A function that is used to aggregate each window into a single value.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowWhileInto")>]
   let inline windowWhileInto cond f (series:Series<'K, 'T>) =
     series.Aggregate(WindowWhile(cond), (fun d -> d.Data.Keys |> Seq.head), fun ds -> OptionalValue(f ds.Data))
 
+  /// <summary>
   /// Creates a sliding window based on a condition on keys. A window is started at each
   /// input element and ends once the specified `cond` function returns `false` when called on
   /// the first and the last key of the window. The windows are then returned as a nested series.
   /// The key of each window is the key of the first element in the window.
-  ///
-  /// ## Parameters
-  ///  - `cond` - A function that is called on the first and the last key of a window
-  ///    to determine when a window should end.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="cond">A function that is called on the first and the last key of a window to determine when a window should end.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowWhile")>]
   let inline windowWhile cond (series:Series<'K, 'T>) =
@@ -936,36 +897,28 @@ module Series =
 
   // Chunk based on size
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks using the specified size and boundary behavior and then
   /// applies the provided value selector `f` on each chunk to produce the result
   /// which is returned as a new series. The key is the first key of the chunk, unless
   /// boundary behavior has `Boundary.AtBeginning` flag (in which case it is the last key).
-  ///
-  /// ## Parameters
-  ///  - `bounds` - Specifies the chunk size and bounary behavior. The boundary behavior
-  ///    can be `Boundary.Skip` (meaning that no incomplete chunks are produced),
-  ///    `Boundary.AtBeginning` (meaning that incomplete chunks are produced at the beginning)
-  ///    or `Boundary.AtEnding` (to produce incomplete chunks at the end of series)
-  ///  - `f` - A value selector that is called to aggregate each chunk.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="bounds">Specifies the chunk size and bounary behavior. The boundary behavior can be `Boundary.Skip` (meaning that no incomplete chunks are produced), `Boundary.AtBeginning` (meaning that incomplete chunks are produced at the beginning) or `Boundary.AtEnding` (to produce incomplete chunks at the end of series)</param>
+  /// <param name="f">A value selector that is called to aggregate each chunk.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkSizeInto")>]
   let inline chunkSizeInto bounds f (series:Series<'K, 'T>) : Series<'K, 'R> =
     // Seq.chunkRangesWithBounds checks for boundary.HasFlag(Boundary.AtBeginning) and assumes AtEnding otherwise
     series.Aggregate(ChunkSize(bounds), (fun d -> d.Data.Keys |> if (snd bounds).HasFlag(Boundary.AtBeginning) then Seq.last else Seq.head), fun ds -> OptionalValue(f ds))
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks using the specified size and boundary behavior and returns
   /// the produced chunks as a nested series. The key is the first key of the chunk, unless
   /// boundary behavior has `Boundary.AtBeginning` flag (in which case it is the last key).
-  ///
-  /// ## Parameters
-  ///  - `bounds` - Specifies the chunk size and bounary behavior. The boundary behavior
-  ///    can be `Boundary.Skip` (meaning that no incomplete chunks are produced),
-  ///    `Boundary.AtBeginning` (meaning that incomplete chunks are produced at the beginning)
-  ///    or `Boundary.AtEnding` (to produce incomplete chunks at the end of series)
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="bounds">Specifies the chunk size and bounary behavior. The boundary behavior can be `Boundary.Skip` (meaning that no incomplete chunks are produced), `Boundary.AtBeginning` (meaning that incomplete chunks are produced at the beginning) or `Boundary.AtEnding` (to produce incomplete chunks at the end of series)</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkSize")>]
   let inline chunkSize bounds (series:Series<'K, 'T>) =
@@ -973,34 +926,28 @@ module Series =
 
   // Chunk based on distance
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks. A chunk is started once
   /// the distance between the first and the last key of a previous chunk is greater
   /// than the specified `distance`. Each chunk is then aggregated into a value using the
   /// specified function `f`. The key of each chunk is the key of the first element in the chunk.
-  ///
-  /// ## Parameters
-  ///  - `distance` - The maximal allowed distance between keys of a chunk. Note that this
-  ///    is an inline function - there must be `-` operator defined between `distance` and the
-  ///    keys of the series.
-  ///  - `f` - A value selector that is called to aggregate each chunk.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="distance">The maximal allowed distance between keys of a chunk. Note that this is an inline function - there must be `-` operator defined between `distance` and the keys of the series.</param>
+  /// <param name="f">A value selector that is called to aggregate each chunk.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkDistanceInto")>]
   let inline chunkDistInto (distance:^D) f (series:Series<'K, 'T>) : Series<'K, 'R> =
     series.Aggregate(ChunkWhile(fun skey ekey -> (ekey - skey) < distance), (fun d -> d.Data.Keys |> Seq.head), fun ds -> OptionalValue(f ds.Data))
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks. A chunk is started once
   /// the distance between the first and the last key of a previous chunk is greater
   /// than the specified `distance`. The chunks are then returned as a nested series.
   /// The key of each chunk is the key of the first element in the chunk.
-  ///
-  /// ## Parameters
-  ///  - `distance` - The maximal allowed distance between keys of a chunk. Note that this
-  ///    is an inline function - there must be `-` operator defined between `distance` and the
-  ///    keys of the series.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="distance">The maximal allowed distance between keys of a chunk. Note that this is an inline function - there must be `-` operator defined between `distance` and the keys of the series.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkDistance")>]
   let inline chunkDist (distance:^D) (series:Series<'K, 'T>) =
@@ -1008,32 +955,28 @@ module Series =
 
   // Chunk while
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks based on a condition on keys. A chunk is started
   /// once the specified `cond` function returns `false` when called on  the first and the last key of the
   /// previous chunk. Each chunk is then aggregated into a value using the
   /// specified function `f`. The key of each chunk is the key of the first element in the chunk.
-  ///
-  /// ## Parameters
-  ///  - `cond` - A function that is called on the first and the last key of a chunk
-  ///    to determine when a window should end.
-  ///  - `f` - A value selector that is called to aggregate each chunk.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="cond">A function that is called on the first and the last key of a chunk to determine when a window should end.</param>
+  /// <param name="f">A value selector that is called to aggregate each chunk.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkWhileInto")>]
   let inline chunkWhileInto cond f (series:Series<'K, 'T>) =
     series.Aggregate(ChunkWhile(cond), (fun d -> d.Data.Keys |> Seq.head), fun ds -> OptionalValue(f ds.Data))
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks based on a condition on keys. A chunk is started
   /// once the specified `cond` function returns `false` when called on  the first and the last key of the
   /// previous chunk. The chunks are then returned as a nested series.
   /// The key of each chunk is the key of the first element in the chunk.
-  ///
-  /// ## Parameters
-  ///  - `cond` - A function that is called on the first and the last key of a chunk
-  ///    to determine when a window should end.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="cond">A function that is called on the first and the last key of a chunk to determine when a window should end.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkWhile")>]
   let inline chunkWhile cond (series:Series<'K, 'T>) =
@@ -1041,55 +984,51 @@ module Series =
 
   // Most common-case functions
 
+  /// <summary>
   /// Creates a sliding window using the specified size and then applies the provided
   /// value selector `f` on each window to produce the result which is returned as a new series.
   /// This function skips incomplete chunks - you can use `Series.windowSizeInto` for more options.
-  ///
-  /// ## Parameters
-  ///  - `size` - The size of the sliding window.
-  ///  - `series` - The input series to be aggregated.
-  ///  - `f` - A function that is called on each created window.
-  ///
+  /// </summary>
+  /// <param name="size">The size of the sliding window.</param>
+  /// <param name="series">The input series to be aggregated.</param>
+  /// <param name="f">A function that is called on each created window.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("WindowInto")>]
   let inline windowInto size f (series:Series<'K, 'T>) : Series<'K, 'R> =
     windowSizeInto (size, Boundary.Skip) (DataSegment.data >> f) series
 
+  /// <summary>
   /// Creates a sliding window using the specified size and returns the produced windows as
   /// a nested series. The key in the new series is the last key of the window. This function
   /// skips incomplete chunks - you can use `Series.windowSize` for more options.
-  ///
-  /// ## Parameters
-  ///  - `size` - The size of the sliding window.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="size">The size of the sliding window.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("Window")>]
   let inline window size (series:Series<'K, 'T>) =
     windowSize (size, Boundary.Skip) series
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks and then applies the provided
   /// value selector `f` on each chunk to produce the result which is returned as a new series.
   /// The key in the new series is the last key of the chunk. This function
   /// skips incomplete chunks - you can use `Series.chunkSizeInto` for more options.
-  ///
-  /// ## Parameters
-  ///  - `size` - The size of the chunk.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="size">The size of the chunk.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkInto")>]
   let inline chunkInto size f (series:Series<'K, 'T>) : Series<'K, 'R> =
     chunkSizeInto (size, Boundary.Skip) (DataSegment.data >> f) series
 
+  /// <summary>
   /// Aggregates the input into a series of adacent chunks and returns the produced chunks as
   /// a nested series. The key in the new series is the last key of the chunk. This function
   /// skips incomplete chunks - you can use `Series.chunkSize` for more options.
-  ///
-  /// ## Parameters
-  ///  - `size` - The size of the chunk.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="size">The size of the chunk.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("Chunk")>]
   let inline chunk size (series:Series<'K, 'T>) =
@@ -1097,32 +1036,29 @@ module Series =
 
   // Pairwise
 
+  /// <summary>
   /// Returns a series containing the predecessor and an element for each input, except
   /// for the first one. The returned series is one key shorter (it does not contain a
   /// value for the first key).
-  ///
-  /// ## Parameters
-  ///  - `series` - The input series to be aggregated.
-  ///
-  /// ## Example
-  ///
+  /// </summary>
+  /// <param name="series">The input series to be aggregated.</param>
+  /// <example>
   ///     let input = series [ 1 => 'a'; 2 => 'b'; 3 => 'c']
   ///     let res = input |> Series.pairwise
   ///     res = series [2 => ('a', 'b'); 3 => ('b', 'c') ]
-  ///
+  /// </example>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("Pairwise")>]
   let pairwise (series:Series<'K, 'T>) =
     series.Pairwise()
 
+  /// <summary>
   /// Aggregates the input into pairs containing the predecessor and an element for each input, except
   /// for the first one. Then calls the specified aggregation function `f` with a tuple and a key.
   /// The returned series is one key shorter (it does not contain a  value for the first key).
-  ///
-  /// ## Parameters
-  ///  - `f` - A function that is called for each pair to produce result in the final series.
-  ///  - `series` - The input series to be aggregated.
-  ///
+  /// </summary>
+  /// <param name="f">A function that is called for each pair to produce result in the final series.</param>
+  /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("PairwiseWith")>]
   let pairwiseWith f (series:Series<'K, 'T>) =
@@ -1130,29 +1066,25 @@ module Series =
 
   // Grouping
 
+  /// <summary>
   /// Groups a series (ordered or unordered) using the specified key selector (`keySelector`)
   /// and then aggregates each group into a single value, returned in the resulting series,
   /// using the provided `f` function.
-  ///
-  /// ## Parameters
-  ///  - `keySelector` - Generates a new key that is used for aggregation, based on the original
-  ///    key and value. The new key must support equality testing.
-  ///  - `f` - A function to aggregate each group of collected elements.
-  ///  - `series` - An input series to be grouped.
-  ///
+  /// </summary>
+  /// <param name="keySelector">Generates a new key that is used for aggregation, based on the original key and value. The new key must support equality testing.</param>
+  /// <param name="f">A function to aggregate each group of collected elements.</param>
+  /// <param name="series">An input series to be grouped.</param>
   /// <category>Grouping, windowing and chunking</category>
   let groupInto (keySelector:'K -> 'T -> 'TNewKey) f (series:Series<'K, 'T>) : Series<'TNewKey, 'TNewValue> =
     series.GroupBy(fun (KeyValue(k,v)) -> keySelector k v) |> map (fun k s -> f k s)
 
+  /// <summary>
   /// Groups a series (ordered or unordered) using the specified key selector (`keySelector`)
   /// and then returns a series of (nested) series as the result. The outer series is indexed by
   /// the newly produced keys, the nested series are indexed with the original keys.
-  ///
-  /// ## Parameters
-  ///  - `keySelector` - Generates a new key that is used for aggregation, based on the original
-  ///    key and value. The new key must support equality testing.
-  ///  - `series` - An input series to be grouped.
-  ///
+  /// </summary>
+  /// <param name="keySelector">Generates a new key that is used for aggregation, based on the original key and value. The new key must support equality testing.</param>
+  /// <param name="series">An input series to be grouped.</param>
   /// <category>Grouping, windowing and chunking</category>
   let groupBy (keySelector:'K -> 'T -> 'TNewKey) (series:Series<'K, 'T>) =
     groupInto keySelector (fun k s -> s) series
@@ -1171,37 +1103,33 @@ module Series =
     series.WithMissingFrom(other)
 
 
+  /// <summary>
   /// Drop missing values from the specified series. The returned series contains
   /// only those keys for which there is a value available in the original one.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be filtered
-  ///
-  /// ## Example
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be filtered</param>
+  /// <example>
   ///     let s = series [ 1 => 1.0; 2 => Double.NaN ]
   ///     s |> Series.dropMissing
   ///     [fsi:val it : Series<int,float> = series [ 1 => 1]
-  ///
+  /// </example>
   /// <category>Missing values</category>
   [<CompiledName("DropMissing")>]
   let dropMissing (series:Series<'K, 'T>) =
     series.WhereOptional(fun (KeyValue(k, v)) -> v.HasValue)
 
+  /// <summary>
   /// Fill missing values in the series using the specified function.
   /// The specified function is called with all keys for which the series
   /// does not contain value and the result of the call is used in place
   /// of the missing value.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series that is to be filled
-  ///  - `f` - A function that takes key `K` and generates a value to be
-  ///    used in a place where the original series contains a missing value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series that is to be filled</param>
+  /// <param name="f">A function that takes key `K` and generates a value to be used in a place where the original series contains a missing value.</param>
+  /// <remarks>
   /// This function can be used to implement more complex interpolation.
   /// For example see [handling missing values in the tutorial](../frame.html#missing)
-  ///
+  /// </remarks>
   /// <category>Missing values</category>
   [<CompiledName("FillMissingUsing")>]
   let fillMissingUsing f (series:Series<'K, 'T>) =
@@ -1209,12 +1137,11 @@ module Series =
       | None -> Some(f k)
       | value -> value)
 
+  /// <summary>
   /// Fill missing values in the series with a constant value.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series that is to be filled
-  ///  - `value` - A constant value that is used to fill all missing values
-  ///
+  /// </summary>
+  /// <param name="series">An input series that is to be filled</param>
+  /// <param name="value">A constant value that is used to fill all missing values</param>
   /// <category>Missing values</category>
   [<CompiledName("FillMissingWith")>]
   let fillMissingWith value (series:Series<'K, 'T>) =
@@ -1222,20 +1149,15 @@ module Series =
     let newVector = series.VectorBuilder.Build(series.Index.AddressingScheme, fillCmd, [|series.Vector|])
     Series<_, _>(series.Index, newVector, series.VectorBuilder, series.IndexBuilder)
 
+  /// <summary>
   /// Fill missing values in the series with the nearest available value
   /// (using the specified direction). Note that the series may still contain
   /// missing values after call to this function. This operation can only be
   /// used on ordered series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series that is to be filled
-  ///  - `direction` - Specifies the direction used when searching for
-  ///    the nearest available value. `Backward` means that we want to
-  ///    look for the first value with a smaller key while `Forward` searches
-  ///    for the nearest greater key.
-  ///
-  /// ## Example
-  ///
+  /// </summary>
+  /// <param name="series">An input series that is to be filled</param>
+  /// <param name="direction">Specifies the direction used when searching for the nearest available value. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
+  /// <example>
   ///     let sample = Series.ofValues [ Double.NaN; 1.0; Double.NaN; 3.0 ]
   ///
   ///     // Returns a series consisting of [1; 1; 3; 3]
@@ -1243,7 +1165,7 @@ module Series =
   ///
   ///     // Returns a series consisting of [<missing>; 1; 1; 3]
   ///     sample |> Series.fillMissing Direction.Forward
-  ///
+  /// </example>
   /// <category>Missing values</category>
   [<CompiledName("FillMissing")>]
   let fillMissing direction (series:Series<'K, 'T>) =
@@ -1251,17 +1173,13 @@ module Series =
     let newVector = series.VectorBuilder.Build(series.Index.AddressingScheme, fillCmd, [|series.Vector|])
     Series<_, _>(series.Index, newVector, series.VectorBuilder, series.IndexBuilder)
 
+  /// <summary>
   /// Fill missing values only between `startKey` and `endKey`, inclusive.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series that is to be filled
-  ///  - `direction` - Specifies the direction used when searching for
-  ///    the nearest available value. `Backward` means that we want to
-  ///    look for the first value with a smaller key while `Forward` searches
-  ///    for the nearest greater key.
-  ///  - `startKey` - the lower bound at which values should be filled
-  ///  - `endKey` - the upper bound at which values should be filled
-  ///
+  /// </summary>
+  /// <param name="series">An input series that is to be filled</param>
+  /// <param name="direction">Specifies the direction used when searching for the nearest available value. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
+  /// <param name="startKey">the lower bound at which values should be filled</param>
+  /// <param name="endKey">the upper bound at which values should be filled</param>
   /// <category>Missing values</category>
   [<CompiledName("FillMissingBetween")>]
   let fillMissingBetween (startKey, endKey) direction (series:Series<'K, 'T>) =
@@ -1317,15 +1235,12 @@ module Series =
     let fseries = Series(index, vector.Select(fun _ -> OptionalValue.map f), series.VectorBuilder, series.IndexBuilder)
     fseries |> sortWithCommand compare
 
+  /// <summary>
   /// Returns a new series, containing the observations of the original series sorted using
   /// the specified comparison function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series whose values are sorter
-  ///  - `comparer` - A comparer function on the series values. The function should return
-  ///    negative integer when the first value is smaller, positive when it is greater and
-  ///    0 when the values are equal.
-  ///
+  /// </summary>
+  /// <param name="series">An input series whose values are sorter</param>
+  /// <param name="comparer">A comparer function on the series values. The function should return negative integer when the first value is smaller, positive when it is greater and 0 when the values are equal.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("SortWith")>]
   let sortWith comparer (series:Series<'K, 'V>) =
@@ -1333,14 +1248,12 @@ module Series =
     let newVector = series.VectorBuilder.Build(newIndex.AddressingScheme, cmd, [| series.Vector |])
     Series(newIndex, newVector, series.VectorBuilder, series.IndexBuilder)
 
+  /// <summary>
   /// Returns a new series, containing the observations of the original series sorted by
   /// values returned by the specified projection function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series whose values are sorter
-  ///  - `proj` - A projection function that returns a value to be compared for each
-  ///    value contained in the original input series.
-  ///
+  /// </summary>
+  /// <param name="series">An input series whose values are sorter</param>
+  /// <param name="proj">A projection function that returns a value to be compared for each value contained in the original input series.</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("SortBy")>]
   let sortBy (proj:'T -> 'V) (series:Series<'K, 'T>) =
@@ -1348,11 +1261,10 @@ module Series =
     let newVector = series.VectorBuilder.Build(newIndex.AddressingScheme, cmd, [| series.Vector |])
     Series<'K,'T>(newIndex, newVector, series.VectorBuilder, series.IndexBuilder)
 
+  /// <summary>
   /// Returns a new series whose observations are sorted according to keys of the index.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be sorted
-  ///
+  /// </summary>
+  /// <param name="series">An input series to be sorted</param>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("SortByKey")>]
   let sortByKey (series:Series<'K, 'T>) =
@@ -1406,70 +1318,60 @@ module Series =
   // Resampling and similar stuff
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Resample the series based on a provided collection of keys. The values of the series
   /// are aggregated into chunks based on the specified keys. Depending on `direction`, the
   /// specified key is either used as the smallest or as the greatest key of the chunk (with
   /// the exception of boundaries that are added to the first/last chunk).
   /// Such chunks are then aggregated using the provided function `f`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `keys` - A collection of keys to be used for resampling of the series
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///  - `f` - A function that is used to collapse a generated chunk into a
-  ///    single value. Note that this function may be called with empty series.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="keys">A collection of keys to be used for resampling of the series</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <param name="f">A function that is used to collapse a generated chunk into a single value. Note that this function may be called with empty series.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let resampleInto keys dir f (series:Series<'K, 'V>) =
     series.Resample(keys, dir, (fun k s -> f k s))
 
+  /// <summary>
   /// Resample the series based on a provided collection of keys. The values of the series
   /// are aggregated into chunks based on the specified keys. Depending on `direction`, the
   /// specified key is either used as the smallest or as the greatest key of the chunk (with
   /// the exception of boundaries that are added to the first/last chunk).
   /// Such chunks are then returned as nested series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `keys` - A collection of keys to be used for resampling of the series
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="keys">A collection of keys to be used for resampling of the series</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let resample keys dir (series:Series<'K, 'V>) =
     resampleInto keys dir (fun k s -> s) series
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys. A specified function
   /// `keyProj` is used to project keys to another space and the observations for which the
   /// projected keys are equivalent are grouped into chunks. The chunks are then transformed
   /// to values using the provided function `f`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///  - `f` - A function that is used to collapse a generated chunk into a
-  ///    single value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <param name="f">A function that is used to collapse a generated chunk into a single value.</param>
+  /// <remarks>
   /// This function is similar to `Series.chunkBy`, with the exception that it transforms
   /// keys to a new space.
   ///
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered. For unordered
   /// series, similar functionality can be implemented using `Series.groupBy`.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline resampleEquivInto (keyProj:'K1 -> 'K2) (f:_ -> 'V2) (series:Series<'K1, 'V1>) =
     series
@@ -1477,24 +1379,22 @@ module Series =
     |> mapKeys keyProj
     |> mapValues f
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys. A specified function
   /// `keyProj` is used to project keys to another space and the observations for which the
   /// projected keys are equivalent are grouped into chunks. The chunks are then returned
   /// as nested series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <remarks>
   /// This function is similar to `Series.chunkBy`, with the exception that it transforms
   /// keys to a new space.
   ///
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered. For unordered
   /// series, similar functionality can be implemented using `Series.groupBy`.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline resampleEquiv (keyProj:'K1 -> 'K2) (series:Series<'K1, 'V1>) =
     resampleEquivInto keyProj id series
@@ -1508,24 +1408,16 @@ module Series =
   /// When there are no values for a (generated) key, then the function behaves according to
   /// `fillMode`. It can look at the greatest value of previous chunk or smallest value of the
   /// next chunk, or it produces an empty series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `fillMode` - When set to `Lookup.ExactOrSmaller` or `Lookup.ExactOrGreater`,
-  ///     the function searches for a nearest available observation in an neighboring chunk.
-  ///     Otherwise, the function `f` is called with an empty series as an argument.
-  ///     Values `Lookup.Smaller` and `Lookup.Greater` are not supported.
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///  - `nextKey` - A function that gets the next key in the transformed space
-  ///  - `f` - A function that is used to collapse a generated chunk into a
-  ///    single value. The function may be called on empty series when `fillMode` is
-  ///    `Lookup.Exact`.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="fillMode">When set to `Lookup.ExactOrSmaller` or `Lookup.ExactOrGreater`, the function searches for a nearest available observation in an neighboring chunk. Otherwise, the function `f` is called with an empty series as an argument. Values `Lookup.Smaller` and `Lookup.Greater` are not supported.</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <param name="nextKey">A function that gets the next key in the transformed space</param>
+  /// <param name="f">A function that is used to collapse a generated chunk into a single value. The function may be called on empty series when `fillMode` is `Lookup.Exact`.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let resampleUniformInto (fillMode:Lookup) (keyProj:'K1 -> 'K2) (nextKey:'K2 -> 'K2) f (series:Series<'K1, 'V>) =
     if not (fillMode.HasFlag(Lookup.Exact)) then
@@ -1563,6 +1455,7 @@ module Series =
         | _ -> Series([], [])  )
     |> mapValues f
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys and also generate values
   /// for all keys of the target space that are between the minimal and maximal key of the
   /// specified series (e.g. generate value for all days in the range covered by the series).
@@ -1572,20 +1465,15 @@ module Series =
   /// When there are no values for a (generated) key, then the function behaves according to
   /// `fillMode`. It can look at the greatest value of previous chunk or smallest value of the
   /// next chunk, or it produces an empty series.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `fillMode` - When set to `Lookup.NearestSmaller` or `Lookup.NearestGreater`,
-  ///     the function searches for a nearest available observation in an neighboring chunk.
-  ///     Otherwise, the function `f` is called with an empty series as an argument.
-  ///  - `keyProj` - A function that transforms keys from original space to a new
-  ///    space (which is then used for grouping based on equivalence)
-  ///  - `nextKey` - A function that gets the next key in the transformed space
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="fillMode">When set to `Lookup.NearestSmaller` or `Lookup.NearestGreater`, the function searches for a nearest available observation in an neighboring chunk. Otherwise, the function `f` is called with an empty series as an argument.</param>
+  /// <param name="keyProj">A function that transforms keys from original space to a new space (which is then used for grouping based on equivalence)</param>
+  /// <param name="nextKey">A function that gets the next key in the transformed space</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let resampleUniform fillMode (keyProj:'K1 -> 'K2) (nextKey:'K2 -> 'K2) (series:Series<'K1, 'V>) =
     resampleUniformInto fillMode keyProj nextKey id series
@@ -1620,138 +1508,110 @@ module Series =
     let lookupTimeInternal add startOpt (interval:'T) dir lookup (series:Series<'K , 'V>) =
       lookupAll (generateKeys add startOpt interval dir series) lookup series
 
+  /// <summary>
   /// Performs sampling by time and aggregates chunks obtained by time-sampling into a single
   /// value using a specified function. The operation generates keys starting at the first
   /// key in the source series, using the specified `interval` and then obtains chunks based on
   /// these keys in a fashion similar to the `Series.resample` function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///  - `f` - A function that is called to aggregate each chunk into a single value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <param name="f">A function that is called to aggregate each chunk into a single value.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline sampleTimeInto interval dir f (series:Series< ^K , ^V >) =
     let add dt ts = (^K: (static member (+) : ^K * TimeSpan -> ^K) (dt, ts))
     Implementation.sampleTimeIntoInternal add None interval dir (fun _ -> f) series
 
+  /// <summary>
   /// Performs sampling by time and aggregates chunks obtained by time-sampling into a single
   /// value using a specified function. The operation generates keys starting at the given
   /// `start` time, using the specified `interval` and then obtains chunks based on these
   /// keys in a fashion similar to the `Series.resample` function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `start` - The initial time to be used for sampling
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///  - `f` - A function that is called to aggregate each chunk into a single value.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="start">The initial time to be used for sampling</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <param name="f">A function that is called to aggregate each chunk into a single value.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline sampleTimeAtInto start interval dir f (series:Series< ^K , ^V >) =
     let add dt ts = (^K: (static member (+) : ^K * TimeSpan -> ^K) (dt, ts))
     Implementation.sampleTimeIntoInternal add (Some start) interval dir (fun _ -> f) series
 
+  /// <summary>
   /// Performs sampling by time and returns chunks obtained by time-sampling as a nested
   /// series. The operation generates keys starting at the first key in the source series,
   /// using the specified `interval` and then obtains chunks based on these
   /// keys in a fashion similar to the `Series.resample` function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline sampleTime interval dir series = sampleTimeInto interval dir id series
 
+  /// <summary>
   /// Performs sampling by time and returns chunks obtained by time-sampling as a nested
   /// series. The operation generates keys starting at the given `start` time, using the
   /// specified `interval` and then obtains chunks based on these
   /// keys in a fashion similar to the `Series.resample` function.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `start` - The initial time to be used for sampling
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - If this parameter is `Direction.Forward`, then each key is
-  ///    used as the smallest key in a chunk; for `Direction.Backward`, the keys are
-  ///    used as the greatest keys in a chunk.
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="start">The initial time to be used for sampling</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">If this parameter is `Direction.Forward`, then each key is used as the smallest key in a chunk; for `Direction.Backward`, the keys are used as the greatest keys in a chunk.</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline sampleTimeAt start interval dir series = sampleTimeAtInto start interval dir id series
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting from the smallest key of the original series, using the specified `interval`
   /// and then finds values close to such keys using the specified `lookup` and `dir`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - Specifies how the keys should be generated. `Direction.Forward` means that the
-  ///    key is the smallest value of each chunk (and so first key of the series is returned and
-  ///    the last is not, unless it matches exactly _start + k*interval_); `Direction.Backward`
-  ///    means that the first key is skipped and sample is generated at, or just before the end
-  ///    of interval and at the end of the series.
-  ///  - `lookup` - Specifies how the lookup based on keys is performed. `Exact` means that the
-  ///    values at exact keys will be returned; `NearestGreater` returns the nearest greater key value
-  ///    (starting at the first key) and `NearestSmaller` returns the nearest smaller key value
-  ///    (starting at most `interval` after the end of the series)
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">Specifies how the keys should be generated. `Direction.Forward` means that the key is the smallest value of each chunk (and so first key of the series is returned and the last is not, unless it matches exactly _start + k*interval_); `Direction.Backward` means that the first key is skipped and sample is generated at, or just before the end of interval and at the end of the series.</param>
+  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline lookupTime interval dir lookup (series:Series< ^K , ^V >) =
     let add dt ts = (^K: (static member (+) : ^K * TimeSpan -> ^K) (dt, ts))
     Implementation.lookupTimeInternal add None interval dir lookup series
 
+  /// <summary>
   /// Finds values at, or near, the specified times in a given series. The operation generates
   /// keys starting at the specified `start` time, using the specified `interval`
   /// and then finds values close to such keys using the specified `lookup` and `dir`.
-  ///
-  /// ## Parameters
-  ///  - `series` - An input series to be resampled
-  ///  - `start` - The initial time to be used for sampling
-  ///  - `interval` - The interval between the individual samples
-  ///  - `dir` - Specifies how the keys should be generated. `Direction.Forward` means that the
-  ///    key is the smallest value of each chunk (and so first key of the series is returned and
-  ///    the last is not, unless it matches exactly _start + k*interval_); `Direction.Backward`
-  ///    means that the first key is skipped and sample is generated at, or just before the end
-  ///    of interval and at the end of the series.
-  ///  - `lookup` - Specifies how the lookup based on keys is performed. `Exact` means that the
-  ///    values at exact keys will be returned; `NearestGreater` returns the nearest greater key value
-  ///    (starting at the first key) and `NearestSmaller` returns the nearest smaller key value
-  ///    (starting at most `interval` after the end of the series)
-  ///
-  /// ## Remarks
+  /// </summary>
+  /// <param name="series">An input series to be resampled</param>
+  /// <param name="start">The initial time to be used for sampling</param>
+  /// <param name="interval">The interval between the individual samples</param>
+  /// <param name="dir">Specifies how the keys should be generated. `Direction.Forward` means that the key is the smallest value of each chunk (and so first key of the series is returned and the last is not, unless it matches exactly _start + k*interval_); `Direction.Backward` means that the first key is skipped and sample is generated at, or just before the end of interval and at the end of the series.</param>
+  /// <param name="lookup">Specifies how the lookup based on keys is performed. `Exact` means that the values at exact keys will be returned; `NearestGreater` returns the nearest greater key value (starting at the first key) and `NearestSmaller` returns the nearest smaller key value (starting at most `interval` after the end of the series)</param>
+  /// <remarks>
   /// This operation is only supported on ordered series. The method throws
   /// `InvalidOperationException` when the series is not ordered.
-  ///
+  /// </remarks>
   /// <category>Sampling, resampling and advanced lookup</category>
   let inline lookupTimeAt start interval dir lookup (series:Series< ^K , ^V >) =
     let add dt ts = (^K: (static member (+) : ^K * TimeSpan -> ^K) (dt, ts))
@@ -1771,23 +1631,21 @@ module Series =
   let merge (series1:Series<'K, 'V>) (series2:Series<'K, 'V>) =
    series1.Merge(series2)
 
+  /// <summary>
   /// Replace series value given in key with value.
-  ///
-  /// ## Parameters
-  ///  - `key` - A key to be used for replacing of the series
-  ///  - `value` - A value to replace value for `key`
-  ///
+  /// </summary>
+  /// <param name="key">A key to be used for replacing of the series</param>
+  /// <param name="value">A value to replace value for `key`</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Replace")>]
   let replace (key: 'K) (value: 'V ) (series:Series<'K, 'V>) =
     series.Replace(key, value)
 
+  /// <summary>
   /// Replace series values given in keys with value.
-  ///
-  /// ## Parameters
-  ///  - `keys` - An array of keys to be used for replacing of the series
-  ///  - `value` - A value to replace any values for `keys`
-  ///
+  /// </summary>
+  /// <param name="keys">An array of keys to be used for replacing of the series</param>
+  /// <param name="value">A value to replace any values for `keys`</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("replaceArray")>]
   let replaceArray (keys: 'K []) (value: 'V ) (series:Series<'K, 'V>) =
@@ -1808,17 +1666,13 @@ module Series =
   let compare (s1:Series<'K, 'T>) (s2:Series<'K, 'T>) =
     s1.Compare(s2)
 
+  /// <summary>
   /// Merge two series with possibly overlapping keys. The `behavior` parameter specifies
   /// how to handle situation when a value is definedin both series.
-  ///
-  /// ## Parameters
-  ///  - `behavior` specifies how to handle values available in both series.
-  ///    You can use `UnionBehavior.Exclusive` to throw an exception, or
-  ///    `UnionBehavior.PreferLeft` and `UnionBehavior.PreferRight` to prefer values
-  ///    from the first or the second series, respectively.
-  /// - `series1` - the first (left) series to be merged
-  /// - `series2` - the second (right) series to be merged
-  ///
+  /// </summary>
+  /// <param name="behavior">specifies how to handle values available in both series. You can use `UnionBehavior.Exclusive` to throw an exception, or `UnionBehavior.PreferLeft` and `UnionBehavior.PreferRight` to prefer values from the first or the second series, respectively.</param>
+  /// <param name="series1">the first (left) series to be merged</param>
+  /// <param name="series2">the second (right) series to be merged</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("MergeUsing")>]
   let mergeUsing behavior (series1:Series<'K, 'V>) (series2:Series<'K, 'V>) =
@@ -1846,20 +1700,15 @@ module Series =
   let zip (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) =
     series1.Zip(series2)
 
+  /// <summary>
   /// Align and zip two series using the specified joining mechanism and key matching.
   /// The function returns a series of tuples where both elements may be missing. As a result,
   /// it is often easier to use join on frames instead.
-  ///
-  /// ## Parameters
-  ///  - `kind` specifies the kind of join you want to use (left, right, inner or outer).
-  ///    For inner join, it is better to use `zipInner` instead.
-  ///  - `lookup` specifies how matching keys are found when left or right join is used
-  ///    on a sorted series. Use this to find the nearest smaller or nearest greater key
-  ///    in the other series.
-  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
-  ///  - `series1` - The first (left) series to be aligned
-  ///  - `series2` - The second (right) series to be aligned
-  ///
+  /// </summary>
+  /// <param name="kind">specifies the kind of join you want to use (left, right, inner or outer). For inner join, it is better to use `zipInner` instead.</param>
+  /// <param name="lookup">specifies how matching keys are found when left or right join is used on a sorted series. Use this to find the nearest smaller or nearest greater key in the other series. Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.</param>
+  /// <param name="series1">The first (left) series to be aligned</param>
+  /// <param name="series2">The second (right) series to be aligned</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("ZipAlign")>]
   let zipAlign kind lookup (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) =
@@ -1873,22 +1722,15 @@ module Series =
   let zipInner (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) =
     series1.ZipInner(series2)
 
+  /// <summary>
   /// Align and zip two series using the specified joining mechanism and key matching.
   /// The function calls the specified function `op` to combine values from the two series
-  ///
-  /// ## Parameters
-  ///  - `kind` specifies the kind of join you want to use (left, right, inner or outer).
-  ///    For inner join, it is better to use `zipInner` instead.
-  ///  - `lookup` specifies how matching keys are found when left or right join is used
-  ///    on a sorted series. Use this to find the nearest smaller or nearest greater key
-  ///    in the other series.
-  ///    Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.
-  ///  - `op` - A function that combines values from the two series. In case of left, right
-  ///    or outer join, some of the values may be missing. The function can also return
-  ///    `None` to indicate a missing result.
-  ///  - `series1` - The first (left) series to be aligned
-  ///  - `series2` - The second (right) series to be aligned
-  ///
+  /// </summary>
+  /// <param name="kind">specifies the kind of join you want to use (left, right, inner or outer). For inner join, it is better to use `zipInner` instead.</param>
+  /// <param name="lookup">specifies how matching keys are found when left or right join is used on a sorted series. Use this to find the nearest smaller or nearest greater key in the other series. Supported values are `Lookup.Exact`, `Lookup.ExactOrSmaller` and `Lookup.ExactOrGreater`.</param>
+  /// <param name="op">A function that combines values from the two series. In case of left, right or outer join, some of the values may be missing. The function can also return `None` to indicate a missing result.</param>
+  /// <param name="series1">The first (left) series to be aligned</param>
+  /// <param name="series2">The second (right) series to be aligned</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("ZipAlignInto")>]
   let zipAlignInto kind lookup (op:'V1 option->'V2 option->'R option) (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) : Series<'K, 'R> =
@@ -1898,15 +1740,14 @@ module Series =
       | OptionalValue.Present(a, b) -> OptionalValue.ofOption(op (OptionalValue.asOption a) (OptionalValue.asOption b))
       | _ -> OptionalValue.Missing )
 
+  /// <summary>
   /// Align and zip two series using inner join and exact key matching (use `zipAlignInto`
   /// for more options). The function calls the specified function `op` to combine values
   /// from the two series
-  ///
-  /// ## Parameters
-  ///  - `op` - A function that combines values from the two series.
-  ///  - `series1` - The first (left) series to be aligned
-  ///  - `series2` - The second (right) series to be aligned
-  ///
+  /// </summary>
+  /// <param name="op">A function that combines values from the two series.</param>
+  /// <param name="series1">The first (left) series to be aligned</param>
+  /// <param name="series2">The second (right) series to be aligned</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("ZipInto")>]
   let zipInto (op:'V1->'V2->'R) (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) : Series<'K, 'R> =

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -8,15 +8,16 @@ open Deedle.Internal
 open Deedle.Vectors
 open Deedle.VectorHelpers
 
+/// <summary>
 /// The `Series` module provides an F#-friendly API for working with data and time series.
 /// The API follows the usual design for collection-processing in F#, so the functions work
-/// well with the pipelining (`|>`) operator. For example, given a series with ages,
+/// well with the pipelining (<c>|&gt;</c>) operator. For example, given a series with ages,
 /// we can use `Series.filterValues` to filter outliers and then `Stats.mean` to calculate
 /// the mean:
 ///
 ///     ages
-///     |> Series.filterValues (fun v -> v > 0.0 && v < 120.0)
-///     |> Stats.mean
+///     |&gt; Series.filterValues (fun v -&gt; v &gt; 0.0 &amp;&amp; v &lt; 120.0)
+///     |&gt; Stats.mean
 ///
 /// The module provides comprehensive set of functions for working with series. The same
 /// API is also exposed using C#-friendly extension methods. In C#, the above snippet could
@@ -24,7 +25,7 @@ open Deedle.VectorHelpers
 ///
 ///     [lang=csharp]
 ///     ages
-///       .Where(kvp => kvp.Value > 0.0 && kvp.Value < 120.0)
+///       .Where(kvp =&gt; kvp.Value &gt; 0.0 &amp;&amp; kvp.Value &lt; 120.0)
 ///       .Mean()
 ///
 /// For more information about similar frame-manipulation functions, see the `Frame` module.
@@ -78,13 +79,13 @@ open Deedle.VectorHelpers
 /// ---------------------------------
 ///
 /// The functions in this group can be used to write computations over series that may fail.
-/// They use the type `tryval<'T>` which is defined as a discriminated union:
+/// They use the type <c>tryval&lt;'T&gt;</c> which is defined as a discriminated union:
 ///
-///     type tryval<'T> =
+///     type <c>tryval&lt;'T&gt;</c> =
 ///       | Success of 'T
 ///       | Error of exn
 ///
-/// The function `tryMap` lets you create `Series<'K, tryval<'T>>` by mapping over values
+/// The function `tryMap` lets you create <c>Series&lt;'K, tryval&lt;'T&gt;&gt;</c> by mapping over values
 /// of an original series. You can then extract values using `tryValues`, which throws
 /// `AggregateException` if there were any errors. Functions `tryErrors` and `trySuccesses`
 /// give series containing only errors and successes. You can fill failed values with
@@ -94,8 +95,8 @@ open Deedle.VectorHelpers
 /// -----------------------------
 ///
 /// When the key of a series is tuple, the elements of the tuple can be treated
-/// as multiple levels of a index. For example `Series<'K1 * 'K2, 'V>` has two
-/// levels with keys of types `'K1` and `'K2` respectively.
+/// as multiple levels of a index. For example <c>Series&lt;'K1 * 'K2, 'V&gt;</c> has two
+/// levels with keys of types <c>'K1</c> and <c>'K2</c> respectively.
 ///
 /// The functions in this cateogry provide a way for aggregating values in the
 /// series at one of the levels. For example, given a series `input` indexed by
@@ -196,19 +197,19 @@ open Deedle.VectorHelpers
 /// of working with series. Create two frames with single columns and then use the join
 /// operation. The result will be a frame with two columns (which is easier to use than
 /// series of tuples).
-///
+/// </summary>
 /// <category>Frame and series operations</category>
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Series =
 
   // ------------------------------------------------------------------------------------
   // Accessing series data and lookup
   // ------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Return observations with available values. The operation skips over
   /// all keys with missing values (such as values created from `null`,
   /// `Double.NaN`, or those that are missing due to outer join etc.).
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetObservations")>]
   let observations (series:Series<'K, 'T>) =
@@ -218,8 +219,9 @@ module Series =
         |> OptionalValue.map (fun v -> kvp.Key, v)
         |> OptionalValue.asOption )
 
+  /// <summary>
   /// Returns all keys from the sequence, together with the associated (optional) values.
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetAllObservations")>]
   let observationsAll (series:Series<'K, 'T>) =
@@ -232,6 +234,7 @@ module Series =
   /// </summary>
   /// <param name="keys">A sequence of keys that will form the keys of the retunred sequence</param>
   /// <param name="lookup">Lookup behavior to use when the value at the specified key does not exist</param>
+  /// <param name="series">The input series</param>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("LookupAll")>]
   let lookupAll keys lookup (series:Series<'K, 'T>) = series.GetItems(keys, lookup)
@@ -241,6 +244,7 @@ module Series =
   /// for some new sequence of keys.
   /// </summary>
   /// <param name="keys">A sequence of keys that will form the keys of the retunred sequence</param>
+  /// <param name="series">The input series</param>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("Sample")>]
   let sample keys (series:Series<'K, 'T>) = series |> lookupAll keys Lookup.ExactOrSmaller
@@ -250,43 +254,49 @@ module Series =
   /// Uses exact lookup semantics for key lookup - use `lookupAll` for more options
   /// </summary>
   /// <param name="keys">A sequence of keys that will form the keys of the retunred sequence</param>
+  /// <param name="series">The input series</param>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetObservations")>]
   let getAll keys (series:Series<'K, 'T>) = series.GetItems(keys)
 
+  /// <summary>
   /// Get the value for the specified key.
   /// Use the specified lookup semantics - for exact matching, use `get`
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("Lookup")>]
   let lookup key lookup (series:Series<'K, 'T>) = series.Get(key, lookup)
 
+  /// <summary>
   /// Get the value for the specified key.
   /// Uses exact lookup semantics for key lookup - use `lookup` for more options
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("Get")>]
   let get key (series:Series<'K, 'T>) = series.Get(key)
 
+  /// <summary>
   /// Returns the value at the specified (integer) offset.
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetAt")>]
   let getAt index (series:Series<'K, 'T>) = series.GetAt(index)
 
+  /// <summary>
   /// Attempts to get the value for the specified key. If the value is not
   /// available, `None` is returned.
   /// Use the specified lookup semantics - for exact matching, use `tryGet`.
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("TryLookup")>]
   let tryLookup key lookup (series:Series<'K, 'T>) = series.TryGet(key, lookup) |> OptionalValue.asOption
 
+  /// <summary>
   /// Attempts to get an observation (key value pair) based on the specified key.
   /// The search uses the specified lookup semantics and so the returned key
   /// may differ from the key searched for. If the value is not
   /// available, `None` is returned.
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("TryLookupObservation")>]
   let tryLookupObservation key lookup (series:Series<'K, 'T>) =
@@ -294,117 +304,144 @@ module Series =
     |> OptionalValue.asOption
     |> Option.map (fun kvp -> (kvp.Key, kvp.Value))
 
+  /// <summary>
   /// Get the value for the specified key. Returns `None` when the key does not exist
   /// or the value is missing.
   /// Uses exact lookup semantics for key lookup - use `tryLookup` for more options
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("TryGet")>]
   let tryGet key (series:Series<'K, 'T>) = series.TryGet(key) |> OptionalValue.asOption
 
+  /// <summary>
   /// Returns the value at the specified (integer) offset, or `None` if the value is missing.
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("TryGetAt")>]
   let tryGetAt index (series:Series<'K, 'T>) = series.TryGetAt(index) |> OptionalValue.asOption
 
+  /// <summary>
   /// Returns the total number of values in the specified series. This excludes
   /// missing values or not available values (such as values created from `null`,
   /// `Double.NaN`, or those that are missing due to outer join etc.).
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("CountValues")>]
   let countValues (series:Series<'K, 'T>) = series.ValueCount
 
+  /// <summary>
   /// Returns the total number of keys in the specified series. This returns
   /// the total length of the series, including keys for which there is no
   /// value available.
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("CountKeys")>]
   let countKeys (series:Series<'K, 'T>) = series.KeyCount
 
+  /// <summary>
   /// Returns true when the series contains value for all of the specified keys
   /// (This is useful for checking prior to performing a computation)
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("HasAll")>]
   let hasAll keys (series:Series<'K, 'T>) =
     keys |> Seq.forall (fun k -> series.TryGet(k).HasValue)
 
+  /// <summary>
   /// Returns true when the series contains value for some of the specified keys
   /// (This is useful for checking prior to performing a computation)
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("HasSome")>]
   let hasSome keys (series:Series<'K, 'T>) =
     keys |> Seq.exists (fun k -> series.TryGet(k).HasValue)
 
+  /// <summary>
   /// Returns true when the series does not contains value for any of the specified keys
   /// (This is useful for checking prior to performing a computation)
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("HasNone")>]
   let hasNone keys (series:Series<'K, 'T>) =
     keys |> Seq.forall (fun k -> series.TryGet(k).HasValue |> not)
 
+  /// <summary>
   /// Returns true when the series contains value for the specified key
   /// (This is useful for checking prior to performing a computation)
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("Has")>]
   let has key (series:Series<'K, 'T>) = series.TryGet(key).HasValue
 
+  /// <summary>
   /// Returns true when the series does not contains value for the specified key
   /// (This is useful for checking prior to performing a computation)
-  ///
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("HasNot")>]
   let hasNot key (series:Series<'K, 'T>) = series.TryGet(key).HasValue |> not
 
+  /// <summary>
   /// Returns the last key of the series, or throws exception if one doesn't exist
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetLastKey")>]
   let lastKey (series:Series< 'K , 'V >) = series.Index.KeyAt (series.Index.AddressAt (series.KeyCount - 1 |> int64))
 
+  /// <summary>
   /// Returns the first key of the series, or throws exception if one doesn't exist
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetFirstKey")>]
   let firstKey (series:Series< 'K , 'V >) = series.Index.KeyAt <| series.Index.AddressAt(0L)
 
+  /// <summary>
   /// Returns the last value of the series. This fails if the last value is missing.
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetLastValue")>]
   let lastValue (series:Series< 'K , 'V >) = series |> getAt (series.KeyCount-1)
 
+  /// <summary>
   /// Returns the last value of the series if one exists.
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("TryGetLastValue")>]
   let tryLastValue (series:Series< 'K , 'V >) =
     if series.KeyCount > 0 then series |> tryGetAt (series.KeyCount-1) else None
 
+  /// <summary>
   /// Returns the first value of the series. This fails if the first value is missing.
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetFirstValue")>]
   let firstValue (series:Series< 'K , 'V >) = series |> getAt 0
 
+  /// <summary>
   /// Returns the first value of the series if one exists.
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("TryGetFirstValue")>]
   let tryFirstValue (series:Series< 'K , 'V >) =
     if series.KeyCount > 0 then series |> getAt 0 |> Some else None
 
+  /// <summary>
   /// Returns the (non-missing) values of the series as a sequence
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetValues")>]
   let values (series:Series<'K, 'T>) = series.Values
 
+  /// <summary>
   /// Returns the series values (both missing and present) as a sequence
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetAllValues")>]
   let valuesAll (series:Series<'K, 'T>) = series.Vector.DataSequence |> Seq.map OptionalValue.asOption
 
+  /// <summary>
   /// Returns the keys of the series as a sequence
+  /// </summary>
   /// <category>Accessing series data and lookup</category>
   [<CompiledName("GetKeys")>]
   let keys (series:Series<'K, 'T>) = series.Keys
@@ -413,65 +450,72 @@ module Series =
   // Series transformations
   // ------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns a new series containing only the elements for which the specified predicate
   /// returns `true`. The function skips over missing values. If you want to handle missing
   /// values, use `filterAll` instead.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("Filter")>]
   let filter f (series:Series<'K, 'T>) =
     series.Where(Func<_, _>(fun (KeyValue(k,v)) -> f k v))
 
+  /// <summary>
   /// Returns a new series containing only the elements for which the specified predicate
   /// returns `true`. The function skips over missing values and calls the predicate with
   /// just the value. See also `filterAll` and `filter` for more options.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("FilterValues")>]
   let filterValues f (series:Series<'K, 'T>) =
     series.Where(Func<_, _>(fun (KeyValue(k,v)) -> f v))
 
+  /// <summary>
   /// Returns a new series containing only the elements for which the specified predicate
   /// returns `true`. The predicate is called for missing values as well.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("FilterAll")>]
   let filterAll f (series:Series<'K, 'T>) =
     series.WhereOptional(fun kvp -> f kvp.Key (OptionalValue.asOption kvp.Value))
 
+  /// <summary>
   /// Returns a new series whose values are the results of applying the given function to
   /// values of the original series. This function skips over missing values and call the
   /// function with both keys and values.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("Map")>]
   let map (f:'K -> 'T -> 'R) (series:Series<'K, 'T>) =
     series.Select(fun (KeyValue(k,v)) -> f k v)
 
+  /// <summary>
   /// Returns a new series whose values are the results of applying the given function to
   /// values of the original series. This function skips over missing values and call the
   /// function with just values. It is also aliased using the `$` operator so you can write
   /// `series $ func` for `series |> Series.mapValues func`.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("MapValues")>]
   let mapValues (f:'T -> 'R) (series:Series<'K, 'T>) =
     series.Select(fun (KeyValue(k,v)) -> f v)
 
+  /// <summary>
   /// Returns a new series whose values are the results of applying the given function to
   /// values of the original series. This specified function is called even when the value
-  /// is missing. It returns `option<'T>` so that it can create/eliminate missing values in
+  /// is missing. It returns <c>option&lt;'T&gt;</c> so that it can create/eliminate missing values in
   /// the result.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("MapAll")>]
   let mapAll (f:_ -> _ -> option<'R>) (series:Series<'K, 'T>) =
     series.SelectOptional(fun kvp ->
       f kvp.Key (OptionalValue.asOption kvp.Value) |> OptionalValue.ofOption)
 
+  /// <summary>
   /// Returns a new series whose keys are the results of applying the given function to
   /// keys of the original series.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("MapKeys")>]
   let mapKeys (f:'K -> 'R) (series:Series<'K, 'T>) =
@@ -484,6 +528,7 @@ module Series =
   /// </summary>
   /// <param name="forward">Function that converts original values to the new</param>
   /// <param name="backward">Function that converts new values back to the original</param>
+  /// <param name="series">The input series</param>
   /// <remarks>
   /// This operation is only interesting when working with virtualized data sources. Using the
   /// `convert` function makes it possible to perfom additional operations on the resulting
@@ -494,10 +539,11 @@ module Series =
   let convert (forward:'T -> 'R) (backward:'R -> 'T) (series:Series<'K, 'T>) =
     series.Convert(Func<_, _>(forward), Func<_, _>(backward))
 
+  /// <summary>
   /// Given a series containing optional values, flatten the option values.
   /// That is, `None` values become missing values of the series and `Some` values
   /// become ordinary values in the resulting series.
-  ///
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("Flatten")>]
   let flatten (series:Series<'K, 'T option>) =
@@ -554,9 +600,10 @@ module Series =
       invalidArg "count" "Must be greater than zero and less than the number of keys."
     series.GetAddressRange(RangeRestriction.Fixed(series.Index.AddressAt(0L), series.Index.AddressAt (series.KeyCount - 1 - count |> int64)))
 
+  /// <summary>
   /// Returns a new fully evaluated series. If the source series contains a lazy index or
   /// lazy vectors, these are forced to evaluate and the resulting series is fully loaded in memory.
-  ////
+  /// </summary>
   /// <category>Series transformations</category>
   [<CompiledName("Force")>]
   let force (series:Series<'K, 'V>) =
@@ -667,19 +714,21 @@ module Series =
   // Processing series with exceptions
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns a new series by applying the specified transformation to all values
   /// of the input series. The result contains `Error(e)` when the projection fails
   /// with an exception `e` or `Success(v)` containing a value `v` otherwise.
-  ///
+  /// </summary>
   /// <category>Processing series with exceptions</category>
   let tryMap (f:'K -> 'T -> 'R) (series:Series<'K, 'T>) : Series<_, _ tryval> =
     series.Select(fun (KeyValue(k,v)) ->
       try TryValue.Success(f k v) with e -> TryValue.Error e )
 
-  /// Obtains values from a series of `tryval<'T>` values. When the series contains
+  /// <summary>
+  /// Obtains values from a series of <c>tryval&lt;'T&gt;</c> values. When the series contains
   /// one or more failures, the operation throws `AggregateException`. Otherwise, it
   /// returns a series containing values.
-  ///
+  /// </summary>
   /// <category>Processing series with exceptions</category>
   let tryValues (series:Series<'K, 'T tryval>) =
     let exceptions = series.Values |> Seq.choose (fun tv ->
@@ -688,9 +737,10 @@ module Series =
       series |> mapValues (fun tv -> tv.Value)
     else raise (new AggregateException(exceptions))
 
-  /// Given a series of `tryval<'V>` values, returns a series that contains all exceptions
+  /// <summary>
+  /// Given a series of <c>tryval&lt;'V&gt;</c> values, returns a series that contains all exceptions
   /// contained in the source series. The exceptions are returned as a series.
-  ///
+  /// </summary>
   /// <category>Processing series with exceptions</category>
   let tryErrors (series: Series<'K, 'V tryval>) =
     let errors =
@@ -699,9 +749,10 @@ module Series =
                               | _ -> None)
     Series<_,_>(errors)
 
-  /// Given a series of `tryval<'V>` values, returns a series that contains all values
+  /// <summary>
+  /// Given a series of <c>tryval&lt;'V&gt;</c> values, returns a series that contains all values
   /// contained in the source series. The input elements containing exceptions are ignored.
-  ///
+  /// </summary>
   /// <category>Processing series with exceptions</category>
   let trySuccesses (series: Series<'K, 'V tryval>) =
     let successes =
@@ -710,9 +761,10 @@ module Series =
                               | _ -> None)
     Series<_,_>(successes)
 
-  /// Givnen a series of `tryval<'V>` values, returns a new series where all `Error`
+  /// <summary>
+  /// Givnen a series of <c>tryval&lt;'V&gt;</c> values, returns a new series where all `Error`
   /// values are filled with the specified constant value.
-  ///
+  /// </summary>
   /// <category>Processing series with exceptions</category>
   let fillErrorsWith value (series:Series<'K, 'T tryval>) =
     series |> mapValues (function TryValue.Error _ -> value | TryValue.Success v -> v)
@@ -776,11 +828,11 @@ module Series =
   // ----------------------------------------------------------------------------------------------
 
   /// <summary>
-  /// Aggregates an ordered series using the method specified by `Aggregation<K>` and
+  /// Aggregates an ordered series using the method specified by <c>Aggregation&lt;K&gt;</c> and
   /// returns the windows or chunks as nested series. A key for each window or chunk is
   /// selected using the specified `keySelector`.
   /// </summary>
-  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="aggregation">Specifies the aggregation method using <c>Aggregation&lt;K&gt;</c>. This is a discriminated union listing various chunking and windowing conditions.</param>
   /// <param name="keySelector">A function that is called on each chunk to obtain a key.</param>
   /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
@@ -790,12 +842,12 @@ module Series =
       ( aggregation, System.Func<_, _>(keySelector), System.Func<_, _>(fun v -> OptionalValue(v)))
 
   /// <summary>
-  /// Aggregates an ordered series using the method specified by `Aggregation<K>` and then
+  /// Aggregates an ordered series using the method specified by <c>Aggregation&lt;K&gt;</c> and then
   /// applies the provided value selector `f` on each window or chunk to produce the result
   /// which is returned as a new series. A key for each window or chunk is
   /// selected using the specified `keySelector`.
   /// </summary>
-  /// <param name="aggregation">Specifies the aggregation method using `Aggregation<K>`. This is a discriminated union listing various chunking and windowing conditions.</param>
+  /// <param name="aggregation">Specifies the aggregation method using <c>Aggregation&lt;K&gt;</c>. This is a discriminated union listing various chunking and windowing conditions.</param>
   /// <param name="keySelector">A function that is called on each chunk to obtain a key.</param>
   /// <param name="f">A value selector function that is called to aggregate each chunk or window.</param>
   /// <param name="series">The input series to be aggregated.</param>
@@ -1016,6 +1068,7 @@ module Series =
   /// skips incomplete chunks - you can use `Series.chunkSizeInto` for more options.
   /// </summary>
   /// <param name="size">The size of the chunk.</param>
+  /// <param name="f">A function that is called to aggregate each chunk into a single value.</param>
   /// <param name="series">The input series to be aggregated.</param>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("ChunkInto")>]
@@ -1043,9 +1096,11 @@ module Series =
   /// </summary>
   /// <param name="series">The input series to be aggregated.</param>
   /// <example>
-  ///     let input = series [ 1 => 'a'; 2 => 'b'; 3 => 'c']
-  ///     let res = input |> Series.pairwise
-  ///     res = series [2 => ('a', 'b'); 3 => ('b', 'c') ]
+  /// <code>
+  /// let input = series [ 1 =&gt; 'a'; 2 =&gt; 'b'; 3 =&gt; 'c']
+  /// let res = input |&gt; Series.pairwise
+  /// res = series [2 =&gt; ('a', 'b'); 3 =&gt; ('b', 'c') ]
+  /// </code>
   /// </example>
   /// <category>Grouping, windowing and chunking</category>
   [<CompiledName("Pairwise")>]
@@ -1094,9 +1149,10 @@ module Series =
   // Handling of missing values
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Returns the current series with the same index but with values missing wherever the
   /// corresponding key exists in the other series index with an associated missing value.
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("WithMissingFrom")>]
   let withMissingFrom (other:Series<'K, 'S>) (series:Series<'K,'T>) =
@@ -1109,9 +1165,11 @@ module Series =
   /// </summary>
   /// <param name="series">An input series to be filtered</param>
   /// <example>
-  ///     let s = series [ 1 => 1.0; 2 => Double.NaN ]
-  ///     s |> Series.dropMissing
-  ///     [fsi:val it : Series<int,float> = series [ 1 => 1]
+  /// <code>
+  /// let s = series [ 1 =&gt; 1.0; 2 =&gt; Double.NaN ]
+  /// s |&gt; Series.dropMissing
+  /// // val it : Series&lt;int,float&gt; = series [ 1 =&gt; 1]
+  /// </code>
   /// </example>
   /// <category>Missing values</category>
   [<CompiledName("DropMissing")>]
@@ -1158,13 +1216,15 @@ module Series =
   /// <param name="series">An input series that is to be filled</param>
   /// <param name="direction">Specifies the direction used when searching for the nearest available value. `Backward` means that we want to look for the first value with a smaller key while `Forward` searches for the nearest greater key.</param>
   /// <example>
-  ///     let sample = Series.ofValues [ Double.NaN; 1.0; Double.NaN; 3.0 ]
+  /// <code>
+  /// let sample = Series.ofValues [ Double.NaN; 1.0; Double.NaN; 3.0 ]
   ///
-  ///     // Returns a series consisting of [1; 1; 3; 3]
-  ///     sample |> Series.fillMissing Direction.Backward
+  /// // Returns a series consisting of [1; 1; 3; 3]
+  /// sample |&gt; Series.fillMissing Direction.Backward
   ///
-  ///     // Returns a series consisting of [<missing>; 1; 1; 3]
-  ///     sample |> Series.fillMissing Direction.Forward
+  /// // Returns a series consisting of [&lt;missing&gt;; 1; 1; 3]
+  /// sample |&gt; Series.fillMissing Direction.Forward
+  /// </code>
   /// </example>
   /// <category>Missing values</category>
   [<CompiledName("FillMissing")>]
@@ -1190,8 +1250,9 @@ module Series =
       | OptionalValue.Present(OptionalValue.Present v1, _) -> OptionalValue v1
       | _ -> OptionalValue.Missing )
 
+  /// <summary>
   /// Fill missing values only between the first and last non-missing values.
-  ///
+  /// </summary>
   /// <category>Missing values</category>
   [<CompiledName("FillMissingInside")>]
   let fillMissingInside direction (series:Series<'K, 'T>) =
@@ -1272,43 +1333,48 @@ module Series =
     let newData = series.VectorBuilder.Build(newRowIndex.AddressingScheme, rowCmd, [| series.Vector |])
     Series(newRowIndex, newData, series.VectorBuilder, series.IndexBuilder)
 
+  /// <summary>
   /// Returns a new series, containing the observations of the original series sorted based
   /// on the default ordering defined on the values of the series.
-  ///
+  /// </summary>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("Sort")>]
   let sort (series:Series<'K, 'V>) =
     series |> sortWith compare
 
+  /// <summary>
   /// Returns a new series, containing the observations of the original series in a reverse order.
-  ///
+  /// </summary>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("Reverse")>]
   let rev (series:Series<'K,'T>) =
     series.Reversed
 
+  /// <summary>
   /// Given an original series and a sequence of keys, returns a new series that contains
   /// the matching value for each of the specified keys. The `KeyCount` of the returned
   /// sequence is the length of `keys`. If there is no value for the specified keys in the
   /// input sequence, the returned series will contain a missing value.
-  ///
+  /// </summary>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("Realign")>]
   let realign keys (series:Series<'K, 'T>) =
     series.Realign(keys)
 
+  /// <summary>
   /// Return a new series containing the same values as the original series, but with
   /// ordinal index formed by `int` values starting from 0.
-  ///
+  /// </summary>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexOrdinally")>]
   let indexOrdinally (series:Series<'K, 'T>) =
     series.IndexOrdinally()
 
+  /// <summary>
   /// Returns a new series containing the specified keys mapped to the original values of the series.
   /// When the sequence contains _fewer_ keys, the values from the series are dropped. When it
   /// contains _more_ keys, the values for additional keys are missing.
-  ///
+  /// </summary>
   /// <category>Sorting and index manipulation</category>
   [<CompiledName("IndexWith")>]
   let indexWith (keys:seq<'K2>) (series:Series<'K1, 'T>) =
@@ -1399,6 +1465,7 @@ module Series =
   let inline resampleEquiv (keyProj:'K1 -> 'K2) (series:Series<'K1, 'V1>) =
     resampleEquivInto keyProj id series
 
+  /// <summary>
   /// Resample the series based on equivalence class on the keys and also generate values
   /// for all keys of the target space that are between the minimal and maximal key of the
   /// specified series (e.g. generate value for all days in the range covered by the series).
@@ -1622,10 +1689,11 @@ module Series =
   // Joining, merging and zipping
   // ----------------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Merge two series with distinct keys. When the same key with a value occurs in both
   /// series, an exception is thrown. In that case, you can use `mergeUsing`, which allows
   /// specifying merging behavior.
-  ///
+  /// </summary>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Merge")>]
   let merge (series1:Series<'K, 'V>) (series2:Series<'K, 'V>) =
@@ -1636,6 +1704,7 @@ module Series =
   /// </summary>
   /// <param name="key">A key to be used for replacing of the series</param>
   /// <param name="value">A value to replace value for `key`</param>
+  /// <param name="series">The input series</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Replace")>]
   let replace (key: 'K) (value: 'V ) (series:Series<'K, 'V>) =
@@ -1646,21 +1715,24 @@ module Series =
   /// </summary>
   /// <param name="keys">An array of keys to be used for replacing of the series</param>
   /// <param name="value">A value to replace any values for `keys`</param>
+  /// <param name="series">The input series</param>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("replaceArray")>]
   let replaceArray (keys: 'K []) (value: 'V ) (series:Series<'K, 'V>) =
     series.Replace(keys, value)
 
+  /// <summary>
   /// Returns a new series which is intersection of two series by (key, value) pair.
-  ///
+  /// </summary>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Intersect")>]
   let intersect (s1:Series<'K, 'T>) (s2:Series<'K, 'T>) =
     s1.Intersect(s2)
 
 
+  /// <summary>
   /// Compares two series and returns a new series of `Diff`s.
-  ///
+  /// </summary>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Compare")>]
   let compare (s1:Series<'K, 'T>) (s2:Series<'K, 'T>) =
@@ -1678,10 +1750,11 @@ module Series =
   let mergeUsing behavior (series1:Series<'K, 'V>) (series2:Series<'K, 'V>) =
     series1.Merge(series2, behavior)
 
+  /// <summary>
   /// Merge multiple series with distinct keys. When the same key with a value occurs in two
   /// of the series, an exception is thrown. This function is efficient even when the number
   /// of series to be merged is large.
-  ///
+  /// </summary>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("MergeAll")>]
   let mergeAll (series: Series<'K, 'V> seq) =
@@ -1691,10 +1764,11 @@ module Series =
         let series = series |> Array.ofSeq
         series.[0].Merge(series.[1 .. ])
 
+  /// <summary>
   /// Align and zip two series using outer join and exact key matching. The function returns
   /// a series of tuples where both elements may be missing. As a result, it is often easier
   /// to use join on frames instead.
-  ///
+  /// </summary>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("Zip")>]
   let zip (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) =
@@ -1714,9 +1788,10 @@ module Series =
   let zipAlign kind lookup (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) =
     series1.Zip(series2, kind, lookup)
 
+  /// <summary>
   /// Align and zip two series using inner join and exact key matching. The function returns
   /// a series of tuples with values from the two series.
-  ///
+  /// </summary>
   /// <category>Joining, merging and zipping</category>
   [<CompiledName("ZipInner")>]
   let zipInner (series1:Series<'K, 'V1>) (series2:Series<'K, 'V2>) =

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -79,13 +79,10 @@ open Deedle.VectorHelpers
 /// ---------------------------------
 ///
 /// The functions in this group can be used to write computations over series that may fail.
-/// They use the type <c>tryval&lt;'T&gt;</c> which is defined as a discriminated union:
+/// They use the type <c>tryval&lt;&apos;T&gt;</c> which is defined as a discriminated union
+/// with two cases: Success containing a value, or Error containing an exception.
 ///
-///     type <c>tryval&lt;'T&gt;</c> =
-///       | Success of 'T
-///       | Error of exn
-///
-/// The function `tryMap` lets you create <c>Series&lt;'K, tryval&lt;'T&gt;&gt;</c> by mapping over values
+/// The function `tryMap` lets you create <c>Series&lt;&apos;K, tryval&lt;&apos;T&gt;&gt;</c> by mapping over values
 /// of an original series. You can then extract values using `tryValues`, which throws
 /// `AggregateException` if there were any errors. Functions `tryErrors` and `trySuccesses`
 /// give series containing only errors and successes. You can fill failed values with
@@ -95,7 +92,7 @@ open Deedle.VectorHelpers
 /// -----------------------------
 ///
 /// When the key of a series is tuple, the elements of the tuple can be treated
-/// as multiple levels of a index. For example <c>Series&lt;'K1 * 'K2, 'V&gt;</c> has two
+/// as multiple levels of a index. For example <c>Series&lt;&apos;K1 * &apos;K2, &apos;V&gt;</c> has two
 /// levels with keys of types <c>'K1</c> and <c>'K2</c> respectively.
 ///
 /// The functions in this cateogry provide a way for aggregating values in the

--- a/src/Deedle/SeriesStatsExtensions.fs
+++ b/src/Deedle/SeriesStatsExtensions.fs
@@ -169,6 +169,7 @@ type SeriesStatsExtensions =
   /// <summary>
   /// Linearly interpolates an ordered series given a new sequence of keys.
   /// </summary>
+  /// <param name="series">The input series to interpolate</param>
   /// <param name="keys">Sequence of new keys that forms the index of interpolated results</param>
   /// <param name="keyDiff">A function representing "subtraction" between two keys</param>
   /// <category>Calculations, aggregation and statistics</category>

--- a/src/Deedle/SeriesStatsExtensions.fs
+++ b/src/Deedle/SeriesStatsExtensions.fs
@@ -83,101 +83,94 @@ type SeriesStatsExtensions =
   [<Extension>]
   static member inline Median(series:Series<'K, 'V>) = Stats.median series
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `groupSelector` and then returns a new series containing
   /// the mean of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../features.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - A series of values that are used to calculate the means
-  ///  - `groupSelector` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">A series of values that are used to calculate the means</param>
+  /// <param name="groupSelector">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Statistics</category>
   [<Extension>]
   static member inline MeanLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) =
     Series.applyLevel groupSelector.Invoke Stats.mean series
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `groupSelector` and then returns a new series containing
   /// the standard deviation of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../features.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - A series of values that are used to calculate the standard deviations
-  ///  - `groupSelector` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">A series of values that are used to calculate the standard deviations</param>
+  /// <param name="groupSelector">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Statistics</category>
   static member inline StdDevLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) =
     Series.applyLevel groupSelector.Invoke Stats.stdDev series
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `groupSelector` and then returns a new series containing
   /// the median of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../features.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - A series of values that are used to calculate the medians
-  ///  - `groupSelector` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">A series of values that are used to calculate the medians</param>
+  /// <param name="groupSelector">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Statistics</category>
   [<Extension>]
   static member inline MedianLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) =
       Series.applyLevel groupSelector.Invoke Stats.median series
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `groupSelector` and then returns a new series containing
   /// the sum of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../features.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - A series of values that are used to calculate the sums
-  ///  - `groupSelector` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">A series of values that are used to calculate the sums</param>
+  /// <param name="groupSelector">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Statistics</category>
   [<Extension>]
   static member inline SumLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) =
     Series.applyLevel groupSelector.Invoke Stats.sum series
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `groupSelector` and then returns a new series containing
   /// the smallest element of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../features.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - A series of values that are used to calculate the smallest elements
-  ///  - `groupSelector` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">A series of values that are used to calculate the smallest elements</param>
+  /// <param name="groupSelector">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Statistics</category>
   [<Extension>]
   static member inline MinLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) =
     Series.applyLevelOptional groupSelector.Invoke Stats.tryMin series
 
+  /// <summary>
   /// Groups the elements of the input series in groups based on the keys
   /// produced by `groupSelector` and then returns a new series containing
   /// the greatest element of each group.
   ///
   /// This operation is designed to be used with [hierarchical indexing](../features.html#indexing).
-  ///
-  /// ## Parameters
-  ///  - `series` - A series of values that are used to calculate the greatest elements
-  ///  - `groupSelector` - A delegate that returns a new group key, based on the key in the input series
-  ///
+  /// </summary>
+  /// <param name="series">A series of values that are used to calculate the greatest elements</param>
+  /// <param name="groupSelector">A delegate that returns a new group key, based on the key in the input series</param>
   /// <category>Statistics</category>
   [<Extension>]
   static member inline MaxLevel(series:Series<'K1, 'V>, groupSelector:Func<'K1, 'K2>) =
     Series.applyLevelOptional groupSelector.Invoke Stats.tryMax series
 
+  /// <summary>
   /// Linearly interpolates an ordered series given a new sequence of keys.
-  ///
-  /// ## Parameters
-  ///  - `keys` - Sequence of new keys that forms the index of interpolated results
-  ///  - `keyDiff` - A function representing "subtraction" between two keys
-  ///
+  /// </summary>
+  /// <param name="keys">Sequence of new keys that forms the index of interpolated results</param>
+  /// <param name="keyDiff">A function representing "subtraction" between two keys</param>
   /// <category>Calculations, aggregation and statistics</category>
   [<Extension>]
   static member inline InterpolateLinear(series:Series<'K, 'V>, keys:'K seq, keyDiff:Func<'K,'K,float>): Series<'K,float> =

--- a/src/Deedle/Stats.fs
+++ b/src/Deedle/Stats.fs
@@ -186,6 +186,7 @@ module StatsInternal =
   /// <param name="initState">is the initial state of the computation</param>
   /// <param name="fupdate">takes the current state and incoming observation to the next state</param>
   /// <param name="ftransf">takes the current state to the current output</param>
+  /// <param name="source">The input sequence to process</param>
   let expandingWindowFn initState fupdate ftransf (source: seq<_>) =
     source
     |> Seq.scan fupdate initState
@@ -767,6 +768,7 @@ type Stats =
   /// </summary>
   /// <param name="keys">Sequence of new keys that forms the index of interpolated results</param>
   /// <param name="f">Function to do the interpolating</param>
+  /// <param name="series">The input series to interpolate</param>
   /// <category>Series interoploation</category>
   static member interpolate keys f (series:Series<'K,'T>) =
     let liftedf k (prev:KeyValuePair<_,_> opt) (next:KeyValuePair<_,_> opt) =
@@ -783,6 +785,7 @@ type Stats =
   /// </summary>
   /// <param name="keys">Sequence of new keys that forms the index of interpolated results</param>
   /// <param name="keyDiff">A function representing "subtraction" between two keys</param>
+  /// <param name="series">The input series to interpolate</param>
   /// <category>Series interoploation</category>
   static member inline interpolateLinear keys (keyDiff:'K->'K->float) (series:Series<'K, 'V>) =
     let linearF k a b =

--- a/src/Deedle/Stats.fs
+++ b/src/Deedle/Stats.fs
@@ -180,12 +180,12 @@ module StatsInternal =
   // Implementation internals - expanding windows
   // ------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Helper for expanding window calculations
-  ///
-  /// ## Parameters
-  ///  - `initState` is the initial state of the computation
-  //   - `fupdate` takes the current state and incoming observation to the next state
-  //   - `ftransf` takes the current state to the current output
+  /// </summary>
+  /// <param name="initState">is the initial state of the computation</param>
+  /// <param name="fupdate">takes the current state and incoming observation to the next state</param>
+  /// <param name="ftransf">takes the current state to the current output</param>
   let expandingWindowFn initState fupdate ftransf (source: seq<_>) =
     source
     |> Seq.scan fupdate initState
@@ -297,6 +297,7 @@ module StatsInternal =
 
 open StatsInternal
 
+/// <summary>
 /// The `Stats` type contains functions for fast calculation of statistics over
 /// series and frames as well as over a moving and an expanding window in a series.
 ///
@@ -304,51 +305,52 @@ open StatsInternal
 /// no values, or missing values, different functions behave in different ways.
 /// Statistics (e.g. mean) return missing value when any value is missing, while min/max
 /// functions return the minimal/maximal element (skipping over missing values).
-///
-/// ## Series statistics
-///
+/// </summary>
+/// <remarks>
+/// <para>Series statistics:</para>
+/// <para>
 /// Functions such as `count`, `mean`, `kurt` etc. return the
 /// statistics calculated over all values of a series. The calculation skips
 /// over missing values (or `nan` values), so for example `mean` returns the
 /// average of all _present_ values.
-///
-/// ## Frame statistics
-///
+/// </para>
+/// <para>Frame statistics:</para>
+/// <para>
 /// The standard functions are exposed as static members and are
-/// overloaded. This means that they can be applied to both `Series<'K, float>` and
-/// to `Frame<'R, 'C>`. When applied to data frame, the functions apply the
+/// overloaded. This means that they can be applied to both `Series&lt;'K, float&gt;` and
+/// to `Frame&lt;'R, 'C&gt;`. When applied to data frame, the functions apply the
 /// statistical calculation to all numerical columns of the frame.
-///
-/// ## Moving windows
-///
+/// </para>
+/// <para>Moving windows:</para>
+/// <para>
 /// Moving window means that the window has a fixed size and moves over the series.
 /// In this case, the result of the statisitcs is always attached to the last key
 /// of the window. The function names are prefixed with `moving`.
-///
-/// ## Expanding windows
-///
+/// </para>
+/// <para>Expanding windows:</para>
+/// <para>
 /// Expanding window means that the window starts as a single-element sized window
 /// and expands as it moves over the series. In this case, statistics is calculated
 /// for all values up to the current key. This means that the result is attached
 /// to the key at the end of the window. The function names are prefixed
 /// with `expanding`.
-///
-/// ## Multi-level statistics
-///
+/// </para>
+/// <para>Multi-level statistics:</para>
+/// <para>
 /// For a series with multi-level (hierarchical) index, the
 /// functions prefixed with `level` provide a way to apply statistical operation on
 /// a single level of the index. (For example you can sum values along the `'K1` keys
-/// in a series `Series<'K1 * 'K2, float>` and get `Series<'K1, float>` as the result.)
-///
-/// ## Remarks
-///
+/// in a series `Series&lt;'K1 * 'K2, float&gt;` and get `Series&lt;'K1, float&gt;` as the result.)
+/// </para>
+/// <para>
 /// The windowing functions in the `Stats` type support calculations over a fixed-size
 /// windows specified by the size of the window. If you need more complex windowing
 /// behavior (such as window based on the distance between keys), different handling
 /// of boundary, or chunking (calculation over adjacent chunks), you can use chunking and
 /// windowing functions from the `Series` module such as `Series.windowSizeInto` or
 /// `Series.chunkSizeInto`.
-///
+/// </para>
+/// </remarks>
 /// <category>Frame and series operations</category>
 type Stats =
 
@@ -758,14 +760,13 @@ type Stats =
   // Series interpolation
   // ------------------------------------------------------------------------------------
 
+  /// <summary>
   /// Interpolates an ordered series given a new sequence of keys. The function iterates through
   /// each new key, and invokes a function on the current key, the nearest smaller and larger valid
   /// observations from the series argument. The function must return a new valid float.
-  ///
-  /// ## Parameters
-  ///  - `keys` - Sequence of new keys that forms the index of interpolated results
-  ///  - `f` - Function to do the interpolating
-  ///
+  /// </summary>
+  /// <param name="keys">Sequence of new keys that forms the index of interpolated results</param>
+  /// <param name="f">Function to do the interpolating</param>
   /// <category>Series interoploation</category>
   static member interpolate keys f (series:Series<'K,'T>) =
     let liftedf k (prev:KeyValuePair<_,_> opt) (next:KeyValuePair<_,_> opt) =
@@ -775,14 +776,13 @@ type Stats =
 
     series.Interpolate(keys, Func<_,_,_,_>(liftedf))
 
+  /// <summary>
   /// Linearly interpolates an ordered series given a new sequence of keys.
-  ///
-  /// ## Parameters
-  ///  - `keys` - Sequence of new keys that forms the index of interpolated results
-  ///  - `keyDiff` - A function representing "subtraction" between two keys
   /// Throws a `FormatException` or an `InvalidCastException` if the value type of the series
   /// is not convertible to floating point number.
-  ///
+  /// </summary>
+  /// <param name="keys">Sequence of new keys that forms the index of interpolated results</param>
+  /// <param name="keyDiff">A function representing "subtraction" between two keys</param>
   /// <category>Series interoploation</category>
   static member inline interpolateLinear keys (keyDiff:'K->'K->float) (series:Series<'K, 'V>) =
     let linearF k a b =

--- a/src/Deedle/Vectors/VirtualVector.fs
+++ b/src/Deedle/Vectors/VirtualVector.fs
@@ -91,14 +91,13 @@ type VirtualAddressingScheme =
 // ------------------------------------------------------------------------------------------------
 
 
-/// In BigDeedle, we often use `Ranges<'T>` to represent the address range obtained as a result
-/// of slicing and merging frames & series. This implements `IAddressOperations` for `Ranges<'T>`.
-///
-/// ## Parameters
-///  - `ranges` - ranges containing any key that we are wrapping
-///  - `asAddress` - converts the key to an address
-///  - `ofAddress` - converts address to a key
-///
+/// <summary>
+/// In BigDeedle, we often use `Ranges&lt;'T&gt;` to represent the address range obtained as a result
+/// of slicing and merging frames &amp; series. This implements `IAddressOperations` for `Ranges&lt;'T&gt;`.
+/// </summary>
+/// <param name="ranges">Ranges containing any key that we are wrapping</param>
+/// <param name="asAddress">Converts the key to an address</param>
+/// <param name="ofAddress">Converts address to a key</param>
 type RangesAddressOperations<'TKey when 'TKey : equality>
       ( ranges:Ranges<'TKey>,
         asAddress:System.Func<'TKey, Address>,


### PR DESCRIPTION
## Summary

- Replace all deprecated `[category:...]` doc comment syntax with `<category>...</category>` XML extension format as per [FST-1031](https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1031-xmldoc-extensions.md) in all `Deedle.Math` source files
- Fix bare `Frame<R, C>` in `Frame.fs` doc comment which produced invalid XML (causing `XmlException` in FSharp.Formatting doc generation)
- Fix redundant triple-slash comment in `docs/series.fsx`

## Files changed
- `src/Deedle.Math/Extensions.fs`
- `src/Deedle.Math/Finance.fs`
- `src/Deedle.Math/Frame.fs`
- `src/Deedle.Math/LinearAlgebra.fs`
- `src/Deedle.Math/Stats.fs`
- `src/Deedle/Frame.fs`
- `docs/series.fsx`
