### PR TITLE
Move to .NET 10 and fsdocs-tool 22.0.0-alpha.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fsdocs-tool": {
-      "version": "21.0.0",
+      "version": "22.0.0-alpha.2",
       "commands": [
         "fsdocs"
       ]

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:
@@ -35,7 +35,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
       - name: Cache NuGet packages
         uses: actions/cache@v4
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,11 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>logo.png</PackageIcon>
     <WarnOn>3390</WarnOn>
+    <!-- Suppress NU1510 (unnecessary package references) for packages that are in-box on net10.0
+         but still pulled in as transitive Paket-managed dependencies -->
+    <NoWarn>$(NoWarn);NU1510</NoWarn>
+    <!-- Suppress NU1701 for NetOfficeFw packages that only ship .NET Framework assets -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
     <!-- SourceLink: embed source references in PDBs for debuggable NuGet packages (#317) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## 5.0.0 - 2026-04-02
+
+### Infrastructure
+
+- Migrate to .NET 10 and FSharp.Core 10.0
+- Update fsdocs-tool to 22.0.0-alpha.2
+- Remove unnecessary System.Reflection.Emit package references (now in-box on net10.0)
+- Suppress NU1510 warnings for in-box packages pulled transitively via Paket
+- Suppress NU1701 warnings for NetOfficeFw packages (no net10.0 assets)
+- Fix self-referential `open FSharp.Data.Runtime` in vendored TextRuntime.fs for newer F# compilers
+- Replace deprecated `Frame.indexRowsDate`/`Frame.indexRowsDateOffs` usage in tests with `Frame.indexRowsDateTime`/`Frame.indexRowsDateTimeOffset`
+
+### Bug fixes
+
+- Fix doc generation "No value returned by any evaluator" errors ([#692](https://github.com/fslaborg/Deedle/issues/692))
+
 ## 4.0.1 - 2026-03-22
 
 ### New packages

--- a/docs/arrow.fsx
+++ b/docs/arrow.fsx
@@ -8,8 +8,9 @@ index: 7
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
-#r "../bin/net9.0/Deedle.Arrow.dll"
+#r "../bin/net10.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.Arrow.dll"
+#r "../packages/Apache.Arrow/lib/net8.0/Apache.Arrow.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"

--- a/docs/arrow.fsx
+++ b/docs/arrow.fsx
@@ -16,6 +16,7 @@ index: 7
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #r "nuget: Deedle.Arrow,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open System.IO

--- a/docs/frame.fsx
+++ b/docs/frame.fsx
@@ -8,7 +8,7 @@ index: 3
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"

--- a/docs/frame.fsx
+++ b/docs/frame.fsx
@@ -13,6 +13,7 @@ index: 3
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open System.IO

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -8,7 +8,7 @@ index: 1
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -13,6 +13,7 @@ index: 1
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open Deedle

--- a/docs/joining.fsx
+++ b/docs/joining.fsx
@@ -8,7 +8,7 @@ index: 8
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"

--- a/docs/joining.fsx
+++ b/docs/joining.fsx
@@ -13,6 +13,7 @@ index: 8
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open Deedle
@@ -40,15 +41,15 @@ controls which rows appear in the result.
 // Stock prices for two securities
 let aapl =
     Frame.ofColumns [
-        "Open",  Series.ofValues [ 150.0; 152.0; 151.0; 153.0 ]
-        "Close", Series.ofValues [ 151.5; 151.0; 153.5; 154.0 ]
+        "AAPL Open",  Series.ofValues [ 150.0; 152.0; 151.0; 153.0 ]
+        "AAPL Close", Series.ofValues [ 151.5; 151.0; 153.5; 154.0 ]
     ]
     |> Frame.indexRowsWith [| "2024-01-15"; "2024-01-16"; "2024-01-17"; "2024-01-18" |]
 
 let msft =
     Frame.ofColumns [
-        "Open",  Series.ofValues [ 370.0; 375.0; 373.0 ]
-        "Close", Series.ofValues [ 374.0; 373.0; 376.0 ]
+        "MSFT Open",  Series.ofValues [ 370.0; 375.0; 373.0 ]
+        "MSFT Close", Series.ofValues [ 374.0; 373.0; 376.0 ]
     ]
     |> Frame.indexRowsWith [| "2024-01-15"; "2024-01-16"; "2024-01-18" |]
 
@@ -63,8 +64,8 @@ let outerJoin = Frame.join JoinKind.Outer aapl msft
 
 (**
 
-An outer join includes all row keys from either frame. Columns from each frame are
-suffixed with `.1` and `.2` when their names clash.
+An outer join includes all row keys from either frame. Columns from each frame
+are combined. When column names clash, they are suffixed with `.1` and `.2`.
 
 Missing values appear where one frame had no data for a given key.
 
@@ -180,7 +181,7 @@ takes priority; values from the *second* are used only where the first is missin
 *)
 
 let primary   = Series.ofOptionalObservations [ (1, Some 10.0); (2, None); (3, Some 30.0); (4, None) ]
-let secondary = Series.ofOptionalObservations [ (1, Some 99.0); (2, Some 20.0); (3, None); (4, Some 40.0) ]
+let secondary = Series.ofOptionalObservations [ (2, Some 20.0); (4, Some 40.0) ]
 
 let merged = Series.merge primary secondary
 (*** include-value: merged ***)

--- a/docs/lazysource.fsx
+++ b/docs/lazysource.fsx
@@ -13,6 +13,7 @@ index: 6
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open System.Collections.Generic

--- a/docs/lazysource.fsx
+++ b/docs/lazysource.fsx
@@ -8,7 +8,7 @@ index: 6
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
@@ -76,6 +76,7 @@ We can now use the series as usual - for example, to get data for the entire yea
 
 (*** define-output:slice ***)
 let slice = ls.[DateTime(2012, 1, 1) .. DateTime(2012, 12, 31)]
+slice
 (*** include-it:slice ***)
 
 (**
@@ -87,4 +88,5 @@ and then access only a slice:
 (*** define-output:frame ***)
 let df = frame ["Values" => ls]
 let slicedDf = df.Rows.[DateTime(2012,6,1) .. DateTime(2012,6,30)]
+slicedDf
 (*** include-it:frame ***)

--- a/docs/math.fsx
+++ b/docs/math.fsx
@@ -19,6 +19,7 @@ index: 7
 #r "nuget: MathNet.Numerics"
 #r "nuget: MathNet.Numerics.FSharp"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open Deedle

--- a/docs/math.fsx
+++ b/docs/math.fsx
@@ -8,8 +8,8 @@ index: 7
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
-#r "../bin/net9.0/Deedle.Math.dll"
+#r "../bin/net10.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.Math.dll"
 #r "nuget: MathNet.Numerics, 5.0.0"
 #r "nuget: MathNet.Numerics.FSharp, 5.0.0"
 (*** condition: fsx ***)

--- a/docs/missing.fsx
+++ b/docs/missing.fsx
@@ -13,6 +13,7 @@ index: 9
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open Deedle

--- a/docs/missing.fsx
+++ b/docs/missing.fsx
@@ -8,7 +8,7 @@ index: 9
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
@@ -59,13 +59,13 @@ Series.ofValues [ "a"; null; "c" ]
 (*** include-it:miss3 ***)
 
 (**
-You can also construct a series with an explicit `OptionalValue.Missing`:
+You can also construct a series with explicit missing values using `None`:
 *)
 (*** define-output:miss4 ***)
 Series.ofOptionalObservations
-  [ 1 => OptionalValue(10.0)
-    2 => OptionalValue.Missing
-    3 => OptionalValue(30.0) ]
+  [ 1 => Some(10.0)
+    2 => None
+    3 => Some(30.0) ]
 (*** include-it:miss4 ***)
 
 (**
@@ -131,7 +131,7 @@ match v with
 
 (**
 You can also use `Series.observationsAll` to iterate over all key-value pairs
-including missing ones (as `OptionalValue`), or `Series.observations` to skip
+including missing ones (as `option`), or `Series.observations` to skip
 missing values:
 *)
 (*** define-output:obsall ***)
@@ -140,8 +140,8 @@ ozone
 |> Seq.truncate 6
 |> Seq.map (fun (k, v) ->
     match v with
-    | OptionalValue.Present x -> sprintf "%d => %g" k x
-    | OptionalValue.Missing   -> sprintf "%d => <missing>" k)
+    | Some x -> sprintf "%d => %g" k x
+    | None   -> sprintf "%d => <missing>" k)
 |> Seq.toList
 (*** include-it:obsall ***)
 

--- a/docs/series.fsx
+++ b/docs/series.fsx
@@ -18,6 +18,7 @@ index: 4
 #r "nuget: MathNet.Numerics"
 #r "nuget: MathNet.Numerics.FSharp"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open Deedle

--- a/docs/series.fsx
+++ b/docs/series.fsx
@@ -8,8 +8,8 @@ index: 4
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
-#r "../bin/net9.0/Deedle.Math.dll"
+#r "../bin/net10.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.Math.dll"
 #r "nuget: MathNet.Numerics, 5.0.0"
 #r "nuget: MathNet.Numerics.FSharp, 5.0.0"
 (*** condition: fsx ***)

--- a/docs/stats.fsx
+++ b/docs/stats.fsx
@@ -13,6 +13,7 @@ index: 5
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open System.Globalization

--- a/docs/stats.fsx
+++ b/docs/stats.fsx
@@ -8,7 +8,7 @@ index: 5
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
@@ -138,7 +138,7 @@ day between May and September. We create a frame with two-level row key using
 *)
 let dateFormat = CultureInfo.CurrentCulture.DateTimeFormat
 let byMonth = air |> Frame.indexRowsUsing (fun r ->
-    dateFormat.GetMonthName(r.GetAs("Month")), r.GetAs<int>("Day"))
+    dateFormat.GetMonthName(r.GetAs<int>("Month")), r.GetAs<int>("Day"))
 
 (**
 We can now access individual columns and calculate statistics over the 

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -13,6 +13,7 @@ index: 2
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
 #endif // FSX
+(*** condition: prepare ***)
 
 open System
 open Deedle
@@ -74,13 +75,13 @@ with 10 day value range and random values:
 *)
 
 /// Generate date range from 'first' with 'count' days
-let dateRange (first:System.DateTime) count = (*[omit:(...)]*)
-  seq { for i in 0 .. (count - 1) -> first.AddDays(float i) }(*[/omit]*)
+let dateRange (first:System.DateTime) count =
+  seq { for i in 0 .. (count - 1) -> first.AddDays(float i) }
 
 /// Generate 'count' number of random doubles
-let rand count = (*[omit:(...)]*)
+let rand count =
   let rnd = System.Random()
-  seq { for i in 0 .. (count - 1) -> rnd.NextDouble() }(*[/omit]*)
+  seq { for i in 0 .. (count - 1) -> rnd.NextDouble() }
 
 // A series with values for 10 days 
 let second = Series(dateRange (DateTime(2013,1,1)) 10, rand 10)

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -8,7 +8,7 @@ index: 2
 *)
 (*** condition: prepare ***)
 #nowarn "211"
-#r "../bin/net9.0/Deedle.dll"
+#r "../bin/net10.0/Deedle.dll"
 (*** condition: fsx ***)
 #if FSX
 #r "nuget: Deedle,{{fsdocs-package-version}}"
@@ -16,6 +16,10 @@ index: 2
 
 open System
 open Deedle
+
+(*** define-output: sanity ***)
+series [1 => 1.0; 2 => 2.0]
+(*** include-it: sanity ***)
 
 (**
 
@@ -81,7 +85,9 @@ let rand count = (*[omit:(...)]*)
 // A series with values for 10 days 
 let second = Series(dateRange (DateTime(2013,1,1)) 10, rand 10)
 
-(*** include-value: (round (second*100.0))/100.0 ***)
+(*** define-output: create3 ***)
+(round (second*100.0))/100.0
+(*** include-it: create3 ***)
 
 (**
 Now we can easily construct a data frame that has two columns - one representing
@@ -90,7 +96,9 @@ the `first` series and another representing the `second` series:
 
 let df1 = Frame(["first"; "second"], [first; second])
 
-(*** include-value: df1 ***)
+(*** define-output: frame1 ***)
+df1
+(*** include-it: frame1 ***)
 
 (** 
 The type representing a data frame has two generic parameters:
@@ -286,8 +294,12 @@ with time component set to the current time:
 let daysSeries = Series(dateRange DateTime.Today 10, rand 10)
 let obsSeries = Series(dateRange DateTime.Now 10, rand 10)
 
-(*** include-value: (round (daysSeries*100.0))/100.0 ***)
-(*** include-value: (round (obsSeries*100.0))/100.0 ***)
+(*** define-output: days ***)
+(round (daysSeries*100.0))/100.0
+(*** include-it: days ***)
+(*** define-output: obs ***)
+(round (obsSeries*100.0))/100.0
+(*** include-it: obs ***)
 
 (**
 The indexing operation written as `daysSeries.[date]` uses _exact_ semantics so it will 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
-    "rollForward": "minor"
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
   }
 }

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,7 +13,7 @@ nuget NUnit.ConsoleRunner
 nuget FsUnit
 nuget System.Reflection.Emit
 nuget System.Reflection.Emit.Lightweight
-nuget FSharp.Core
+nuget FSharp.Core >= 10.0 < 11.0
 nuget Microsoft.NET.Test.Sdk
 nuget NUnit3TestAdapter
 nuget Microsoft.CSharp
@@ -25,8 +25,8 @@ nuget ExcelDataReader.DataSet
 
 group interactive
     source https://api.nuget.org/v3/index.json
-    framework: net9.0
-    nuget FSharp.Core
+    framework: net10.0
+    nuget FSharp.Core >= 10.0 < 11.0
     nuget Microsoft.DotNet.Interactive
     nuget Microsoft.DotNet.Interactive.Formatting
 

--- a/paket.lock
+++ b/paket.lock
@@ -6,18 +6,18 @@ NUGET
       System.Runtime.CompilerServices.Unsafe (>= 6.1) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
       System.Threading.Tasks.Extensions (>= 4.6) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
       System.ValueTuple (>= 4.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
-    Azure.Core (1.51.1) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
-      Microsoft.Bcl.AsyncInterfaces (>= 10.0.2) - restriction: || (>= net462) (>= netstandard2.0)
-      System.ClientModel (>= 1.9) - restriction: || (>= net462) (>= netstandard2.0)
-      System.Diagnostics.DiagnosticSource (>= 10.0.2) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Memory.Data (>= 10.0.1) - restriction: || (>= net462) (>= netstandard2.0)
+    Azure.Core (1.52) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
+      Microsoft.Bcl.AsyncInterfaces (>= 10.0.3) - restriction: || (>= net462) (>= netstandard2.0)
+      System.ClientModel (>= 1.10) - restriction: || (>= net462) (>= netstandard2.0)
+      System.Diagnostics.DiagnosticSource (>= 10.0.3) - restriction: || (&& (< net10.0) (>= net8.0)) (>= net462) (&& (< net8.0) (>= netstandard2.0))
+      System.Memory.Data (>= 10.0.3) - restriction: || (>= net462) (>= netstandard2.0)
       System.Numerics.Vectors (>= 4.6.1) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Text.Encodings.Web (>= 10.0.1) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Text.Json (>= 10.0.1) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
+      System.Text.Encodings.Web (>= 10.0.3) - restriction: || (&& (< net10.0) (>= net8.0)) (>= net462) (&& (< net8.0) (>= netstandard2.0))
+      System.Text.Json (>= 10.0.3) - restriction: || (&& (< net10.0) (>= net8.0)) (>= net462) (&& (< net8.0) (>= netstandard2.0))
       System.Threading.Tasks.Extensions (>= 4.6.3) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-    Azure.Monitor.OpenTelemetry.Exporter (1.6) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
-      Azure.Core (>= 1.50) - restriction: >= netstandard2.0
-      OpenTelemetry.Extensions.Hosting (>= 1.14) - restriction: >= netstandard2.0
+    Azure.Monitor.OpenTelemetry.Exporter (1.7) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
+      Azure.Core (>= 1.52) - restriction: >= netstandard2.0
+      OpenTelemetry.Extensions.Hosting (>= 1.15.1) - restriction: >= netstandard2.0
       OpenTelemetry.PersistentStorage.FileSystem (>= 1.0.2) - restriction: >= netstandard2.0
     BenchmarkDotNet (0.13.12)
       BenchmarkDotNet.Annotations (>= 0.13.12) - restriction: >= netstandard2.0
@@ -54,42 +54,42 @@ NUGET
       System.Reflection.Metadata (>= 9.0) - restriction: >= netstandard2.0
       System.Runtime.CompilerServices.Unsafe (>= 6.1) - restriction: >= netstandard2.0
     FSharp.Core (10.1.201)
-    FSharp.Data (8.1.2)
+    FSharp.Data (8.1.4)
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-      FSharp.Data.Csv.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Html.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Http (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Json.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Runtime.Utilities (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.WorldBank.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Xml.Core (>= 8.1.2) - restriction: >= netstandard2.0
-    FSharp.Data.Csv.Core (8.1.2) - restriction: >= netstandard2.0
+      FSharp.Data.Csv.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Html.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Http (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Json.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Runtime.Utilities (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.WorldBank.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Xml.Core (>= 8.1.4) - restriction: >= netstandard2.0
+    FSharp.Data.Csv.Core (8.1.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-      FSharp.Data.Runtime.Utilities (>= 8.1.2) - restriction: >= netstandard2.0
-    FSharp.Data.Html.Core (8.1.2) - restriction: >= netstandard2.0
+      FSharp.Data.Runtime.Utilities (>= 8.1.4) - restriction: >= netstandard2.0
+    FSharp.Data.Html.Core (8.1.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-      FSharp.Data.Csv.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Json.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Runtime.Utilities (>= 8.1.2) - restriction: >= netstandard2.0
-    FSharp.Data.Http (8.1.2) - restriction: >= netstandard2.0
+      FSharp.Data.Csv.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Json.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Runtime.Utilities (>= 8.1.4) - restriction: >= netstandard2.0
+    FSharp.Data.Http (8.1.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-    FSharp.Data.Json.Core (8.1.2) - restriction: >= netstandard2.0
+    FSharp.Data.Json.Core (8.1.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-      FSharp.Data.Http (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Runtime.Utilities (>= 8.1.2) - restriction: >= netstandard2.0
-    FSharp.Data.Runtime.Utilities (8.1.2) - restriction: >= netstandard2.0
+      FSharp.Data.Http (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Runtime.Utilities (>= 8.1.4) - restriction: >= netstandard2.0
+    FSharp.Data.Runtime.Utilities (8.1.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-      FSharp.Data.Http (>= 8.1.2) - restriction: >= netstandard2.0
-    FSharp.Data.WorldBank.Core (8.1.2) - restriction: >= netstandard2.0
+      FSharp.Data.Http (>= 8.1.4) - restriction: >= netstandard2.0
+    FSharp.Data.WorldBank.Core (8.1.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-      FSharp.Data.Http (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Json.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Runtime.Utilities (>= 8.1.2) - restriction: >= netstandard2.0
-    FSharp.Data.Xml.Core (8.1.2) - restriction: >= netstandard2.0
+      FSharp.Data.Http (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Json.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Runtime.Utilities (>= 8.1.4) - restriction: >= netstandard2.0
+    FSharp.Data.Xml.Core (8.1.4) - restriction: >= netstandard2.0
       FSharp.Core (>= 6.0.1) - restriction: >= netstandard2.0
-      FSharp.Data.Http (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Json.Core (>= 8.1.2) - restriction: >= netstandard2.0
-      FSharp.Data.Runtime.Utilities (>= 8.1.2) - restriction: >= netstandard2.0
+      FSharp.Data.Http (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Json.Core (>= 8.1.4) - restriction: >= netstandard2.0
+      FSharp.Data.Runtime.Utilities (>= 8.1.4) - restriction: >= netstandard2.0
     FsUnit (7.1.1)
       FSharp.Core (>= 5.0.2)
       NUnit (>= 4.0.1)
@@ -147,7 +147,7 @@ NUGET
       Microsoft.Diagnostics.NETCore.Client (>= 0.2.410101) - restriction: >= netstandard2.0
       System.Collections.Immutable (>= 6.0) - restriction: && (< net6.0) (>= netstandard2.0)
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: && (< net6.0) (>= netstandard2.0)
-    Microsoft.Diagnostics.Tracing.TraceEvent (3.1.30) - restriction: >= netstandard2.0
+    Microsoft.Diagnostics.Tracing.TraceEvent (3.2) - restriction: >= netstandard2.0
       Microsoft.Diagnostics.NETCore.Client (>= 0.2.510501) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 5.0) - restriction: >= netstandard2.0
       System.Collections.Immutable (>= 9.0.8) - restriction: >= netstandard2.0
@@ -173,6 +173,9 @@ NUGET
     Microsoft.Extensions.DependencyInjection.Abstractions (10.0.5) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 10.0.5) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
       System.Threading.Tasks.Extensions (>= 4.6.3) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
+    Microsoft.Extensions.DependencyModel (10.0.5) - restriction: >= net8.0
+      System.Text.Encodings.Web (>= 10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (>= net462) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= netstandard2.0))
+      System.Text.Json (>= 10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (>= net462) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= netstandard2.0))
     Microsoft.Extensions.Diagnostics.Abstractions (10.0.5) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 10.0.5) - restriction: || (>= net462) (>= netstandard2.0)
       Microsoft.Extensions.Options (>= 10.0.5) - restriction: || (>= net462) (>= netstandard2.0)
@@ -282,17 +285,17 @@ NUGET
       System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= uap10.1)
       System.Security.AccessControl (>= 5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Security.Principal.Windows (>= 5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (&& (< monoandroid) (>= netcoreapp2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    NetOfficeFw.Core (1.9.8)
-    NetOfficeFw.Excel (1.9.8)
-      NetOfficeFw.Core (>= 1.9.8) - restriction: >= net462
-      NetOfficeFw.Office (>= 1.9.8) - restriction: >= net462
-      NetOfficeFw.VBIDE (>= 1.9.8) - restriction: >= net462
-    NetOfficeFw.Office (1.9.8) - restriction: >= net462
-      NetOfficeFw.Core (>= 1.9.8) - restriction: >= net462
+    NetOfficeFw.Core (1.9.9)
+    NetOfficeFw.Excel (1.9.9)
+      NetOfficeFw.Core (>= 1.9.9) - restriction: >= net462
+      NetOfficeFw.Office (>= 1.9.9) - restriction: >= net462
+      NetOfficeFw.VBIDE (>= 1.9.9) - restriction: >= net462
+    NetOfficeFw.Office (1.9.9) - restriction: >= net462
+      NetOfficeFw.Core (>= 1.9.9) - restriction: >= net462
       stdole (>= 7.0.3300) - restriction: >= net462
-    NetOfficeFw.VBIDE (1.9.8) - restriction: >= net462
-      NetOfficeFw.Core (>= 1.9.8) - restriction: >= net462
-      NetOfficeFw.Office (>= 1.9.8) - restriction: >= net462
+    NetOfficeFw.VBIDE (1.9.9) - restriction: >= net462
+      NetOfficeFw.Core (>= 1.9.9) - restriction: >= net462
+      NetOfficeFw.Office (>= 1.9.9) - restriction: >= net462
     NETStandard.Library (2.0.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
       Microsoft.Win32.Primitives (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4)) (&& (< netstandard1.5) (>= uap10.0) (< uap10.1))
@@ -343,29 +346,30 @@ NUGET
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: >= net462
       System.ValueTuple (>= 4.4) - restriction: >= net462
     NUnit.ConsoleRunner (3.22)
-    NUnit3TestAdapter (6.1)
-      Microsoft.Testing.Extensions.VSTestBridge (>= 2.0.2) - restriction: || (>= net462) (>= net8.0)
-      Microsoft.Testing.Platform.MSBuild (>= 2.0.2) - restriction: || (>= net462) (>= net8.0)
-    OpenTelemetry (1.15) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
+    NUnit3TestAdapter (6.2)
+      Microsoft.Extensions.DependencyModel (>= 8.0.2) - restriction: >= net8.0
+      Microsoft.Testing.Extensions.VSTestBridge (>= 2.1) - restriction: || (>= net462) (>= net8.0)
+      Microsoft.Testing.Platform.MSBuild (>= 2.1) - restriction: || (>= net462) (>= net8.0)
+    OpenTelemetry (1.15.1) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
       Microsoft.Extensions.Diagnostics.Abstractions (>= 8.0) - restriction: && (>= net8.0) (< net9.0)
       Microsoft.Extensions.Diagnostics.Abstractions (>= 9.0) - restriction: && (< net10.0) (>= net9.0)
       Microsoft.Extensions.Diagnostics.Abstractions (>= 10.0) - restriction: || (>= net10.0) (>= net462) (&& (< net8.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
       Microsoft.Extensions.Logging.Configuration (>= 8.0) - restriction: && (>= net8.0) (< net9.0)
       Microsoft.Extensions.Logging.Configuration (>= 9.0) - restriction: && (< net10.0) (>= net9.0)
       Microsoft.Extensions.Logging.Configuration (>= 10.0) - restriction: || (>= net10.0) (>= net462) (&& (< net8.0) (>= netstandard2.1)) (&& (>= netstandard2.0) (< netstandard2.1))
-      OpenTelemetry.Api.ProviderBuilderExtensions (>= 1.15) - restriction: || (>= net462) (>= netstandard2.0)
-    OpenTelemetry.Api (1.15) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
+      OpenTelemetry.Api.ProviderBuilderExtensions (>= 1.15.1) - restriction: || (>= net462) (>= netstandard2.0)
+    OpenTelemetry.Api (1.15.1) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
       System.Diagnostics.DiagnosticSource (>= 10.0) - restriction: || (&& (< net10.0) (>= net9.0)) (>= net462) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= netstandard2.0))
-    OpenTelemetry.Api.ProviderBuilderExtensions (1.15) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
+    OpenTelemetry.Api.ProviderBuilderExtensions (1.15.1) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 8.0) - restriction: && (>= net8.0) (< net9.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 9.0) - restriction: && (< net10.0) (>= net9.0)
       Microsoft.Extensions.DependencyInjection.Abstractions (>= 10.0) - restriction: || (>= net10.0) (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      OpenTelemetry.Api (>= 1.15) - restriction: || (>= net462) (>= netstandard2.0)
-    OpenTelemetry.Extensions.Hosting (1.15) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
+      OpenTelemetry.Api (>= 1.15.1) - restriction: || (>= net462) (>= netstandard2.0)
+    OpenTelemetry.Extensions.Hosting (1.15.1) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
       Microsoft.Extensions.Hosting.Abstractions (>= 8.0) - restriction: && (>= net8.0) (< net9.0)
       Microsoft.Extensions.Hosting.Abstractions (>= 9.0) - restriction: && (< net10.0) (>= net9.0)
       Microsoft.Extensions.Hosting.Abstractions (>= 10.0) - restriction: || (>= net10.0) (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      OpenTelemetry (>= 1.15) - restriction: || (>= net462) (>= netstandard2.0)
+      OpenTelemetry (>= 1.15.1) - restriction: || (>= net462) (>= netstandard2.0)
     OpenTelemetry.PersistentStorage.Abstractions (1.0.2) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
     OpenTelemetry.PersistentStorage.FileSystem (1.0.2) - restriction: || (&& (>= net462) (>= netstandard2.0)) (>= net8.0)
       OpenTelemetry.PersistentStorage.Abstractions (>= 1.0.2) - restriction: || (>= net462) (>= netstandard2.0)
@@ -457,7 +461,7 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (10.0.5) - restriction: || (&& (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net10.0) (>= net9.0)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (>= net462) (>= net8.0)) (&& (>= net462) (>= net9.0)) (&& (>= net462) (>= netstandard2.1)) (&& (>= net8.0) (< net9.0)) (&& (>= net8.0) (< netstandard2.1)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (>= netstandard2.0)
+    System.Diagnostics.DiagnosticSource (10.0.5) - restriction: || (&& (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net10.0) (>= net8.0)) (&& (< net10.0) (>= net9.0)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (>= net462) (>= net8.0)) (&& (>= net462) (>= net9.0)) (&& (>= net462) (>= netstandard2.1)) (&& (>= net8.0) (< net9.0)) (&& (>= net8.0) (< netstandard2.1)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (>= netstandard2.0)
       System.Memory (>= 4.6.3) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
       System.Runtime.CompilerServices.Unsafe (>= 6.1.2) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
     System.Diagnostics.Tools (4.3) - restriction: || (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81))
@@ -542,10 +546,7 @@ NUGET
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     System.IO.FileSystem.Primitives (4.3) - restriction: || (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IO.Pipelines (10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (&& (>= net462) (>= netstandard2.0)) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= netstandard2.0))
-      System.Buffers (>= 4.6.1) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Memory (>= 4.6.3) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Threading.Tasks.Extensions (>= 4.6.3) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
+    System.IO.Pipelines (10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (&& (>= net462) (>= net8.0)) (&& (>= net462) (>= net9.0)) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= net9.0))
     System.Linq (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81))
       System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Diagnostics.Debug (>= 4.3) - restriction: && (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -861,19 +862,10 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Text.Encodings.Web (10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (&& (>= net462) (>= net8.0)) (&& (>= net462) (>= netstandard2.0)) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= netstandard2.0))
-      System.Buffers (>= 4.6.1) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Memory (>= 4.6.3) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Runtime.CompilerServices.Unsafe (>= 6.1.2) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
+    System.Text.Encodings.Web (10.0.5) - restriction: || (&& (< net10.0) (>= net8.0)) (&& (< net10.0) (>= net9.0)) (&& (>= net462) (>= net8.0)) (&& (>= net462) (>= netstandard2.0)) (&& (>= net8.0) (< net9.0))
     System.Text.Json (10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (&& (>= net462) (>= net8.0)) (&& (>= net462) (>= net9.0)) (&& (>= net8.0) (< net9.0)) (>= netstandard2.0)
-      Microsoft.Bcl.AsyncInterfaces (>= 10.0.5) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Buffers (>= 4.6.1) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
       System.IO.Pipelines (>= 10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (>= net462) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= netstandard2.0))
-      System.Memory (>= 4.6.3) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.Runtime.CompilerServices.Unsafe (>= 6.1.2) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
       System.Text.Encodings.Web (>= 10.0.5) - restriction: || (&& (< net10.0) (>= net9.0)) (>= net462) (&& (>= net8.0) (< net9.0)) (&& (< net8.0) (>= netstandard2.0))
-      System.Threading.Tasks.Extensions (>= 4.6.3) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
-      System.ValueTuple (>= 4.6.1) - restriction: >= net462
     System.Text.RegularExpressions (4.3.1) - restriction: || (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81))
       System.Collections (>= 4.3) - restriction: && (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Globalization (>= 4.3) - restriction: && (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -958,7 +950,7 @@ NUGET
       System.Xml.XmlDocument (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
 
 GROUP interactive
-RESTRICTION: == net9.0
+RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (10.1.201)
@@ -1023,17 +1015,9 @@ NUGET
       Microsoft.CodeAnalysis.CSharp (>= 5.0)
       Microsoft.CodeAnalysis.CSharp.Workspaces (>= 5.0)
       Microsoft.CodeAnalysis.Workspaces.Common (>= 5.0)
-      Microsoft.CSharp (>= 4.7)
       Microsoft.DotNet.Interactive.Documents (1.0.0-beta.26120.1)
       Microsoft.DotNet.Interactive.Formatting (1.0.0-beta.26120.1)
-      System.Collections.Immutable (>= 10.0)
-      System.Diagnostics.DiagnosticSource (>= 10.0)
-      System.IO.Pipelines (>= 10.0)
-      System.Memory (>= 4.6.3)
       System.Reactive (>= 6.0)
-      System.Reflection.Metadata (>= 10.0)
-      System.Runtime.Loader (>= 4.3)
-      System.Text.Json (>= 10.0)
     Microsoft.DotNet.Interactive.Documents (1.0.0-beta.26120.1)
       Microsoft.Bcl.AsyncInterfaces (>= 10.0)
       Microsoft.Bcl.HashCode (>= 6.0)
@@ -1048,8 +1032,6 @@ NUGET
       System.IO.Pipelines (>= 10.0)
       System.Memory (>= 4.6.3)
       System.Text.Json (>= 10.0)
-    Microsoft.NETCore.Platforms (7.0.4)
-    Microsoft.NETCore.Targets (5.0)
     System.Buffers (4.6.1)
     System.Collections.Immutable (10.0.5)
     System.Composition (10.0.5)
@@ -1068,49 +1050,14 @@ NUGET
       System.Composition.AttributedModel (>= 10.0.5)
       System.Composition.Hosting (>= 10.0.5)
       System.Composition.Runtime (>= 10.0.5)
-    System.Diagnostics.DiagnosticSource (10.0.5)
-    System.IO (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1)
-      Microsoft.NETCore.Targets (>= 1.1)
-      System.Runtime (>= 4.3)
-      System.Text.Encoding (>= 4.3)
-      System.Threading.Tasks (>= 4.3)
     System.IO.Pipelines (10.0.5)
     System.Memory (4.6.3)
     System.Numerics.Vectors (4.6.1)
     System.Reactive (6.1)
-    System.Reflection (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1)
-      Microsoft.NETCore.Targets (>= 1.1)
-      System.IO (>= 4.3)
-      System.Reflection.Primitives (>= 4.3)
-      System.Runtime (>= 4.3)
     System.Reflection.Metadata (10.0.5)
-      System.Collections.Immutable (>= 10.0.5)
-    System.Reflection.Primitives (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1)
-      Microsoft.NETCore.Targets (>= 1.1)
-      System.Runtime (>= 4.3)
-    System.Runtime (4.3.1)
-      Microsoft.NETCore.Platforms (>= 1.1.1)
-      Microsoft.NETCore.Targets (>= 1.1.3)
     System.Runtime.CompilerServices.Unsafe (6.1.2)
-    System.Runtime.Loader (4.3)
-      System.IO (>= 4.3)
-      System.Reflection (>= 4.3)
-      System.Runtime (>= 4.3)
-    System.Text.Encoding (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1)
-      Microsoft.NETCore.Targets (>= 1.1)
-      System.Runtime (>= 4.3)
     System.Text.Encoding.CodePages (10.0.5)
     System.Text.Encodings.Web (10.0.5)
     System.Text.Json (10.0.5)
-      System.IO.Pipelines (>= 10.0.5)
-      System.Text.Encodings.Web (>= 10.0.5)
     System.Threading.Channels (10.0.5)
-    System.Threading.Tasks (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1)
-      Microsoft.NETCore.Targets (>= 1.1)
-      System.Runtime (>= 4.3)
     System.Threading.Tasks.Extensions (4.6.3)

--- a/src/Deedle.Arrow/Deedle.Arrow.fsproj
+++ b/src/Deedle.Arrow/Deedle.Arrow.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../../bin/</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Deedle.Excel.Reader/Deedle.Excel.Reader.fsproj
+++ b/src/Deedle.Excel.Reader/Deedle.Excel.Reader.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../../bin/</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Deedle.Excel/Deedle.Excel.fsproj
+++ b/src/Deedle.Excel/Deedle.Excel.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../../bin/</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Deedle.Interactive/Deedle.Interactive.fsproj
+++ b/src/Deedle.Interactive/Deedle.Interactive.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../../bin/</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Deedle.Math/Deedle.Math.fsproj
+++ b/src/Deedle.Math/Deedle.Math.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../../bin/</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Deedle.MicrosoftML/Deedle.MicrosoftML.fsproj
+++ b/src/Deedle.MicrosoftML/Deedle.MicrosoftML.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../../bin/</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Deedle/Deedle.fsproj
+++ b/src/Deedle/Deedle.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../../bin/</OutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Deedle/FSharp.Data/CommonRuntime/TextRuntime.fs
+++ b/src/Deedle/FSharp.Data/CommonRuntime/TextRuntime.fs
@@ -3,7 +3,6 @@
 open System
 open System.Globalization
 open FSharp.Data
-open FSharp.Data.Runtime
 
 /// Static helper methods called from the generated code for working with text
 type TextRuntime =

--- a/src/Deedle/paket.references
+++ b/src/Deedle/paket.references
@@ -1,3 +1,1 @@
-System.Reflection.Emit
-System.Reflection.Emit.Lightweight
 FSharp.Core

--- a/tests/Deedle.Arrow.Tests/Deedle.Arrow.Tests.fsproj
+++ b/tests/Deedle.Arrow.Tests/Deedle.Arrow.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Deedle.Benchmarks/Deedle.Benchmarks.fsproj
+++ b/tests/Deedle.Benchmarks/Deedle.Benchmarks.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Deedle.Benchmarks</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Deedle.CSharp.Tests/Deedle.CSharp.Tests.csproj
+++ b/tests/Deedle.CSharp.Tests/Deedle.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>

--- a/tests/Deedle.Excel.Reader.Tests/Deedle.Excel.Reader.Tests.fsproj
+++ b/tests/Deedle.Excel.Reader.Tests/Deedle.Excel.Reader.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deedle\Deedle.fsproj" />

--- a/tests/Deedle.Math.Tests/Deedle.Math.Tests.fsproj
+++ b/tests/Deedle.Math.Tests/Deedle.Math.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deedle\Deedle.fsproj" />

--- a/tests/Deedle.MicrosoftML.Tests/Deedle.MicrosoftML.Tests.fsproj
+++ b/tests/Deedle.MicrosoftML.Tests/Deedle.MicrosoftML.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deedle\Deedle.fsproj" />

--- a/tests/Deedle.PerfTests/Deedle.PerfTests.fsproj
+++ b/tests/Deedle.PerfTests/Deedle.PerfTests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\PerformanceTools\Deedle.PerfTest.Core\Deedle.PerfTest.Core.fsproj" />

--- a/tests/Deedle.Tests.Console/Deedle.Tests.Console.fsproj
+++ b/tests/Deedle.Tests.Console/Deedle.Tests.Console.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deedle\Deedle.fsproj" />

--- a/tests/Deedle.Tests/Deedle.Tests.fsproj
+++ b/tests/Deedle.Tests/Deedle.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -25,7 +25,7 @@ open Deedle
 
 let msft() =
   Frame.ReadCsv(__SOURCE_DIRECTORY__ + "/data/MSFT.csv", inferRows=10)
-  |> Frame.indexRowsDate "Date"
+  |> Frame.indexRowsDateTime "Date"
 
 let msftNoHeaders() =
   let noHeaders =
@@ -37,7 +37,7 @@ let msftNoHeaders() =
 let msftString() =
   let csvString = IO.File.ReadAllText(__SOURCE_DIRECTORY__ + "/data/MSFT.csv")
   Frame.ReadCsvString(csvString, inferRows=10)
-  |> Frame.indexRowsDate "Date"
+  |> Frame.indexRowsDateTime "Date"
 
 [<Test>]
 let ``Can create empty data frame and empty series`` () =
@@ -77,7 +77,7 @@ let ``Can read MSFT data from CSV file without header row`` () =
   let df = msftNoHeaders()
   let expected = msft()
   let colKeys = Seq.append ["Date"] expected.ColumnKeys
-  let actual = df |> Frame.indexColsWith colKeys |> Frame.indexRowsDate "Date"
+  let actual = df |> Frame.indexColsWith colKeys |> Frame.indexRowsDateTime "Date"
   actual |> shouldEqual expected
 
 [<Test>]
@@ -330,7 +330,7 @@ let ``Can save MSFT data as CSV file and read it afterwards (with custom format)
   expected.SaveCsv(file, keyNames=["Date"], separator=';', culture=cz)
   let actual =
     Frame.ReadCsv(file, separators=";", culture="cs-CZ")
-    |> Frame.indexRowsDate "Date"
+    |> Frame.indexRowsDateTime "Date"
   actual |> shouldEqual expected
 
 [<Test>]

--- a/tests/Deedle.Tests/VirtualFrame.fs
+++ b/tests/Deedle.Tests/VirtualFrame.fs
@@ -423,7 +423,7 @@ let ``Can add computed series as a new column to a frame with the same index``()
 let ``Can index frame by an ordered column computed using series transform`` () =
   let s1, s2, f = createTicksFrame()
   f?Times <- f.GetColumn<int64>("Ticks") |> Series.convert fromTicks toTicks
-  let byTimes = f |> Frame.indexRowsDateOffs "Times"
+  let byTimes = f |> Frame.indexRowsDateTimeOffset "Times"
 
   byTimes.Rows.TryGet(date 2010 1 1, Lookup.Exact) |> shouldEqual OptionalValue.Missing
   let prev = byTimes.Rows.Get(date 2010 1 1, Lookup.ExactOrSmaller).["Ticks"] |> unbox<int64> |> fromTicks

--- a/tests/PerformanceTools/Deedle.PerfTest.Core/Deedle.PerfTest.Core.fsproj
+++ b/tests/PerformanceTools/Deedle.PerfTest.Core/Deedle.PerfTest.Core.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputPath>../bin/</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/PerformanceTools/Deedle.PerfTest/Deedle.PerfTest.fsproj
+++ b/tests/PerformanceTools/Deedle.PerfTest/Deedle.PerfTest.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />


### PR DESCRIPTION
## Summary

Move the repo to .NET 10 SDK and update fsdocs-tool to the latest alpha.

### Changes

**SDK & TFM:**
- `global.json`: SDK `9.0.100` → `10.0.100`
- All 18 project files: TFM `net9.0` → `net10.0`
- `paket.dependencies`: `FSharp.Core >= 10.0 < 11.0`, interactive group `framework: net10.0`

**Tooling:**
- `fsdocs-tool`: `21.0.0` → `22.0.0-alpha.2`

**CI:**
- `pull-requests.yml` and `push-master.yml`: `dotnet-version: 10.0.x`

**Docs:**
- Updated `#r` bin paths from `net9.0` to `net10.0` in all `.fsx` doc scripts
- Doc improvements from fsdocs eval: updated `missing.fsx` to use `option` instead of `OptionalValue`, added missing expression results in `lazysource.fsx`, minor fixes in `tutorial.fsx`, `stats.fsx`, `arrow.fsx`

### Verification

- Full solution builds with 0 errors
- All 892 tests pass
- `dotnet fsdocs build --eval` completes successfully
- `Deedle.Interactive` builds cleanly