### PR TITLE
Simplify doc output directives: use include-it instead of define-output/include-it:name

### DIFF
--- a/docs/frame.fsx
+++ b/docs/frame.fsx
@@ -19,6 +19,13 @@ open System
 open System.IO
 open Deedle
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 let root = __SOURCE_DIRECTORY__ + "/data/"
 
 (**

--- a/docs/frame.fsx
+++ b/docs/frame.fsx
@@ -134,14 +134,13 @@ For frames that contain complex .NET objects as column values, you can use `Fram
 to create a new frame that contains properties of the object as new columns. For example: 
 *)
 
-(*** define-output:ppl ***)
 // Create frame with single column 'People'
 let peopleNested = 
   [ "People" => Series.ofValues peopleRecds ] |> frame
 
 // Expand the 'People' column
 peopleNested |> Frame.expandCols ["People"]
-(*** include-it:ppl ***)
+(*** include-it ***)
 
 (**
 <a name="dataframe"></a>
@@ -237,12 +236,11 @@ ages |> Series.observationsAll
 With ordered series, we can use slicing to get a sub-range:
 *)
 
-(*** define-output:opens ***)
 let opens = msft?Open
 opens.[DateTime(2013, 1, 1) .. DateTime(2013, 1, 31)]
 |> Series.mapKeys (fun k -> k.ToShortDateString())
 
-(*** include-it:opens ***)
+(*** include-it ***)
 
 (**
 <a name="grouping"></a>
@@ -263,13 +261,12 @@ travels |> Series.groupInto
   (fun k v -> k.Length) 
   (fun len people -> Series.countKeys people)
 
-(*** define-output: trav ***)
 travels
 |> Series.mapValues (Seq.countBy id >> series)
 |> Frame.ofRows
 |> Frame.fillMissingWith 0
 
-(*** include-it: trav ***)
+(*** include-it ***)
 
 (**
 ### Grouping data frames
@@ -322,17 +319,15 @@ The first argument specifies the grouping columns; the second specifies the colu
 aggregate; the third is the aggregation function to apply to each group series:
 *)
 
-(*** define-output:aggby1 ***)
 // Average fare by Pclass and Sex
 titanic
 |> Frame.aggregateRowsBy ["Pclass"; "Sex"] ["Fare"] Stats.mean
-(*** include-it:aggby1 ***)
+(*** include-it ***)
 
-(*** define-output:aggby2 ***)
 // Count survivors (sum of bool-as-int) and average age per Pclass
 titanic
 |> Frame.aggregateRowsBy ["Pclass"] ["Age"] Stats.mean
-(*** include-it:aggby2 ***)
+(*** include-it ***)
 
 (**
 <a name="pivot"></a>
@@ -343,7 +338,6 @@ A pivot table is a useful tool if you want to summarize data in the frame based
 on two keys that are available in the rows of the data frame. 
 *)
 
-(*** define-output:pivot1 ***)
 titanic 
 |> Frame.pivotTable 
     // Returns a new row key
@@ -353,9 +347,8 @@ titanic
     // Specifies aggregation for sub-frames
     Frame.countRows 
 
-(*** include-it:pivot1 ***)
+(*** include-it ***)
 
-(*** define-output:pivot2 ***)
 titanic 
 |> Frame.pivotTable 
     (fun k r -> r.GetAs<string>("Sex")) 
@@ -363,7 +356,7 @@ titanic
     (fun frame -> frame?Age |> Stats.mean)
 |> round
 
-(*** include-it:pivot2 ***)
+(*** include-it ***)
 
 (**
 <a name="indexing"></a>
@@ -397,16 +390,14 @@ contain missing values. When constructing series or frames from data, certain va
 are automatically treated as "missing values". This includes `Double.NaN`, `null` values
 for reference types and for nullable types:
 *)
-(*** define-output:misv1 ***)
 Series.ofValues [ Double.NaN; 1.0; 3.14 ]
 
-(*** include-it:misv1 ***)
+(*** include-it ***)
 
-(*** define-output:misv2 ***)
 [ Nullable(1); Nullable(); Nullable(3) ]
 |> Series.ofValues
 
-(*** include-it:misv2 ***)
+(*** include-it ***)
 
 (**
 Missing values are automatically skipped when performing statistical computations such

--- a/docs/joining.fsx
+++ b/docs/joining.fsx
@@ -18,6 +18,13 @@ index: 8
 open System
 open Deedle
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 (**
 
 # Joining, Merging and Appending Frames

--- a/docs/lazysource.fsx
+++ b/docs/lazysource.fsx
@@ -20,6 +20,13 @@ open System.Collections.Generic
 open Deedle
 open Deedle.Indices
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 (**
 
 # Delay-loaded series

--- a/docs/lazysource.fsx
+++ b/docs/lazysource.fsx
@@ -75,10 +75,9 @@ is called only when we access part of the series.
 We can now use the series as usual - for example, to get data for the entire year 2012:
 *)
 
-(*** define-output:slice ***)
 let slice = ls.[DateTime(2012, 1, 1) .. DateTime(2012, 12, 31)]
 slice
-(*** include-it:slice ***)
+(*** include-it ***)
 
 (**
 Similarly, we can add the delayed series to a data frame. When doing this, Deedle will
@@ -86,8 +85,7 @@ only load the data that is needed. In the following example, we add the series t
 and then access only a slice:
 *)
 
-(*** define-output:frame ***)
 let df = frame ["Values" => ls]
 let slicedDf = df.Rows.[DateTime(2012,6,1) .. DateTime(2012,6,30)]
 slicedDf
-(*** include-it:frame ***)
+(*** include-it ***)

--- a/docs/math.fsx
+++ b/docs/math.fsx
@@ -72,30 +72,26 @@ let df =
           "B" => series [ 1 => 2.0; 2 => 5.0; 3 => 8.0 ]
           "C" => series [ 1 => 3.0; 2 => 6.0; 3 => 9.0 ] ]
 
-(*** define-output: mat1 ***)
 // Convert frame to a MathNet DenseMatrix
 let m : Matrix<float> = Frame.toMatrix df
 m
-(*** include-it: mat1 ***)
+(*** include-it ***)
 
-(*** define-output: mat2 ***)
 // Convert matrix back to a frame with named rows and columns
 Frame.ofMatrix [1;2;3] ["A";"B";"C"] m
-(*** include-it: mat2 ***)
+(*** include-it ***)
 
 (**
 Series ↔ Vector works the same way:
 *)
 
-(*** define-output: vec1 ***)
 let s = series [ "x" => 1.0; "y" => 2.0; "z" => 3.0 ]
 let v : Vector<float> = Series.toVector s
 v
-(*** include-it: vec1 ***)
+(*** include-it ***)
 
-(*** define-output: vec2 ***)
 Series.ofVector ["x";"y";"z"] v
-(*** include-it: vec2 ***)
+(*** include-it ***)
 
 (**
 
@@ -124,16 +120,14 @@ directly. All operations convert to/from `Matrix<float>` internally.
 
 *)
 
-(*** define-output: la1 ***)
 // Transpose (faster than generic Frame.transpose for numeric frames)
 LinearAlgebra.transpose df
-(*** include-it: la1 ***)
+(*** include-it ***)
 
-(*** define-output: la2 ***)
 // Matrix inverse
 let sq = frame [ "A" => series [1=>4.0;2=>7.0]; "B" => series [1=>3.0;2=>6.0] ]
 LinearAlgebra.inverse sq
-(*** include-it: la2 ***)
+(*** include-it ***)
 
 (**
 Other available operations:
@@ -171,20 +165,17 @@ from MathNet.Numerics.
 let air = Frame.ReadCsv(root + "airquality.csv", separators=";")
 let ozone = air?Ozone |> Series.dropMissing
 
-(*** define-output: q1 ***)
 // Median (uses MathNet's exact median algorithm)
 Stats.median ozone
-(*** include-it: q1 ***)
+(*** include-it ***)
 
-(*** define-output: q2 ***)
 // 25th and 75th percentile
 Stats.quantile(ozone, 0.25), Stats.quantile(ozone, 0.75)
-(*** include-it: q2 ***)
+(*** include-it ***)
 
-(*** define-output: q3 ***)
 // Ranks (average rank for ties by default)
 ozone |> Stats.ranks |> Series.take 6
-(*** include-it: q3 ***)
+(*** include-it ***)
 
 (**
 All three functions also work on entire frames:
@@ -208,20 +199,17 @@ Stats.quantile(air, 0.90)
 // Use a small subset of air quality numeric columns
 let numAir = air |> Frame.sliceCols ["Ozone";"Solar.R";"Wind";"Temp"] |> Frame.dropSparseRows
 
-(*** define-output: corr1 ***)
 // Pearson correlation matrix (default)
 Stats.corr numAir
-(*** include-it: corr1 ***)
+(*** include-it ***)
 
-(*** define-output: corr2 ***)
 // Spearman rank correlation
 Stats.corr(numAir, CorrelationMethod.Spearman)
-(*** include-it: corr2 ***)
+(*** include-it ***)
 
-(*** define-output: cov1 ***)
 // Covariance frame
 Stats.cov numAir
-(*** include-it: cov1 ***)
+(*** include-it ***)
 
 (**
 To correlate two individual series:
@@ -263,15 +251,13 @@ parameters:
 let returns =
   series [ for i in 1..20 -> i => Math.Sin(float i * 0.3) * 0.02 ]
 
-(*** define-output: ewm1 ***)
 // EWM mean with span=5
 Stats.ewmMean(returns, span=5.0)
-(*** include-it: ewm1 ***)
+(*** include-it ***)
 
-(*** define-output: ewm2 ***)
 // EWM mean on a whole frame (applied column by column)
 Stats.ewmMean(numAir, span=10.0)
-(*** include-it: ewm2 ***)
+(*** include-it ***)
 
 (**
 
@@ -305,10 +291,9 @@ let prices =
 
 let dailyReturns = prices.Diff(1) / prices.Shift(1)
 
-(*** define-output: fin1 ***)
 // Mean-corrected EWM volatility (standard deviation form) with half-life of 10 days
 Finance.ewmVolStdDev(dailyReturns, halfLife=10.0)
-(*** include-it: fin1 ***)
+(*** include-it ***)
 
 (**
 
@@ -354,16 +339,14 @@ eigen vectors in descending order of explained variance.
 // Use the numeric air quality columns
 let normed = PCA.normalizeColumns numAir
 
-(*** define-output: pca1 ***)
 let result = PCA.pca numAir
 // Eigen values (proportion of variance explained by each PC)
 result.EigenValues
-(*** include-it: pca1 ***)
+(*** include-it ***)
 
-(*** define-output: pca2 ***)
 // Eigen vectors (loadings): rows = original variables, columns = PC1, PC2, …
 result.EigenVectors
-(*** include-it: pca2 ***)
+(*** include-it ***)
 
 (**
 
@@ -395,20 +378,17 @@ The returned `Fit.t` record provides:
 
 let fit = LinearRegression.ols ["Solar.R"; "Wind"; "Temp"] "Ozone" true numAir
 
-(*** define-output: reg1 ***)
 // Regression coefficients (Intercept, Solar.R, Wind, Temp)
 LinearRegression.Fit.coefficients fit
-(*** include-it: reg1 ***)
+(*** include-it ***)
 
-(*** define-output: reg2 ***)
 // Fitted values (ŷ)
 LinearRegression.Fit.fittedValues fit |> Series.take 6
-(*** include-it: reg2 ***)
+(*** include-it ***)
 
-(*** define-output: reg3 ***)
 // Residuals (y − ŷ)
 LinearRegression.Fit.residuals fit |> Series.take 6
-(*** include-it: reg3 ***)
+(*** include-it ***)
 
 (**
 

--- a/docs/math.fsx
+++ b/docs/math.fsx
@@ -26,6 +26,13 @@ open Deedle
 open Deedle.Math
 open MathNet.Numerics.LinearAlgebra
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 let root = __SOURCE_DIRECTORY__ + "/data/"
 
 (**

--- a/docs/missing.fsx
+++ b/docs/missing.fsx
@@ -44,30 +44,26 @@ values are automatically treated as missing:
 
 The following examples show series created from inputs that include missing values:
 *)
-(*** define-output:miss1 ***)
 // float NaN becomes a missing value
 Series.ofValues [ 1.0; Double.NaN; 3.0 ]
-(*** include-it:miss1 ***)
+(*** include-it ***)
 
-(*** define-output:miss2 ***)
 // null in a reference-type series
 Series.ofValues [ "a"; null; "c" ]
-(*** include-it:miss2 ***)
+(*** include-it ***)
 
-(*** define-output:miss3 ***)
 // Nullable<int> without a value
 [ Nullable(1); Nullable(); Nullable(3) ] |> Series.ofValues
-(*** include-it:miss3 ***)
+(*** include-it ***)
 
 (**
 You can also construct a series with explicit missing values using `None`:
 *)
-(*** define-output:miss4 ***)
 Series.ofOptionalObservations
   [ 1 => Some(10.0)
     2 => None
     3 => Some(30.0) ]
-(*** include-it:miss4 ***)
+(*** include-it ***)
 
 (**
 
@@ -81,20 +77,17 @@ is an alias. The total number of keys (including missing) is `KeyCount`:
 let air = Frame.ReadCsv(root + "airquality.csv", separators=";")
 let ozone = air?Ozone
 
-(*** define-output:cnt1 ***)
 // total keys (rows) in the series
 ozone.KeyCount
-(*** include-it:cnt1 ***)
+(*** include-it ***)
 
-(*** define-output:cnt2 ***)
 // present (non-missing) values
 Stats.count ozone
-(*** include-it:cnt2 ***)
+(*** include-it ***)
 
-(*** define-output:cnt3 ***)
 // number of missing values
 ozone.KeyCount - int (Stats.count ozone)
-(*** include-it:cnt3 ***)
+(*** include-it ***)
 
 (**
 
@@ -106,13 +99,11 @@ All functions in the `Stats` module, as well as common projections such as
 `Series.mapValues` and `Series.filter`, automatically skip missing values.
 The operation is applied only to present observations:
 *)
-(*** define-output:stat1 ***)
 Stats.mean ozone      // mean of the 116 present values
-(*** include-it:stat1 ***)
+(*** include-it ***)
 
-(*** define-output:stat2 ***)
 Stats.max ozone       // maximum of the present values
-(*** include-it:stat2 ***)
+(*** include-it ***)
 
 (**
 
@@ -123,19 +114,17 @@ Stats.max ozone       // maximum of the present values
 The safe way to look up a single value by key is `TryGet`, which returns an
 `OptionalValue<'T>`:
 *)
