### PR TITLE
Rewrite tutorial as a simpler Titanic-based quick start

### DIFF
--- a/docs/arrow.fsx
+++ b/docs/arrow.fsx
@@ -1,6 +1,6 @@
 (**
 ---
-title: Apache Arrow and Feather integration
+title: Deedle.Arrow — Apache Arrow and Feather integration
 category: Integrations
 categoryindex: 2
 index: 2
@@ -27,7 +27,7 @@ open Deedle.Arrow
 
 (**
 
-# Apache Arrow and Feather Integration
+# Deedle.Arrow — Apache Arrow and Feather Integration
 
 The `Deedle.Arrow` package adds first-class support for [Apache Arrow](https://arrow.apache.org/) —
 the industry-standard columnar in-memory format used by Python (`pyarrow`/`pandas`), R (`arrow`),

--- a/docs/csharp.md
+++ b/docs/csharp.md
@@ -7,7 +7,7 @@ description: Using Deedle data frames and series from C# with extension methods,
 keywords: C#, cookbook, extension methods, LINQ, interop
 ---
 
-# Deedle in C# — Cookbook
+# Deedle in C#
 
 Deedle is an F# library, but it exposes a fully usable C# API through .NET standard
 interfaces and extension methods. This page is a practical reference for C# developers.

--- a/docs/dotnetinteractive.fsx
+++ b/docs/dotnetinteractive.fsx
@@ -1,6 +1,6 @@
 (**
 ---
-title: .NET Interactive notebook formatting
+title: Deedle.DotNetInteractive — .NET Interactive notebook formatting
 category: Integrations
 categoryindex: 2
 index: 5
@@ -22,7 +22,7 @@ open Deedle
 
 (**
 
-# .NET Interactive Notebook Formatting
+# Deedle.DotNetInteractive — .NET Interactive Notebook Formatting
 
 The `Deedle.DotNetInteractive` package registers HTML formatters for Deedle frames and
 series in [.NET Interactive](https://github.com/dotnet/interactive) notebooks —

--- a/docs/excel.fsx
+++ b/docs/excel.fsx
@@ -1,6 +1,6 @@
 (**
 ---
-title: Excel integration
+title: Deedle.Excel.Reader — Excel integration
 category: Integrations
 categoryindex: 2
 index: 1
@@ -30,7 +30,7 @@ open Deedle.ExcelReader
 
 (**
 
-# Excel integration
+# Deedle.Excel.Reader — Excel integration
 
 Deedle provides two separate packages for working with Microsoft Excel files:
 

--- a/docs/excel.fsx
+++ b/docs/excel.fsx
@@ -154,7 +154,7 @@ frame:
 // Keep only the Revenue column and use Month as the row index
 let q1Indexed =
     q1
-    |> Frame.indexRows "Month"
+    |> Frame.indexRowsString "Month"
     |> Frame.sliceCols ["Revenue"]
 (*** include-it ***)
 
@@ -166,7 +166,7 @@ or `Frame.append`:
 *)
 let allRevenue =
     [q1; q2]
-    |> List.map (fun f -> f |> Frame.indexRows "Month")
+    |> List.map (fun f -> f |> Frame.indexRowsString "Month")
     |> List.reduce Frame.merge
 (*** include-it ***)
 

--- a/docs/frame.fsx
+++ b/docs/frame.fsx
@@ -1,6 +1,6 @@
 (**
 ---
-title: Working with data frames in F#
+title: Data frame features
 category: Guides
 categoryindex: 1
 index: 3
@@ -32,431 +32,324 @@ let root = __SOURCE_DIRECTORY__ + "/data/"
 
 (**
 
-# Working with data frames
+# Data frame features
 
-In this section, we look at various features of the F# data frame library (using both
-`Series` and `Frame` types and modules). Feel free to jump to the section you are interested
-in, but note that some sections refer back to values built in "Creating & loading".
+This page is a comprehensive reference for `Frame<'R,'C>` operations.
+If you are new to Deedle, start with the [quick start tutorial](tutorial.html)
+which introduces loading, filtering, grouping, and missing values
+using the Titanic data set.
 
-<a name="creating"></a>
+## Loading data
 
-## Creating frames & loading data
+### CSV files
 
-<a name="creating-csv"></a>
+`Frame.ReadCsv` loads CSV (and TSV) files. The most common usage is a
+single path, but it accepts many optional parameters:
 
-### Loading and saving CSV files
-
-The easiest way to get data into data frame is to use a CSV file. The `Frame.ReadCsv`
-function exposes this functionality:
+ * `path` — file path or URL
+ * `indexCol` — column to use as row index (the type is inferred from the type parameter)
+ * `inferTypes` — whether to auto-detect column types (default `true`)
+ * `inferRows` — number of rows used for type inference (default 100; 0 = all)
+ * `schema` — explicit CSV schema string
+ * `separators` — column separator characters (e.g. `";"`)
+ * `culture` — culture name for parsing (default invariant)
 *)
 
-// Assuming 'root' is a directory containing the file
 let titanic = Frame.ReadCsv(root + "titanic.csv")
 
-// Read data and set the index column & order rows
+// Use a typed index column and sort
 let msft = 
   Frame.ReadCsv(root + "stocks/msft.csv") 
   |> Frame.indexRowsDateTime "Date"
   |> Frame.sortRowsByKey
 
-// Specify column separator
+// Semicolon-separated file
 let air = Frame.ReadCsv(root + "airquality.csv", separators=";")
 
-(**
-In the second example, we call `indexRowsDate` to use the "Date" column as a row index
-of the resulting data frame. This is a very common scenario and so Deedle provides an
-easier option using a generic overload of the `ReadCsv` method:
-*)
+// Shorthand: specify index column via type parameter
 let msftSimpler = 
   Frame.ReadCsv<DateTime>(root + "stocks/msft.csv", indexCol="Date") 
   |> Frame.sortRowsByKey
 
 (**
-The `ReadCsv` method has a number of optional arguments that you can use to control 
-the loading. It supports both CSV files, TSV files and other formats. If the file name
-ends with `tsv`, the Tab is used automatically, but you can set `separator` explicitly.
-The following parameters can be used:
-
- * `path` - Specifies a file name or an web location of the resource.
- * `indexCol` - Specifies the column that should be used as an index in the 
-   resulting frame. The type is specified via a type parameter.
- * `inferTypes` - Specifies whether the method should attempt to infer types
-   of columns automatically (set this to `false` if you want to specify schema)
- * `inferRows` - If `inferTypes=true`, this parameter specifies the number of
-   rows to use for type inference. The default value is 100. Value 0 means all rows.
- * `schema` - A string that specifies CSV schema. See the documentation for 
-   information about the schema format.
- * `separators` - A string that specifies one or more (single character) separators
-   that are used to separate columns in the CSV file. Use for example `";"` to 
-   parse semicolon separated files.
- * `culture` - Specifies the name of the culture that is used when parsing 
-   values in the CSV file (such as `"en-US"`). The default is invariant culture. 
-
-Once you have a data frame, you can also save it to a CSV file using the 
-`SaveCsv` method. For example:
+### Saving CSV files
 *)
-// Save CSV with semicolon separator
+
+// Save with semicolon separator
 air.SaveCsv(Path.GetTempFileName(), separator=';')
-// Save as CSV and include row key as "Date" column
+
+// Include the row key as a column named "Date"
 msft.SaveCsv(Path.GetTempFileName(), keyNames=["Date"], separator='\t')
 
 (**
-By default, the `SaveCsv` method does not include the key from the data frame. This can be
-overridden by calling `SaveCsv` with the optional argument `includeRowKeys=true`, or with an
-additional argument `keyNames` (demonstrated above) which sets the headers for the key column(s)
-in the CSV file.
+By default `SaveCsv` omits the row key. Pass `includeRowKeys=true` or
+provide `keyNames` to include it.
 
-<a name="creating-recd"></a>
+### From F# records or .NET objects
 
-### Loading F# records or .NET objects
-
-If you have another .NET or F# components that returns data as a sequence of F# records,
-C# anonymous types or other .NET objects, you can use `Frame.ofRecords` to turn them
-into a data frame. Assume we have:
+`Frame.ofRecords` turns any sequence of records or objects into a frame,
+using public properties as columns:
 *)
+
 type Person = 
-  { Name:string; Age:int; Countries:string list; }
+  { Name: string; Age: int; Countries: string list }
 
 let peopleRecds = 
-  [ { Name = "Joe"; Age = 51; Countries = [ "UK"; "US"; "UK"] }
-    { Name = "Tomas"; Age = 28; Countries = [ "CZ"; "UK"; "US"; "CZ" ] }
-    { Name = "Eve"; Age = 2; Countries = [ "FR" ] }
-    { Name = "Suzanne"; Age = 15; Countries = [ "US" ] } ]
+  [ { Name = "Joe"; Age = 51; Countries = ["UK"; "US"; "UK"] }
+    { Name = "Tomas"; Age = 28; Countries = ["CZ"; "UK"; "US"; "CZ"] }
+    { Name = "Eve"; Age = 2; Countries = ["FR"] }
+    { Name = "Suzanne"; Age = 15; Countries = ["US"] } ]
+
+let people = 
+  Frame.ofRecords peopleRecds 
+  |> Frame.indexRowsString "Name"
+
+(*** include-value: people ***)
 
 (**
-Now we can easily create a data frame that contains three columns 
-(`Name`, `Age` and `Countries`) containing data of the same type as 
-the properties of `Person`:
-*)
-// Turn the list of records into data frame 
-let peopleList = Frame.ofRecords peopleRecds
-// Use the 'Name' column as a key (of type string)
-let people = peopleList |> Frame.indexRowsString "Name"
+### Expanding nested objects
 
-people?Age
-people.GetColumn<string list>("Countries")
-
-(**
-### Expanding objects in columns
-
-For frames that contain complex .NET objects as column values, you can use `Frame.expandCols`
-to create a new frame that contains properties of the object as new columns. For example: 
+If a column contains complex .NET objects, `Frame.expandCols` flattens
+their properties into new columns:
 *)
 
-// Create frame with single column 'People'
 let peopleNested = 
   [ "People" => Series.ofValues peopleRecds ] |> frame
 
-// Expand the 'People' column
 peopleNested |> Frame.expandCols ["People"]
 (*** include-it ***)
 
 (**
-<a name="dataframe"></a>
 
-## Manipulating data frames
+## Getting and setting data
 
-### Getting data from a frame
-*)
-(*** include-value:people ***)
-(**
-To get a column (series) from a frame `df`, you can use operations that are exposed directly
-by the data frame, or you can use `df.Columns` which returns all columns of the frame as a
-series of series.
+### Columns and rows
 *)
 
-// Get the 'Age' column as a series of 'float' values
+// Get column as float series (using ?)
 people?Age
-// Get the 'Countries' column as a series of 'string list' values
+
+// Get column with explicit type
 people.GetColumn<string list>("Countries")
-// Get all frame columns as a series of series
+
+// All columns as a series of series
 people.Columns
 
 (**
-### Adding rows and columns
-
-The series type is _immutable_ and so it is not possible to add new values to a series or 
-change the values stored in an existing series. However, you can use operations that return
-a new series as the result such as `Merge`.
+### Adding and replacing columns
 *)
 
-// Create series with more value
-let more = series [ "John" => 48.0 ]
-// Create a new, concatenated series
-people?Age.Merge(more)
+// Add a computed column
+people?AgePlusOne <- people?Age |> Series.mapValues ((+) 1.0)
 
-(**
-Data frame allows a very limited form of mutation. It is possible to add new series (as a column)
-to an existing data frame, drop a series or replace a series.
-*)
-// Calculate age + 1 for all people
-let add1 = people?Age |> Series.mapValues ((+) 1.0)
-
-// Add as a new series to the frame
-people?AgePlusOne <- add1
-
-// Add new series from a list of values
+// Add from a list (must match row count)
 people?Siblings <- [0; 2; 1; 3]
 
-// Replace existing series with new values
+// Replace an existing column
 people.ReplaceColumn("Siblings", [3; 2; 1; 0])
 
-// Create new object series with values for required columns
+(**
+### Adding rows
+*)
+
 let newRow = 
   [ "Name" => box "Jim"; "Age" => box 51;
     "Countries" => box ["US"]; "Siblings" => box 5 ]
   |> series
-// Create a new data frame, containing the new series
+
 people.Merge("Jim", newRow)
 
 (**
-<a name="slicing"></a>
 
-## Advanced slicing and lookup
+## Slicing and lookup
 
-Given a series, we have a number of options for getting one or more values or 
-observations from the series.
+### Indexing into series
 *)
 
-// Get an unordered sample series 
 let ages = people?Age
 
-// Returns value for a given key
+// Single key
 ages.["Tomas"]
-// Returns series with two keys from the source
+
+// Multiple keys
 ages.[ ["Tomas"; "Joe"] ]
 
-// Returns 'None' when key is not present
+// Safe lookup (returns None for missing keys)
 ages |> Series.tryGet "John"
-// Returns series with missing value for 'John'
+
+// Series that may contain missing values for unknown keys
 ages |> Series.getAll [ "Tomas"; "John" ]
 
 (**
-We can also obtain all data from the series. The data frame library uses the
-term _observations_ for all key-value pairs:
+### Iterating observations
 *)
 
-// Get all observations as a sequence of tuples
+// All key-value pairs
 ages |> Series.observations
-// Get all observations, with 'None' for missing values
+
+// Including missing values as None
 ages |> Series.observationsAll
 
 (**
-With ordered series, we can use slicing to get a sub-range:
+### Slicing ordered series by range
 *)
 
 let opens = msft?Open
 opens.[DateTime(2013, 1, 1) .. DateTime(2013, 1, 31)]
 |> Series.mapKeys (fun k -> k.ToShortDateString())
-
 (*** include-it ***)
 
 (**
-<a name="grouping"></a>
 
-## Grouping data
+## Grouping and aggregation
 
-### Grouping series
+The [quick start tutorial](tutorial.html) shows basic `Frame.groupRowsByString`,
+`Frame.aggregateRowsBy`, and `Frame.pivotTable`. This section covers deeper
+features: hierarchical keys, `Frame.nest`/`Frame.unnest`, and multi-level
+aggregation.
+
+### Hierarchical (multi-level) keys
+
+Grouping produces tuple keys treated as a hierarchical index:
 *)
-let travels = people.GetColumn<string list>("Countries")
 
-// Group by name length (ignoring visited countries)
-travels |> Series.groupBy (fun k v -> k.Length)
-// Group by visited countries (people visited/not visited US)
-travels |> Series.groupBy (fun k v -> List.exists ((=) "US") v)
+// Group MSFT stock prices by decade
+let decades = msft |> Frame.groupRowsUsing (fun k _ -> 
+  sprintf "%d0s" (k.Year / 10))
 
-// Group by name length and get number of values in each group
-travels |> Series.groupInto 
-  (fun k v -> k.Length) 
-  (fun len people -> Series.countKeys people)
+// Mean Close price per decade
+decades?Close |> Stats.levelMean fst
+(*** include-it ***)
 
-travels
-|> Series.mapValues (Seq.countBy id >> series)
-|> Frame.ofRows
-|> Frame.fillMissingWith 0
-
+// Means for all numeric columns
+decades
+|> Frame.getNumericCols
+|> Series.mapValues (Stats.levelMean fst)
+|> Frame.ofColumns
 (*** include-it ***)
 
 (**
-### Grouping data frames
+### Multi-level grouping
 *)
 
-// Group using column 'Sex' of type 'string'
-titanic |> Frame.groupRowsByString "Sex"
-
-// Group using calculated value - length of name
-titanic |> Frame.groupRowsUsing (fun k row -> 
-  row.GetAs<string>("Name").Length)
-
-let bySex = titanic |> Frame.groupRowsByString "Sex" 
-// Returns series with two frames as values
-let bySex1 = bySex |> Frame.nest
-// Converts unstacked data back to a single frame
-let bySex2 = bySex |> Frame.nest |> Frame.unnest
-
-// Group by passanger class and port
+// Group Titanic by class then port of embarkation
 let byClassAndPort = 
   titanic
   |> Frame.groupRowsByInt "Pclass"
   |> Frame.groupRowsByString "Embarked"
   |> Frame.mapRowKeys Pair.flatten3
 
-// Get average ages in each group
+// Average age per (Embarked, Pclass) group
 byClassAndPort?Age
 |> Stats.levelMean Pair.get1And2Of3
+(*** include-it ***)
 
-// Averages for all numeric columns
-byClassAndPort
-|> Frame.getNumericCols
-|> Series.dropMissing
-|> Series.mapValues (Stats.levelMean Pair.get1And2Of3)
-|> Frame.ofColumns
-
-// Count number of survivors in each group
+// Survival counts per group
 byClassAndPort.GetColumn<bool>("Survived")
 |> Series.applyLevel Pair.get1And2Of3 (Series.values >> Seq.countBy id >> series)
 |> Frame.ofRows
+(*** include-it ***)
+
+(**
+### Nesting and unnesting
+
+`Frame.nest` splits a grouped frame into a series of sub-frames;
+`Frame.unnest` reverses this:
+*)
+
+let bySex = titanic |> Frame.groupRowsByString "Sex"
+let nested = bySex |> Frame.nest      // Series of frames
+let flat = nested |> Frame.unnest     // Back to single frame
 
 (**
 
-### Aggregating by columns with `Frame.aggregateRowsBy`
-
-`Frame.aggregateRowsBy` provides a convenient way to group by one or more columns and
-apply an aggregation function to other columns — similar to SQL `GROUP BY … SELECT aggregate`.
-
-The first argument specifies the grouping columns; the second specifies the columns to
-aggregate; the third is the aggregation function to apply to each group series:
+### Grouping series
 *)
 
-// Average fare by Pclass and Sex
+let travels = people.GetColumn<string list>("Countries")
+
+// Country visit frequency per person, as a frame
+travels
+|> Series.mapValues (Seq.countBy id >> series)
+|> Frame.ofRows
+|> Frame.fillMissingWith 0
+(*** include-it ***)
+
+(**
+### aggregateRowsBy
+
+`Frame.aggregateRowsBy` is Deedle's equivalent of SQL
+`GROUP BY … SELECT aggregate(col)`:
+*)
+
 titanic
 |> Frame.aggregateRowsBy ["Pclass"; "Sex"] ["Fare"] Stats.mean
 (*** include-it ***)
 
-// Count survivors (sum of bool-as-int) and average age per Pclass
 titanic
 |> Frame.aggregateRowsBy ["Pclass"] ["Age"] Stats.mean
 (*** include-it ***)
 
 (**
-<a name="pivot"></a>
+### Pivot tables
 
-## Summarizing data with pivot table
-
-A pivot table is a useful tool if you want to summarize data in the frame based
-on two keys that are available in the rows of the data frame. 
+Cross-tabulate two categorical variables with an aggregation function:
 *)
 
+// Passenger counts by Sex × Survived
 titanic 
 |> Frame.pivotTable 
-    // Returns a new row key
     (fun k r -> r.GetAs<string>("Sex")) 
-    // Returns a new column key
     (fun k r -> r.GetAs<bool>("Survived")) 
-    // Specifies aggregation for sub-frames
     Frame.countRows 
-
 (*** include-it ***)
 
+// Mean age by Sex × Survived
 titanic 
 |> Frame.pivotTable 
     (fun k r -> r.GetAs<string>("Sex")) 
     (fun k r -> r.GetAs<bool>("Survived")) 
     (fun frame -> frame?Age |> Stats.mean)
 |> round
-
 (*** include-it ***)
 
 (**
-<a name="indexing"></a>
-
-## Hierarchical indexing
-
-### Grouping and aggregating
-
-Hierarchical keys are often created as a result of grouping. For example, we can group
-the rows (representing individual years) by decades:
-*)
-let decades = msft |> Frame.groupRowsUsing (fun k _ -> 
-  sprintf "%d0s" (k.Year / 10))
-
-// Calculate means per decade for the Close column
-decades?Close |> Stats.levelMean fst
-
-// Calculate means per decade for all numeric columns
-decades
-|> Frame.getNumericCols
-|> Series.mapValues (Stats.levelMean fst)
-|> Frame.ofColumns
-
-(**
-<a name="missing"></a>
 
 ## Handling missing values
 
-The support for missing values is built-in, which means that any series or frame can
-contain missing values. When constructing series or frames from data, certain values
-are automatically treated as "missing values". This includes `Double.NaN`, `null` values
-for reference types and for nullable types:
+The [quick start](tutorial.html) covers `fillMissingWith`, `fillMissing`, and `dropMissing`.
+This section shows how missing values arise and the more advanced `fillMissingUsing` strategy.
+
+### How missing values arise
+
+`Double.NaN`, `null`, and empty `Nullable<T>` are all treated as missing:
 *)
+
 Series.ofValues [ Double.NaN; 1.0; 3.14 ]
-
 (*** include-it ***)
 
-[ Nullable(1); Nullable(); Nullable(3) ]
-|> Series.ofValues
-
+[ Nullable(1); Nullable(); Nullable(3) ] |> Series.ofValues
 (*** include-it ***)
 
 (**
-Missing values are automatically skipped when performing statistical computations such
-as `Series.mean`. They are also ignored by projections and filtering, including
-`Series.mapValues`. When you want to handle missing values, you can use `Series.mapAll` 
-that gets the value as `option<T>`:
+### Custom fill with interpolation
+
+`Series.fillMissingUsing` calls a function for each missing key, enabling
+strategies like linear interpolation:
 *)
 
-// Get column with missing values
-let ozone = air?Ozone 
+let ozone = air?Ozone
 
-// Replace missing values with zeros
-ozone |> Series.mapAll (fun k v -> 
-  match v with None -> Some 0.0 | v -> v)
-
-// Fill missing values with constant
-ozone |> Series.fillMissingWith 0.0
-
-// Available values are copied in backward 
-// direction to fill missing values
-ozone |> Series.fillMissing Direction.Backward
-
-// Available values are propagated forward
-ozone |> Series.fillMissing Direction.Forward
-
-// Fill values and drop those that could not be filled
-ozone |> Series.fillMissing Direction.Forward
-      |> Series.dropMissing
-
-(**
-Various other strategies for handling missing values are not currently directly 
-supported by the library, but can be easily added using `Series.fillMissingUsing`.
-It takes a function and calls it on all missing values:
-*)
-
-// Fill missing values using interpolation function
 ozone |> Series.fillMissingUsing (fun k -> 
-  // Get previous and next values
   let prev = ozone.TryGet(k, Lookup.ExactOrSmaller)
   let next = ozone.TryGet(k, Lookup.ExactOrGreater)
-  // Pattern match to check which values were available
   match prev, next with 
-  | OptionalValue.Present(p), OptionalValue.Present(n) -> 
-      (p + n) / 2.0
+  | OptionalValue.Present(p), OptionalValue.Present(n) -> (p + n) / 2.0
   | OptionalValue.Present(v), _ 
   | _, OptionalValue.Present(v) -> v
   | _ -> 0.0)
 
 (**
-For a comprehensive reference covering `OptionalValue`, sentinel types, all fill strategies,
-and how missing values interact with joins and statistics, see the dedicated
-[Handling missing values](missing.html) page.
+For the full missing-value reference (sentinel types, all fill strategies,
+interaction with joins), see [Handling missing values](missing.html).
 *)

--- a/docs/math.fsx
+++ b/docs/math.fsx
@@ -43,7 +43,7 @@ let root = __SOURCE_DIRECTORY__ + "/data/"
 
 `Deedle.Math` is a separate NuGet package that extends Deedle with linear algebra,
 advanced statistics, PCA, and financial time-series functions via the
-[MathNet.Numerics](https://numerics.mathnetchr.net) library.
+[MathNet.Numerics](https://numerics.mathdotnet.com/) library.
 
 ## Installation
 

--- a/docs/parquet.fsx
+++ b/docs/parquet.fsx
@@ -1,6 +1,6 @@
 (**
 ---
-title: Apache Parquet integration
+title: Deedle.Parquet — Apache Parquet integration
 category: Integrations
 categoryindex: 2
 index: 3
@@ -27,7 +27,7 @@ open Deedle.Parquet
 
 (**
 
-# Apache Parquet Integration
+# Deedle.Parquet — Apache Parquet Integration
 
 The `Deedle.Parquet` package adds support for [Apache Parquet](https://parquet.apache.org/) —
 a columnar storage format optimised for analytics workloads. Parquet files are widely used by

--- a/docs/series.fsx
+++ b/docs/series.fsx
@@ -1,10 +1,10 @@
 (**
 ---
-title: Working with series and time series data in F#
+title: Series and time series features
 category: Guides
 categoryindex: 1
 index: 4
-description: Creating and manipulating ordered and unordered series, time-series sampling, and windowing
+description: Ordered series, time-series alignment, windowing, chunking, resampling, and arithmetic
 keywords: series, time series, sampling, windowing, resampling, F#
 ---
 *)
@@ -35,65 +35,52 @@ fsi.AddPrinter(fun (o: obj) ->
 
 (**
 
-# Working with series and time series
+# Series and time series features
 
-In this section, we look at F# data frame library features that are useful when working
-with time series data or, more generally, any ordered series. Although we mainly look at
-operations on the `Series` type, many of the operations can be applied to data frame `Frame`
-containing multiple series. Furthermore, data frame provides an elegant way for aligning and
-joining series. 
+This page covers features for working with ordered series and time series —
+alignment, windowing, chunking, resampling, and arithmetic operators.
+For basic series and frame operations, see the [quick start](tutorial.html).
+For frame-specific features, see [data frames](frame.html).
 
-## Generating input data
+## Sample data
 
-For the purpose of this tutorial, we'll need some input data. We use a function which generates
-random prices using the geometric Brownian motion.
+We generate random stock-like prices to demonstrate time series operations.
+The function below uses geometric Brownian motion:
 *)
 
-/// Generates price using geometric Brownian motion
-///  - 'seed' specifies the seed for random number generator
-///  - 'drift' and 'volatility' set properties of the price movement
-///  - 'initial' and 'start' specify the initial price and date
-///  - 'span' specifies time span between individual observations
-///  - 'count' is the number of required values to generate
-let randomPrice seed drift volatility initial start span count = 
+/// Generate random prices with geometric Brownian motion
+let randomPrice seed drift volatility initial (start: DateTimeOffset) (span: TimeSpan) count = 
   let dist = Normal(0.0, 1.0, RandomSource=Random(seed))  
-  let dt = (span:TimeSpan).TotalDays / 250.0
+  let dt = span.TotalDays / 250.0
   let driftExp = (drift - 0.5 * pown volatility 2) * dt
   let randExp = volatility * (sqrt dt)
-  ((start:DateTimeOffset), initial) |> Seq.unfold (fun (dt, price) ->
+  (start, initial) |> Seq.unfold (fun (dt, price) ->
     let price = price * exp (driftExp + randExp * dist.Sample()) 
     Some((dt, price), (dt + span, price))) |> Seq.take count
 
-// 12:00 AM today, in current time zone
 let today = DateTimeOffset(DateTime.Today)
 let stock1 = randomPrice 1 0.1 3.0 20.0 today 
 let stock2 = randomPrice 2 0.2 1.5 22.0 today
 
 (**
-To get random prices, we now only need to call `stock1` or `stock2` with `TimeSpan` and 
-the required number of prices.
+Call `stock1` or `stock2` with a `TimeSpan` and count to get prices
+at different intervals.
 
-<a name="alignment"></a>
+## Alignment and zipping
 
-## Data alignment and zipping
-
-One of the key features of the data frame library for working with time series data is 
-_automatic alignment_ based on the keys. When we have multiple time series with date 
-as the key (here, we use `DateTimeOffset`), we can combine multiple series and align 
-them automatically to specified date keys.
-
-To demonstrate this feature, we generate random prices in 60 minute, 30 minute and 
-65 minute intervals:
+A key time series feature is _automatic alignment_ — combining series
+with different keys, matching by key or nearest available value.
 *)
 
+// Hourly, half-hourly, and 65-minute series
 let s1 = stock1 (TimeSpan(1, 0, 0)) 6 |> series
 let s2 = stock2 (TimeSpan(0, 30, 0)) 12 |> series
 let s3 = stock1 (TimeSpan(1, 5, 0)) 6 |> series
 
 (**
-### Zipping time series 
+### Zipping series
 
-A series exposes `Zip` operation that can combine multiple series into a single series of pairs.
+`Zip` combines two series into a series of pairs, with configurable alignment:
 *)
 // Match values from right series to keys of the left one
 s1.Zip(s2, JoinKind.Left)
@@ -107,8 +94,7 @@ s1.Zip(s2, JoinKind.Left, Lookup.ExactOrSmaller)
 (**
 ### Joining data frames
 
-When we store data in data frames, we can simply use a data frame with multiple columns
-instead of series of tuples. Let's first create three data frames:
+The same alignment works at frame level via `Join`:
 *)
 
 // Contains value for each hour
@@ -127,18 +113,17 @@ f2.Join(f3, JoinKind.Inner)
 // Take keys from the left frame and find nearest smaller value from the right frame
 f2.Join(f3, JoinKind.Left, Lookup.ExactOrSmaller)
 
-// Equivalent using function syntax 
+// Function syntax equivalents
 Frame.join JoinKind.Outer f1 f2
 Frame.joinAlign JoinKind.Left Lookup.ExactOrSmaller f1 f2
 
 (**
-<a name="windowing"></a>
+For more on joins, see [Joining and merging](joining.html).
 
-## Windowing, chunking and pairwise
+## Windowing, chunking, and pairwise
 
-Windowing and chunking are two operations on ordered series that allow aggregating
-the values of series into groups. Both of these operations work on consecutive elements,
-which contrasts with [grouping](tutorial.html#grouping) that does not use order.
+These operations aggregate _consecutive_ elements — unlike grouping, they
+rely on ordering.
 
 ### Sliding windows
 *)
@@ -146,36 +131,26 @@ which contrasts with [grouping](tutorial.html#grouping) that does not use order.
 // Create input series with 6 observations
 let lf = stock1 (TimeSpan(0, 1, 0)) 6 |> series
 
-// Create series of series representing individual windows
+// Sliding windows of size 4
 lf |> Series.window 4
-// Aggregate each window using 'Stats.mean'
+// Aggregate each window
 lf |> Series.windowInto 4 Stats.mean
-// Get first value in each window
+// First value of each window
 lf |> Series.windowInto 4 Series.firstValue
 
 (**
-The functions above create windows of size 4 that move from the left to right.
-Given input `[1,2,3,4,5,6]`, this produces the following three windows:
-`[1,2,3,4]`, `[2,3,4,5]` and `[3,4,5,6]`. 
+Given input `[1,2,3,4,5,6]`, windows of size 4 produce:
+`[1,2,3,4]`, `[2,3,4,5]`, `[3,4,5,6]`.
 
-> **Performance note:** `Series.windowInto` materialises each window as a full series
-> before calling the aggregation function. This gives O(n × window) time and allocation.
-> When computing rolling statistics (mean, standard deviation, variance, etc.), prefer the
-> dedicated `Stats.moving*` functions (e.g. `Stats.movingMean`, `Stats.movingStd`), which
-> use an online algorithm and run in O(n) time:
+> **Performance tip:** For rolling statistics, prefer the dedicated `Stats.moving*`
+> functions which use O(n) online algorithms instead of materialising each window:
 >
->     // Fast – O(n) online algorithm
->     lf |> Stats.movingMean 4
+>     lf |> Stats.movingMean 4     // fast
+>     lf |> Series.windowInto 4 Stats.mean  // slow
 >
->     // Slow – O(n × window), allocates a series per step
->     lf |> Series.windowInto 4 Stats.mean
->
-> See the [Statistics documentation](stats.html#moving) for the full list of `Stats.moving*`
-> and `Stats.expanding*` functions.
+> See [Statistics](stats.html) for the full list.
 
-What if we want to avoid creating `<missing>` values? One approach is to 
-specify that we want to generate windows of smaller sizes at the beginning 
-or at the end. This way, we get _incomplete_ windows at the boundary:
+Incomplete windows at the boundary avoid missing values:
 *)
 let lfm2 = 
   // Create sliding windows with incomplete windows at the beginning
@@ -185,8 +160,7 @@ let lfm2 =
 Frame.ofColumns [ "Orig" => lf; "Means" => lfm2 ]
 
 (**
-In the previous sample, the code that performs aggregation is a lambda that takes `ds`,
-which is of type `DataSegment<T>`. This type informs us whether the window is complete or not:
+The `DataSegment<T>` type tells you whether a window is `Complete` or `Incomplete`:
 *)
 
 // Simple series with characters
@@ -202,10 +176,7 @@ st |> Series.windowSizeInto (3, Boundary.AtEnding) (function
 (**
 ### Window size conditions
 
-There are two other options for specifying when a window ends. 
-
- - Specify the maximal _distance_ between the first and the last key
- - Specify a function that is called with the first and the last key; a window ends when it returns false.
+Windows can also end based on key distance or a predicate:
 *)
 // Generate prices for each hour over 30 days
 let hourly = stock1 (TimeSpan(1, 0, 0)) (30*24) |> series
@@ -217,10 +188,9 @@ hourly |> Series.windowDist (TimeSpan(24, 0, 0))
 hourly |> Series.windowWhile (fun d1 d2 -> d1.Date = d2.Date)
 
 (**
-### Chunking series
+### Chunking
 
-Chunking is similar to windowing, but it creates non-overlapping chunks, 
-rather than (overlapping) sliding windows:
+Chunking creates _non-overlapping_ groups (unlike overlapping windows):
 *)
 
 // Generate per-second observations over 10 minutes
@@ -237,10 +207,9 @@ hf |> Series.chunkWhile (fun k1 k2 ->
   (k1.Hour, k1.Minute) = (k2.Hour, k2.Minute))
 
 (**
-### Pairwise 
+### Pairwise
 
-A special form of windowing is building a series of pairs containing a current
-and previous value from the input series:
+Build pairs of consecutive values — useful for computing returns or differences:
 *)
 
 // Create a series of pairs from earlier 'hf' input
@@ -250,15 +219,12 @@ hf |> Series.pairwise
 hf |> Series.pairwiseWith (fun k (v1, v2) -> v2 - v1)
 
 (**
-<a name="sampling"></a>
 
-## Sampling and resampling time series
+## Sampling and resampling
 
 ### Lookup
 
-Given a series `hf`, you can get a value at a specified key using `hf.Get(key)`.
-It is also possible to find values for larger number of keys at once using 
-`Series.lookupAll` when you want more flexible lookup:
+`Series.lookupAll` retrieves values for many keys at once with flexible matching:
 *)
 // Generate a bit less than 24 hours of data with 13.7sec offsets
 let mf = stock1 (TimeSpan.FromSeconds(13.7)) 6300 |> series
@@ -273,6 +239,8 @@ mf |> Series.lookupAll keys Lookup.ExactOrSmaller
 
 (**
 ### Resampling
+
+Resample by collecting values between specified keys:
 *)
 
 // For each key, collect values for greater keys until the next one
@@ -283,9 +251,7 @@ mf |> Series.resampleInto keys Direction.Backward
   (fun k s -> Stats.mean s)
 
 (**
-The second kind of resampling is based on a projection from existing keys in 
-the series. The typical scenario is when you have time series with date time information
-and want to get information for each day:
+Resample by projecting existing keys (e.g. group by date):
 *)
 
 // Generate 2.5 months of data in 1.7 hour offsets
@@ -298,9 +264,7 @@ ds.ResampleEquivalence(fun d -> d.Date)
 (**
 ### Uniform resampling
 
-If you want to create sampling that assigns value to each key in the range specified
-by the input sequence (including days with no observations), then you can use 
-_uniform resampling_:
+Assign values to every key in a range, filling gaps for days with no observations:
 *)
 
 // Create input data with non-uniformly distributed keys
@@ -323,7 +287,7 @@ sampled
 |> Frame.ofRows
 
 (**
-### Sampling time series
+### Sampling at fixed intervals
 *)
 // Generate 1k observations with 1.7 hour offsets
 let pr = stock1 (TimeSpan.FromHours(1.7)) 1000 |> series
@@ -336,9 +300,8 @@ pr |> Series.sampleTimeInto
   (TimeSpan(2, 0, 0)) Direction.Backward Series.lastValue
 
 (**
-<a name="stats"></a>
 
-## Calculations and statistics
+## Arithmetic and statistics
 
 ### Shifting and differences
 *)
@@ -361,9 +324,8 @@ let alignedDf =
 (**
 ### Operators and functions
 
-Time series supports a large number of standard F# functions such as `log` and `abs`.
-You can also use standard numerical operators to apply some operation to all elements
-of the series, and binary operators automatically align two series before applying:
+Series supports standard F# math functions and binary operators.
+Binary operators auto-align two series by key before applying:
 *)
 
 // Subtract previous value from the current value
@@ -382,9 +344,9 @@ let adjust v = min 1.0 (max -1.0 v)
 adjust $ sample.Diff(1)
 
 (**
-### Data frame operations
+### Frame-level operations
 
-Many of the time series operations can be applied to entire data frames as well:
+Many time-series operations apply to entire frames:
 *)
 // Multiply all numeric columns by a given constant
 alignedDf * 0.65

--- a/docs/tutorial.fsx
+++ b/docs/tutorial.fsx
@@ -1,6 +1,6 @@
 (**
 ---
-title: Deedle in 10 minutes using F#
+title: Deedle in 10 minutes
 category: Guides
 categoryindex: 1
 index: 2
@@ -20,6 +20,8 @@ keywords: tutorial, quick start, getting started, F#, data frame, series
 open System
 open Deedle
 
+let root = __SOURCE_DIRECTORY__ + "/data/"
+
 fsi.AddPrinter(fun (o: obj) ->
   let iface = o.GetType().GetInterface("IFsiFormattable")
   if iface <> null then
@@ -27,351 +29,263 @@ fsi.AddPrinter(fun (o: obj) ->
     fmt.Invoke(o, [||]) :?> string
   else null)
 
-series [1 => 1.0; 2 => 2.0]
+(**
+
+# Deedle in 10 minutes
+
+This quick-start gets you productive with Deedle fast.
+We use the classic [Titanic passenger data set](http://www.kaggle.com/c/titanic-gettingStarted)
+to show the most important features — loading data, exploring columns,
+filtering, grouping, handling missing values, and basic statistics.
+
+## Setup
+
+Install from NuGet and open the namespace:
+
+    [lang=text]
+    dotnet add package Deedle
+
+*)
+
+(*** do-not-eval ***)
+#r "nuget: Deedle"
+open Deedle
+
+(**
+
+## Loading data
+
+The fastest way to get data into Deedle is `Frame.ReadCsv`:
+*)
+
+let titanic = Frame.ReadCsv(root + "titanic.csv")
+
+(**
+Let's see what we have:
+*)
+
+titanic.RowCount
+(*** include-it ***)
+
+titanic.ColumnCount
+(*** include-it ***)
+
+titanic.ColumnKeys |> Seq.toList
+(*** include-it ***)
+
+(**
+Print the first few rows:
+*)
+titanic |> Frame.take 5
 (*** include-it ***)
 
 (**
 
-# Quick Start
+## Accessing columns
 
-This document is a quick overview of the most important features of Deedle.
-
-The first step is to install `Deedle` [from NuGet](https://www.nuget.org/packages/Deedle).
-In F# Interactive, reference the library:
-
-// #r "nuget: Deedle,{{fsdocs-package-version}}"
-
-<a name="creating"></a>
-
-## Creating series and frames
-
-A data frame is a collection of series with unique column names (although these
-do not actually have to be strings). So, to create a data frame, we first need
-to create a series:
+Use `?` to grab a column as a `Series`. Deedle reads numeric columns as `float`
+and text columns as `string`:
 *)
 
-// Create from sequence of keys and sequence of values
-let dates  = 
-  [ DateTime(2013,1,1); 
-    DateTime(2013,1,4); 
-    DateTime(2013,1,8) ]
-let values = 
-  [ 10.0; 20.0; 30.0 ]
-let first = Series(dates, values)
-
-// Create from a single list of observations
-Series.ofObservations
-  [ DateTime(2013,1,1) => 10.0
-    DateTime(2013,1,4) => 20.0
-    DateTime(2013,1,8) => 30.0 ]
-
+// A numeric column
+titanic?Age
 (*** include-it ***)
 
-// Shorter alternative to 'Series.ofObservations'
-series [ 1 => 1.0; 2 => 2.0 ]
-
-// Create series with implicit (ordinal) keys
-Series.ofValues [ 10.0; 20.0; 30.0 ]
+// A text column
+titanic.GetColumn<string>("Name") |> Series.take 3
 (*** include-it ***)
 
 (**
-Note that the series type is generic. `Series<K, T>` represents a series
-with keys of type `K` and values of type `T`. Let's now generate series
-with 10 day value range and random values:
+
+## Basic statistics
+
+Compute summary statistics on any numeric series:
 *)
 
-/// Generate date range from 'first' with 'count' days
-let dateRange (first:System.DateTime) count =
-  seq { for i in 0 .. (count - 1) -> first.AddDays(float i) }
+titanic?Age |> Stats.mean
+(*** include-it ***)
 
-/// Generate 'count' number of random doubles
-let rand count =
-  let rnd = System.Random()
-  seq { for i in 0 .. (count - 1) -> rnd.NextDouble() }
+titanic?Fare |> Stats.mean
+(*** include-it ***)
 
-// A series with values for 10 days 
-let second = Series(dateRange (DateTime(2013,1,1)) 10, rand 10)
+titanic?Age |> Stats.median
+(*** include-it ***)
 
-(round (second*100.0))/100.0
+titanic?Age |> Stats.stdDev
 (*** include-it ***)
 
 (**
-Now we can easily construct a data frame that has two columns - one representing
-the `first` series and another representing the `second` series:
+Missing values (like missing `Age` entries in the Titanic data) are automatically
+skipped by all statistical functions.
+
+## Filtering rows
+
+Use `Frame.filterRowValues` to keep only rows matching a condition:
 *)
 
-let df1 = Frame(["first"; "second"], [first; second])
-df1
+// Passengers who survived
+let survived = titanic |> Frame.filterRowValues (fun row ->
+  row.GetAs<bool>("Survived"))
+
+survived.RowCount
 (*** include-it ***)
 
-(** 
-The type representing a data frame has two generic parameters:
-`Frame<TRowKey, TColumnKey>`. The first parameter represents the type of
-row keys - this can be `int` if we do not give the keys explicitly or `DateTime`
-like in the example above. The second parameter is the type of column keys.
-This is typically `string`, but sometimes it is useful to create a 
-transposed frame with dates as column keys. Because a data frame can contain
-heterogeneous data, there is no type of values - this needs to be specified
-when getting data from the data frame.
+// First-class passengers
+let firstClass = titanic |> Frame.filterRowValues (fun row ->
+  row.GetAs<int>("Pclass") = 1)
 
-As the output shows, creating a frame automatically combines the indices of 
-the two series (using "outer join" so the result has all the dates that appear 
-in any of the series). The data frame now contains `first` column with some 
-missing values.
-
-You can also use the following nicer syntax and create frame from rows as well as 
-individual values:
-*)
-
-// The same as previously
-let df2 = Frame.ofColumns ["first" => first; "second" => second]
-
-// Transposed - here, rows are "first" and "second" & columns are dates
-let df3 = Frame.ofRows ["first" => first; "second" => second]
-
-// Create from individual observations (row * column * value)
-let df4 = 
-  [ ("Monday", "Tomas", 1.0); ("Tuesday", "Adam", 2.1)
-    ("Tuesday", "Tomas", 4.0); ("Wednesday", "Tomas", -5.4) ]
-  |> Frame.ofValues
-
-(**
-Data frame can be also easily created from a collection of F# record types (or of any classes
-with public readable properties). The `Frame.ofRecords` function uses reflection to find the 
-names and types of properties of a record and creates a data frame with the same structure.
-*)
-// Assuming we have a record 'Price' and a collection 'values'
-type Price = { Day : DateTime; Open : float }
-let prices = 
-  [ { Day = DateTime.Now; Open = 10.1 }
-    { Day = DateTime.Now.AddDays(1.0); Open = 15.1 }
-    { Day = DateTime.Now.AddDays(2.0); Open = 9.1 } ]
-
-// Creates a data frame with columns 'Day' and 'Open'
-let df5 = Frame.ofRecords prices
-
-(**
-Finally, we can also load data frame from CSV:
-*)
-let root = __SOURCE_DIRECTORY__ + "/data/"
-
-let msftCsv = Frame.ReadCsv(root + "stocks/msft.csv")
-let fbCsv = Frame.ReadCsv(root + "stocks/fb.csv")
-
-(*** include-value: fbCsv ***)
-
-(**
-When loading the data, the data frame analyses the values and automatically converts
-them to the most appropriate type. However, no conversion is automatically performed
-for dates and times - the user needs to decide what is the desirable representation
-of dates (e.g. `DateTime`, `DateTimeOffset` or some custom type).
-
-<a name="reindexing-and-joins"></a>
-
-## Specifying index and joining
-
-Now we have `fbCsv` and `msftCsv` frames containing stock prices, but they are
-indexed with ordinal numbers. This means that we can get e.g. 4th price. 
-However, we would like to align them using their dates (in case there are some 
-values missing). This can be done by setting the row index to the "Date" column.
-Once we set the date as the index, we also need to order the index. The Yahoo 
-Finance prices are ordered from the newest to the oldest, but our data-frame 
-requires ascending ordering.
-
-When a frame has ordered index, we can use additional functionality that will 
-be needed later (for example, we can select sub-range by specifying dates that 
-are not explicitly included in the index).
-*)
-
-// Use the Date column as the index & order rows
-let msftOrd = 
-  msftCsv
-  |> Frame.indexRowsDateTime "Date"
-  |> Frame.sortRowsByKey
-
-(**
-The `indexRowsDateTime` function uses a column of type `DateTime` as a new index.
-The library provides other functions for common types of indices (like `indexRowsInt`)
-and you can also use a generic function - when using the generic function, some 
-type annotations may be needed, so it is better to use a specific function.
-Next, we sort the rows using another function from the `Frame` module. The module
-contains a large number of useful functions that you'll use all the time - it
-is a good idea to go through the list to get an idea of what is supported.
-
-Now that we have properly indexed stock prices, we can create a new data frame that
-only has the data we're interested (Open & Close) prices and we add a new column 
-that shows their difference:
-*)
-
-// Create data frame with just Open and Close prices
-let msft = msftOrd.Columns.[ ["Open"; "Close"] ]
-
-// Add new column with the difference between Open & Close
-msft?Difference <- msft?Open - msft?Close
-
-// Do the same thing for Facebook
-let fb = 
-  fbCsv
-  |> Frame.indexRowsDateTime "Date"
-  |> Frame.sortRowsByKey
-  |> Frame.sliceCols ["Open"; "Close"]
-fb?Difference <- fb?Open - fb?Close
-
-(**
-When selecting columns using `f.Columns.[ .. ]` it is possible to use a list of columns
-(as we did), a single column key, or a range (if the associated index is ordered). 
-Then we use the `df?Column <- (...)` syntax to add a new column to the data frame. 
-This is the only mutating operation that is supported on data frames - all other 
-operations create a new data frame and return it as the result.
-
-Next we would like to create a single data frame that contains (properly aligned) data
-for both Microsoft and Facebook. This is done using the `Join` method - but before we
-can do this, we need to rename their columns, because duplicate keys are not allowed:
-*)
-
-// Change the column names so that they are unique
-let msftNames = ["MsftOpen"; "MsftClose"; "MsftDiff"]
-let msftRen = msft |> Frame.indexColsWith msftNames
-
-let fbNames = ["FbOpen"; "FbClose"; "FbDiff"]
-let fbRen = fb |> Frame.indexColsWith fbNames
-
-// Outer join (align & fill with missing values)
-let joinedOut = msftRen.Join(fbRen, kind=JoinKind.Outer)
-
-// Inner join (remove rows with missing values)
-let joinedIn = msftRen.Join(fbRen, kind=JoinKind.Inner)
-
-(**
-<a name="selecting"></a>
-
-## Selecting values and slicing
-
-The data frame provides two key properties that we can use to access the data. The 
-`Rows` property returns a series containing individual rows (as a series) and `Columns`
-returns a series containing columns (as a series). We can then use various indexing and
-slicing operators on the series:
-*)
-
-// Look for a row at a specific date
-joinedIn.Rows.[DateTime(2013, 1, 2)]
-
-// Get opening Facebook price for 2 Jan 2013
-joinedIn.Rows.[DateTime(2013, 1, 2)]?FbOpen
-
-(**
-In the previous example, we used an indexer with a single key. You can also specify multiple
-keys (using a list) or a range (using the slicing syntax):
-*)
-
-// Get values for the first three days of January 2013
-let janDates = [ for d in 2 .. 4 -> DateTime(2013, 1, d) ]
-let jan234 = joinedIn.Rows.[janDates]
-
-// Calculate mean of Open price for 3 days
-jan234?MsftOpen |> Stats.mean
-
-// Get values corresponding to entire January 2013
-let jan = joinedIn.Rows.[DateTime(2013, 1, 1) .. DateTime(2013, 1, 31)] 
-
-(*** include-value:round (jan*100.0)/100.0 |> Frame.mapRowKeys (fun dt -> dt.ToShortDateString()) ***)
-
-// Calculate means over the period
-jan?FbOpen |> Stats.mean
-jan?MsftOpen |> Stats.mean
-
-(**
-<a name="timeseries"></a>
-
-## Using ordered time series
-
-As already mentioned, if we have an ordered series or an ordered data frame, then we can
-leverage the ordering in a number of ways. In the previous example, slicing used lower
-and upper bounds rather than exact matching. Similarly, it is possible to get nearest
-smaller (or greater) element when using direct lookup.
-
-For example, let's create two series with 10 values for 10 days. The `daysSeries` 
-contains keys starting from `DateTime.Today` (12:00 AM) and `obsSeries` has dates
-with time component set to the current time:
-*)
-
-let daysSeries = Series(dateRange DateTime.Today 10, rand 10)
-let obsSeries = Series(dateRange DateTime.Now 10, rand 10)
-
-(round (daysSeries*100.0))/100.0
-(*** include-it ***)
-(round (obsSeries*100.0))/100.0
+firstClass.RowCount
 (*** include-it ***)
 
 (**
-The indexing operation written as `daysSeries.[date]` uses _exact_ semantics so it will 
-fail if the exact date is not available. When using `Get` method, we can provide an
-additional parameter to specify the required behaviour:
+
+## Adding computed columns
+
+The `?<-` operator adds or replaces a column. Let's add a `HasCabin` flag:
 *)
 
-// This works - we get the value for DateTime.Today (12:00 AM)
-daysSeries.Get(DateTime.Now, Lookup.ExactOrSmaller)
+titanic?HasCabin <- titanic.GetColumn<string>("Cabin")
+  |> Series.mapAll (fun _ v -> Some(v.IsSome))
+
+titanic.Columns.[ ["Name"; "Pclass"; "HasCabin"] ] |> Frame.take 5
+(*** include-it ***)
 
 (**
-<a name="projections"></a>
-
-## Projection and filtering
-
-For filtering and projection, series provides `Where` and `Select` methods and 
-corresponding `Series.map` and `Series.filter` functions. The following adds a new 
-column that contains the name of the stock with greater price ("FB" or "MSFT"):
-*)
-
-joinedOut?Comparison <- joinedOut |> Frame.mapRowValues (fun row -> 
-  if row?MsftOpen > row?FbOpen then "MSFT" else "FB")
-
-(**
-When projecting or filtering rows, we need to be careful about missing data. The row
-accessor `row?MsftOpen` reads the specified column (and converts it to `float`), but when
-the column is not available, it throws the `MissingValueException` exception. Projection
-functions such as `mapRowValues` automatically catch this exception and mark the 
-corresponding series value as missing.
-
-Now we can get the number of days when Microsoft stock prices were above Facebook:
-*)
-
-joinedOut.GetColumn<string>("Comparison")
-|> Series.filterValues ((=) "MSFT") |> Series.countValues
-
-joinedOut.GetColumn<string>("Comparison")
-|> Series.filterValues ((=) "FB") |> Series.countValues
-
-(**
-<a name="grouping"></a>
 
 ## Grouping and aggregation
 
-As a last thing, we briefly look at grouping and aggregation. For more information
-about grouping of time series data, see [the time series features tutorial](series.html)
-and [the data frame features](frame.html) contains more about grouping of unordered frames.
+Group rows by a column and aggregate — one of Deedle's most powerful features.
 
-The following snippet groups rows by month and year:
+### Survival rate by passenger class
 *)
-let monthly =
-  joinedIn
-  |> Frame.groupRowsUsing (fun k _ -> DateTime(k.Year, k.Month, 1))
 
-(**
-As you can see, we get back a frame that has a tuple `DateTime * DateTime` as the row key.
-This is treated in a special way as a _hierarchical_ (or multi-level) index. A number of 
-operations can be used on hierarchical indices. For example, we can get rows in a specified 
-group (say, May 2013) and calculate means of columns in the group:
-*)
-monthly.Rows.[DateTime(2013,5,1), *] |> Stats.mean
+titanic
+|> Frame.aggregateRowsBy ["Pclass"] ["Fare"] Stats.mean
+(*** include-it ***)
 
 (**
-We can also use `Frame.getNumericColumns` in combination with 
-`Stats.levelMean` to get means for all first-level groups:
+### Survival counts by class and sex
 *)
-monthly 
-|> Frame.getNumericCols
-|> Series.mapValues (Stats.levelMean fst)
-|> Frame.ofColumns
+
+let byClassAndSex = 
+  titanic
+  |> Frame.groupRowsByInt "Pclass"
+  |> Frame.groupRowsByString "Sex"
+  |> Frame.mapRowKeys Pair.flatten3
+
+byClassAndSex.GetColumn<bool>("Survived")
+|> Series.applyLevel Pair.get1And2Of3 (fun s ->
+    series (Seq.countBy id s.Values))
+|> Frame.ofRows
+(*** include-it ***)
+
+(**
+### Average age by class
+*)
+
+titanic
+|> Frame.aggregateRowsBy ["Pclass"] ["Age"] Stats.mean
+(*** include-it ***)
+
+(**
+
+### Pivot tables
+
+Pivot tables cross-tabulate two categorical variables with an aggregation:
+*)
+
+titanic 
+|> Frame.pivotTable 
+    (fun k r -> r.GetAs<string>("Sex"))
+    (fun k r -> r.GetAs<int>("Pclass"))
+    Frame.countRows
+
+(*** include-it ***)
+
+(**
+
+## Handling missing values
+
+Real data has gaps. The Titanic `Age` and `Cabin` columns both contain missing
+entries. Deedle makes this explicit — missing values show as `<missing>` and are
+automatically skipped by statistics:
+*)
+
+// How many ages are missing?
+let ageCol = titanic?Age
+let total = ageCol |> Series.countKeys
+let present = ageCol |> Series.countValues
+(*** include-value: total ***)
+(*** include-value: present ***)
+(*** include-value: total - present ***)
+
+(**
+Fill strategies let you choose how to handle the gaps:
+*)
+
+// Replace missing ages with a constant
+ageCol |> Series.fillMissingWith 0.0 |> Series.take 5
+(*** include-it ***)
+
+// Fill forward (propagate last known value)
+ageCol |> Series.fillMissing Direction.Forward |> Series.take 5
+(*** include-it ***)
+
+// Drop rows with missing values
+ageCol |> Series.dropMissing |> Series.countKeys
+(*** include-it ***)
+
+(**
+
+## Creating frames and series from scratch
+
+You can also build data frames from scratch rather than loading CSV.
+*)
+
+// A simple series
+let ages = series [ "Alice" => 30.0; "Bob" => 25.0; "Carol" => 35.0 ]
+ages
+(*** include-it ***)
+
+// Build a frame from columns
+let people = 
+  Frame.ofColumns [
+    "Age" => ages
+    "Score" => series [ "Alice" => 90.0; "Bob" => 85.0; "Carol" => 92.0 ]
+  ]
+people
+(*** include-it ***)
+
+// Build a frame from records
+type Person = { Name: string; Age: int }
+let records = 
+  [ { Name = "Alice"; Age = 30 }
+    { Name = "Bob"; Age = 25 } ]
+Frame.ofRecords records
+(*** include-it ***)
+
+(**
+
+## Selecting columns and rows
+
+Pick specific columns with `Frame.sliceCols` or the indexer:
+*)
+
+titanic.Columns.[ ["Name"; "Age"; "Fare"] ] |> Frame.take 3
+(*** include-it ***)
+
+titanic |> Frame.sliceCols ["Pclass"; "Survived"] |> Frame.take 3
+(*** include-it ***)
+
+(**
+
+## Sorting
+
+Sort a frame by column values:
+*)
+
+titanic |> Frame.sortRowsBy "Fare" (fun (v: float) -> -v) |> Frame.take 5
+(*** include-it ***)
 
 (**
 


### PR DESCRIPTION
## Summary

Rewrites `tutorial.fsx` ("Deedle in 10 minutes") to be a much simpler, more compelling quick start that uses the Titanic dataset from the very first line of code.

### Before
The tutorial started with abstract series construction (dates, random values, manually building frames) — hard to follow and not immediately useful. It overlapped heavily with `frame.fsx`.

### After
The tutorial now:
- **Starts immediately** with `Frame.ReadCsv` on Titanic data — real data from line one
- Explores data shape, columns, and basic statistics (`Stats.mean`, `Stats.median`, `Stats.stdDev`)
- Shows **filtering** rows (survivors, first-class passengers)
- Shows **adding computed columns** (`HasCabin` flag)
- Demonstrates **grouping and aggregation** — survival rates by class/sex, average age by class, pivot tables
- Covers **missing values** — counting, fill strategies, drop
- Briefly shows building frames/series **from scratch** (moved to end, not front)
- Shows column selection and sorting
- Ends with links to deeper guides

### Also included
- Doc title and category improvements from prior commit (arrow, excel, math, parquet, dotnetinteractive, csharp)