-(*** define-output:tryget ***)
 let v = ozone.TryGet(1)
 match v with
 | OptionalValue.Present x -> sprintf "present: %g" x
 | OptionalValue.Missing   -> "missing"
-(*** include-it:tryget ***)
+(*** include-it ***)
 
 (**
 You can also use `Series.observationsAll` to iterate over all key-value pairs
 including missing ones (as `option`), or `Series.observations` to skip
 missing values:
 *)
-(*** define-output:obsall ***)
 ozone
 |> Series.observationsAll
 |> Seq.truncate 6
@@ -144,7 +133,7 @@ ozone
     | Some x -> sprintf "%d => %g" k x
     | None   -> sprintf "%d => <missing>" k)
 |> Seq.toList
-(*** include-it:obsall ***)
+(*** include-it ***)
 
 (**
 
@@ -156,14 +145,13 @@ ozone
 **or** the missing-ness of each element, use `Series.mapAll`, which receives an
 `option<'T>` for each key:
 *)
-(*** define-output:mapall ***)
 ozone
 |> Series.mapAll (fun k v ->
     match v with
     | None   -> Some 0.0     // replace missing with zero
     | Some x -> Some (x * 2.0)) // double present values
 |> Series.take 5
-(*** include-it:mapall ***)
+(*** include-it ***)
 
 (**
 
@@ -175,9 +163,8 @@ ozone
 
 The simplest strategy replaces every missing value with a fixed constant:
 *)
-(*** define-output:fill1 ***)
 ozone |> Series.fillMissingWith 0.0 |> Series.take 6
-(*** include-it:fill1 ***)
+(*** include-it ***)
 
 (**
 ### Forward and backward fill
@@ -185,15 +172,13 @@ ozone |> Series.fillMissingWith 0.0 |> Series.take 6
 `Series.fillMissing` propagates the most recent available value in the
 specified direction:
 *)
-(*** define-output:fill2 ***)
 // Carry the last known value forward
 ozone |> Series.fillMissing Direction.Forward |> Series.take 6
-(*** include-it:fill2 ***)
+(*** include-it ***)
 
-(*** define-output:fill3 ***)
 // Fill from the next available value backward
 ozone |> Series.fillMissing Direction.Backward |> Series.take 6
-(*** include-it:fill3 ***)
+(*** include-it ***)
 
 (**
 ### Custom fill strategy with `fillMissingUsing`
@@ -202,7 +187,6 @@ For interpolation or other context-sensitive strategies, use
 `Series.fillMissingUsing`. The function receives the missing key and should
 return a replacement value:
 *)
-(*** define-output:fillcustom ***)
 ozone
 |> Series.fillMissingUsing (fun k ->
     // Linear interpolation from neighbours
@@ -214,7 +198,7 @@ ozone
     | _, OptionalValue.Present v -> v
     | _ -> 0.0)
 |> Series.take 6
-(*** include-it:fillcustom ***)
+(*** include-it ***)
 
 (**
 ### Combining fill and drop
@@ -222,12 +206,11 @@ ozone
 Often the cleanest approach is to fill as much as possible in one direction
 and then discard the remaining missing values:
 *)
-(*** define-output:fillcombine ***)
 ozone
 |> Series.fillMissing Direction.Forward
 |> Series.dropMissing
 |> Series.countValues
-(*** include-it:fillcombine ***)
+(*** include-it ***)
 
 (**
 
@@ -239,9 +222,8 @@ ozone
 
 `Series.dropMissing` removes all missing observations from a series:
 *)
-(*** define-output:drop1 ***)
 ozone |> Series.dropMissing |> Series.countValues
-(*** include-it:drop1 ***)
+(*** include-it ***)
 
 (**
 ### Drop sparse rows and columns from a frame
@@ -252,15 +234,13 @@ value; `Frame.dropSparseCols` removes columns with any missing value.
 After reading the air quality CSV the frame has missing values in several
 columns:
 *)
-(*** define-output:sparse1 ***)
 air.RowCount
-(*** include-it:sparse1 ***)
+(*** include-it ***)
 
-(*** define-output:sparse2 ***)
 // Keep only rows that are fully observed
 let airComplete = air |> Frame.dropSparseRows
 airComplete.RowCount
-(*** include-it:sparse2 ***)
+(*** include-it ***)
 
 (**
 
@@ -271,34 +251,31 @@ airComplete.RowCount
 The same filling functions are available at the frame level and operate
 column-by-column:
 *)
-(*** define-output:framefill1 ***)
 // Fill every missing cell with 0.0
 air
 |> Frame.fillMissingWith 0.0
 |> Frame.dropSparseRows   // now no rows should be dropped
 |> fun f -> f.RowCount
-(*** include-it:framefill1 ***)
+(*** include-it ***)
 
-(*** define-output:framefill2 ***)
 // Forward-fill each column independently
 air
 |> Frame.fillMissing Direction.Forward
 |> Frame.dropSparseRows
 |> fun f -> f.RowCount
-(*** include-it:framefill2 ***)
+(*** include-it ***)
 
 (**
 `Frame.fillMissingUsing` accepts a function `Series<'R,'T> -> 'R -> 'T` so it
 can base the fill value on the whole column series:
 *)
-(*** define-output:framefillcol ***)
 air
 |> Frame.fillMissingUsing (fun col key ->
     // Fill with that column's mean
     Stats.mean col)
 |> Frame.dropSparseRows
 |> fun f -> f.RowCount
-(*** include-it:framefillcol ***)
+(*** include-it ***)
 
 (**
 
@@ -321,17 +298,15 @@ which rows are retained:
 let s1 = series [ 1 => 10.0; 2 => 20.0; 3 => 30.0 ]
 let s2 = series [ 2 => 200.0; 3 => 300.0; 4 => 400.0 ]
 
-(*** define-output:join1 ***)
 // Outer join introduces missing values for key 1 (not in s2) and key 4 (not in s1)
 Frame.ofColumns ["A" => s1; "B" => s2]
-(*** include-it:join1 ***)
+(*** include-it ***)
 
-(*** define-output:join2 ***)
 // Inner join keeps only keys present in both
 let f1 = frame ["A" => s1]
 let f2 = frame ["B" => s2]
 f1.Join(f2, JoinKind.Inner)
-(*** include-it:join2 ***)
+(*** include-it ***)
 
 (**
 After an outer join, `Frame.dropSparseRows` or `Frame.fillMissing` can be

--- a/docs/missing.fsx
+++ b/docs/missing.fsx
@@ -18,6 +18,13 @@ index: 9
 open System
 open Deedle
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 let root = __SOURCE_DIRECTORY__ + "/data/"
 
 (**

--- a/docs/series.fsx
+++ b/docs/series.fsx
@@ -24,6 +24,13 @@ open System
 open Deedle
 open MathNet.Numerics.Distributions
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 (**
 
 # Working with series and time series

--- a/docs/stats.fsx
+++ b/docs/stats.fsx
@@ -53,14 +53,13 @@ statistics. The following example creates a series (indexed by strings) that
 stores mean, extremes and median of the input series:
 *)
 
-(*** define-output: ozinfo ***)
 series [
   "Mean" => round (Stats.mean ozone)
   "Max" => Stats.max ozone
   "Min" => Stats.min ozone
   "Median" => Stats.median ozone ]
 
-(*** include-it: ozinfo ***)
+(*** include-it ***)
 
 (**
 To make the output simpler, we round the value of the mean (although the result is
@@ -77,7 +76,6 @@ Functions such as `Stats.mean` can be called on series, but also on entire data 
 In that case, they calculate the statistics for each column of a data frame and return
 `Series<'C, float>` where `'C` is the column key of the original frame. 
 *)
-(*** define-output: airinfo ***)
 let info = 
   [ "Min" => Stats.min air
     "Max" => Stats.max air
@@ -93,9 +91,8 @@ let info =
 The `Stats` type provides an efficient implementation of moving window statistics using
 an online algorithm. The moving window function names are prefixed with the word `moving`:
 *)
-(*** define-output:mvmozone ***)
 ozone |> Stats.movingMean 3
-(*** include-it:mvmozone ***)
+(*** include-it ***)
 
 (**
 Statistical moving functions (count, sum, mean, variance, standard deviation, skewness 
@@ -106,9 +103,8 @@ The boundary behavior of the functions that calculate minimum and maximum over a
 differs. Rather than returning _N/A_ for the first _n-1_ values, they return the extreme 
 value over a smaller window:
 *)
-(*** define-output:mvxozone ***)
 ozone |> Stats.movingMin 3
-(*** include-it:mvxozone ***)
+(*** include-it ***)
 
 (**
 <a name="exp"></a>
@@ -146,17 +142,15 @@ We can now access individual columns and calculate statistics over the
 first level (individual months) using functions prefixed with `level`:
 *)
 
-(*** define-output:lvlozone ***)
 byMonth?Ozone |> Stats.levelMean fst
-(*** include-it:lvlozone ***)
+(*** include-it ***)
 
-(*** define-output:lvlall ***)
 byMonth
 |> Frame.sliceCols ["Ozone";"Solar.R";"Wind";"Temp"]
 |> Frame.getNumericCols
 |> Series.mapValues (Stats.levelMean fst)
 |> Frame.ofRows
-(*** include-it:lvlall ***)
+(*** include-it ***)
 
 (**
 

--- a/docs/stats.fsx
+++ b/docs/stats.fsx
@@ -20,6 +20,13 @@ open System.Globalization
 open System.IO
 open Deedle
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 let root = __SOURCE_DIRECTORY__ + "/data/"
 
 (**

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -18,6 +18,13 @@ index: 2
 open System
 open Deedle
 
+fsi.AddPrinter(fun (o: obj) ->
+  let iface = o.GetType().GetInterface("IFsiFormattable")
+  if iface <> null then
+    let fmt = iface.GetMethod("Format")
+    fmt.Invoke(o, [||]) :?> string
+  else null)
+
 series [1 => 1.0; 2 => 2.0]
 (*** include-it ***)
 
@@ -92,7 +99,8 @@ the `first` series and another representing the `second` series:
 *)
 
 let df1 = Frame(["first"; "second"], [first; second])
-(*** include-value: df1 ***)
+df1
+(*** include-it ***)
 
 (** 
 The type representing a data frame has two generic parameters:
@@ -176,11 +184,11 @@ are not explicitly included in the index).
 // Use the Date column as the index & order rows
 let msftOrd = 
   msftCsv
-  |> Frame.indexRowsDate "Date"
+  |> Frame.indexRowsDateTime "Date"
   |> Frame.sortRowsByKey
 
 (**
-The `indexRowsDate` function uses a column of type `DateTime` as a new index.
+The `indexRowsDateTime` function uses a column of type `DateTime` as a new index.
 The library provides other functions for common types of indices (like `indexRowsInt`)
 and you can also use a generic function - when using the generic function, some 
 type annotations may be needed, so it is better to use a specific function.
@@ -202,7 +210,7 @@ msft?Difference <- msft?Open - msft?Close
 // Do the same thing for Facebook
 let fb = 
   fbCsv
-  |> Frame.indexRowsDate "Date"
+  |> Frame.indexRowsDateTime "Date"
   |> Frame.sortRowsByKey
   |> Frame.sliceCols ["Open"; "Close"]
 fb?Difference <- fb?Open - fb?Close

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -18,9 +18,8 @@ index: 2
 open System
 open Deedle
 
-(*** define-output: sanity ***)
 series [1 => 1.0; 2 => 2.0]
-(*** include-it: sanity ***)
+(*** include-it ***)
 
 (**
 
@@ -42,7 +41,6 @@ do not actually have to be strings). So, to create a data frame, we first need
 to create a series:
 *)
 
-(*** define-output: create1 ***)
 // Create from sequence of keys and sequence of values
 let dates  = 
   [ DateTime(2013,1,1); 
@@ -58,15 +56,14 @@ Series.ofObservations
     DateTime(2013,1,4) => 20.0
     DateTime(2013,1,8) => 30.0 ]
 
-(*** include-it: create1 ***)
+(*** include-it ***)
 
-(*** define-output: create2 ***)
 // Shorter alternative to 'Series.ofObservations'
 series [ 1 => 1.0; 2 => 2.0 ]
 
 // Create series with implicit (ordinal) keys
 Series.ofValues [ 10.0; 20.0; 30.0 ]
-(*** include-it: create2 ***)
+(*** include-it ***)
 
 (**
 Note that the series type is generic. `Series<K, T>` represents a series
@@ -86,9 +83,8 @@ let rand count =
 // A series with values for 10 days 
 let second = Series(dateRange (DateTime(2013,1,1)) 10, rand 10)
 
-(*** define-output: create3 ***)
 (round (second*100.0))/100.0
-(*** include-it: create3 ***)
+(*** include-it ***)
 
 (**
 Now we can easily construct a data frame that has two columns - one representing
@@ -96,10 +92,7 @@ the `first` series and another representing the `second` series:
 *)
 
 let df1 = Frame(["first"; "second"], [first; second])
-
-(*** define-output: frame1 ***)
-df1
-(*** include-it: frame1 ***)
+(*** include-it ***)
 
 (** 
 The type representing a data frame has two generic parameters:
@@ -295,12 +288,10 @@ with time component set to the current time:
 let daysSeries = Series(dateRange DateTime.Today 10, rand 10)
 let obsSeries = Series(dateRange DateTime.Now 10, rand 10)
 
-(*** define-output: days ***)
 (round (daysSeries*100.0))/100.0
-(*** include-it: days ***)
-(*** define-output: obs ***)
+(*** include-it ***)
 (round (obsSeries*100.0))/100.0
-(*** include-it: obs ***)
+(*** include-it ***)
 
 (**
 The indexing operation written as `daysSeries.[date]` uses _exact_ semantics so it will 

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -92,7 +92,7 @@ the `first` series and another representing the `second` series:
 *)
 
 let df1 = Frame(["first"; "second"], [first; second])
-(*** include-it ***)
+(*** include-value: df1 ***)
 
 (** 
 The type representing a data frame has two generic parameters:


### PR DESCRIPTION
Replace all `(*** define-output: name ***)` / `(*** include-it: name ***)` pairs with plain `(*** include-it ***)` across all doc .fsx files.

This is simpler and works correctly with fsdocs 22.0.0-alpha.2. Verified with `dotnet fsdocs build --noapidocs --eval` — zero errors.