### PR TITLE
Add Iteration functions for Series and Frame

### DIFF
--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1466,6 +1466,17 @@ module Frame =
     frame.Rows |> Series.map f
 
   /// <summary>
+  /// Applies the specified function to each row of the data frame. 
+  /// The function is called with the row key and an object series that represents the row data.
+  /// </summary>
+  /// <param name="f">The function to apply to each row key and row data.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  [<CompiledName("IterateRows")>]
+  let inline iterRows (f:_ -> _ -> unit) (frame:Frame<'R, 'C>) =
+    frame.Rows |> Series.iter f
+
+  /// <summary>
   /// Builds a new data frame whose rows are the results of applying the specified
   /// function on the rows of the input data frame. The function is called
   /// with an object series that represents the row data (use `mapRows`
@@ -1479,6 +1490,18 @@ module Frame =
     frame.Rows |> Series.mapValues f
 
   /// <summary>
+  /// Applies the specified function to each row of the data frame. 
+  /// The function is called with an object series that represents the row data 
+  /// (use `iterRows` if you need to access the row key).
+  /// </summary>
+  /// <param name="f">The function to apply to each row data.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  [<CompiledName("IterateRowValues")>]
+  let inline iterRowValues (f:_ -> unit) (frame:Frame<'R, 'C>) =
+    frame.Rows |> Series.iterValues f
+
+  /// <summary>
   /// Builds a new data frame whose row keys are the results of applying the
   /// specified function on the row keys of the original data frame.
   /// </summary>
@@ -1490,6 +1513,17 @@ module Frame =
     let newRowIndex = frame.IndexBuilder.Create(frame.RowIndex.Keys |> Seq.map f, None)
     let newData = frame.Data.Select(VectorHelpers.transformColumn frame.VectorBuilder newRowIndex.AddressingScheme (Vectors.Return 0))
     Frame(newRowIndex, frame.ColumnIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
+
+  /// <summary>
+  /// Applies the specified function to each row key of the data frame.
+  /// </summary>
+  /// <param name="f">The function to apply to each row key.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  [<CompiledName("IterateRowKeys")>]
+  let iterRowKeys (f: _ -> unit) (frame: Frame<'R, 'C>) =
+    frame.RowIndex.Keys |> Seq.iter f
+    
 
   /// <summary>
   /// Returns a data frame whose rows are indexed based on the specified column of the original
@@ -1550,6 +1584,17 @@ module Frame =
     frame.Columns |> Series.map f |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
 
   /// <summary>
+  /// Applies the specified function to each column of the data frame. 
+  /// The function is called with the column key and an object series that represents the column data.
+  /// </summary>
+  /// <param name="f">The function to apply to each column key and column data.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  [<CompiledName("IterateColumns")>]
+  let iterCols (f: 'C -> ObjectSeries<'R> -> unit) (frame: Frame<'R, 'C>) =
+    frame.Columns |> Series.iter f
+
+  /// <summary>
   /// Builds a new data frame whose columns are the results of applying the specified
   /// function on the columns of the input data frame. The function is called
   /// with an object series that represents the column data (use `mapCols`
@@ -1561,6 +1606,18 @@ module Frame =
   [<CompiledName("SelectColumnValues")>]
   let mapColValues f (frame:Frame<'R, 'C>) =
     frame.Columns |> Series.mapValues f |> FrameUtils.fromColumns frame.IndexBuilder frame.VectorBuilder
+
+  /// <summary>
+  /// Applies the specified function to each column of the data frame. 
+  /// The function is called with an object series that represents the column data.
+  /// (use `mapCols`if you need to access the column key).
+  /// </summary>
+  /// <param name="f">The function to apply to each column key and column data.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  [<CompiledName("IterateColumnValues")>]
+  let iterColValues (f: ObjectSeries<'R> -> unit) (frame: Frame<'R, 'C>) =
+    frame.Columns |> Series.iterValues f
 
   /// <summary>
   /// Builds a new data frame whose columns are the results of applying the specified
@@ -1590,6 +1647,16 @@ module Frame =
     Frame(frame.RowIndex, newColIndex, newData, frame.IndexBuilder, frame.VectorBuilder)
 
   /// <summary>
+  /// Applies the specified function to each column key of the data frame. 
+  /// </summary>
+  /// <param name="f">The function to apply to each column key.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  [<CompiledName("IterateColumnKeys")>]
+  let iterColKeys (f: 'C -> unit) (frame:Frame<'R, 'C>) =
+    frame.ColumnIndex.Keys |> Seq.iter f
+
+  /// <summary>
   /// Builds a new data frame whose values are the results of applying the specified
   /// function on these values, but only for those columns which can be converted
   /// to the appropriate type for input to the mapping function (use `map` if you need
@@ -1602,6 +1669,18 @@ module Frame =
   let mapValues f (frame:Frame<'R, 'C>) = frame.SelectValues(Func<_,_>(f))
 
   /// <summary>
+  /// Applies the specified function to each value of the data frame.
+  /// The function is only applied to columns which can be converted to the 
+  /// appropriate type for input to the function.
+  /// </summary>
+  /// <param name="f">The function to apply to each value.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  [<CompiledName("IterateValues")>]
+  let iterValues f (frame:Frame<'R, 'C>) =
+    frame.SelectValues(Func<_, _>(f)) |> ignore
+
+  /// <summary>
   /// Builds a new data frame whose values are the results of applying the specified
   /// function on these values, but only for those columns which can be converted
   /// to the appropriate type for input to the mapping function.
@@ -1610,6 +1689,15 @@ module Frame =
   /// <param name="f">Function that defines the mapping</param>
   /// <category>Frame transformations</category>
   let map f (frame:Frame<'R, 'C>) = frame.Select(Func<_,_,_,_>(f))
+
+  /// <summary>
+  /// Applies the specified function to the values of the data frame, but only for those columns 
+  /// which can be converted to the appropriate type for input to the function.
+  /// </summary>
+  /// <param name="f">The function to apply to each row key, column key, and value.</param>
+  /// <param name="frame">The input data frame.</param>
+  /// <category>Frame transformations</category>
+  let iter f (frame:Frame<'R, 'C>) = frame.Select(Func<_,_,_,_>(f)) |> ignore
 
   /// <summary>
   /// Returns a series that contains the results of aggregating each column

--- a/src/Deedle/FrameModule.fs
+++ b/src/Deedle/FrameModule.fs
@@ -1677,8 +1677,9 @@ module Frame =
   /// <param name="frame">The input data frame.</param>
   /// <category>Frame transformations</category>
   [<CompiledName("IterateValues")>]
-  let iterValues f (frame:Frame<'R, 'C>) =
-    frame.SelectValues(Func<_, _>(f)) |> ignore
+  let iterValues (f: 'T -> unit) (frame: Frame<'R, 'C>) =
+    frame.GetColumns<'T>()
+    |> Series.iterValues (fun col -> col |> Series.iterValues f)
 
   /// <summary>
   /// Builds a new data frame whose values are the results of applying the specified
@@ -1697,7 +1698,9 @@ module Frame =
   /// <param name="f">The function to apply to each row key, column key, and value.</param>
   /// <param name="frame">The input data frame.</param>
   /// <category>Frame transformations</category>
-  let iter f (frame:Frame<'R, 'C>) = frame.Select(Func<_,_,_,_>(f)) |> ignore
+  let iter (f: 'R -> 'C -> 'T -> unit) (frame:Frame<'R, 'C>) =
+    frame.GetColumns<'T>()
+    |> Series.iter (fun c col -> col |> Series.iter (fun r v -> f r c v))
 
   /// <summary>
   /// Returns a series that contains the results of aggregating each column

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -1,4 +1,4 @@
-﻿#nowarn "77" // Static constraint in Series.sample requires special + operator
+#nowarn "77" // Static constraint in Series.sample requires special + operator
 #nowarn "10002" // Custom CompilerMessage used to hide internals that are inlined
 
 namespace Deedle
@@ -591,6 +591,20 @@ module Series =
     series.Select(fun (KeyValue(k,v)) -> f k v)
 
   /// <summary>
+  /// Applies the given function to each key and value of the series.
+  /// This function skips over missing values and call the
+  /// function with both keys and values.
+  /// </summary>
+  /// <param name="f">The function to apply to each key and value.</param>
+  /// <param name="series">The input series.</param>
+  /// <category>Series transformations</category>
+  [<CompiledName("Iterate")>]
+  let iter (f: 'K -> 'T -> unit) (series: Series<'K, 'T>) =
+    series
+    |> observations
+    |> Seq.iter (fun (k, v) -> f k v)
+
+  /// <summary>
   /// Returns a new series whose values are the results of applying the given function to
   /// values of the original series. This function skips over missing values and call the
   /// function with just values. It is also aliased using the `$` operator so you can write
@@ -600,6 +614,20 @@ module Series =
   [<CompiledName("MapValues")>]
   let mapValues (f:'T -> 'R) (series:Series<'K, 'T>) =
     series.Select(fun (KeyValue(k,v)) -> f v)
+
+  /// <summary>
+  /// Applies the given function to each value of the series.
+  /// This function skips over missing values and calls the
+  /// function with just values.
+  /// </summary>
+  /// <param name="f">The function to apply to each value.</param>
+  /// <param name="series">The input series.</param>
+  /// <category>Series transformations</category>
+  [<CompiledName("IterateValues")>]
+  let iterValues (f: 'T -> unit) (series: Series<'K, 'T>) =
+    series
+    |> values
+    |> Seq.iter f
 
   /// <summary>
   /// Returns a new series whose values are the results of applying the given function to
@@ -612,6 +640,32 @@ module Series =
   let mapAll (f:_ -> _ -> option<'R>) (series:Series<'K, 'T>) =
     series.SelectOptional(fun kvp ->
       f kvp.Key (OptionalValue.asOption kvp.Value) |> OptionalValue.ofOption)
+
+  /// <summary>
+  /// Applies the given function to each key and value of the series.
+  /// This specified function is called even when the value is missing.
+  /// </summary>
+  /// <param name="f">The function to apply to each key and optional value.</param>
+  /// <param name="series">The input series.</param>
+  /// <category>Series transformations</category>
+  [<CompiledName("IterateAll")>]
+  let iterAll (f: _ -> _ -> unit) (series: Series<'K, 'T>) =
+    series
+    |> observationsAll
+    |> Seq.iter (fun (k, v) -> f k v)
+
+  /// <summary>
+  /// Applies the given function to each value of the series.
+  /// This specified function is called even when the value is missing.
+  /// </summary>
+  /// <param name="f">The function to apply to each key and optional value.</param>
+  /// <param name="series">The input series.</param>
+  /// <category>Series transformations</category>
+  [<CompiledName("IterateAll")>]
+  let iterAllValues (f: _ -> unit) (series: Series<'K, 'T>) =
+    series
+    |> observationsAll
+    |> Seq.iter (fun (_, v) -> f v)
 
   /// <summary>
   /// Returns a new series with values replaced by missing where the predicate returns `true`.
@@ -664,6 +718,17 @@ module Series =
   [<CompiledName("MapKeys")>]
   let mapKeys (f:'K -> 'R) (series:Series<'K, 'T>) =
     series.SelectKeys(fun kvp -> f kvp.Key)
+
+  /// <summary>
+  /// Applies the given function to each key of the series.
+  /// Note that this iterates over the entire index, including keys where the corresponding value is missing.
+  /// </summary>
+  /// <param name="f">The function to apply to each key.</param>
+  /// <param name="series">The input series.</param>
+  /// <category>Series transformations</category>
+  [<CompiledName("IterateKeys")>]
+  let iterKeys (f:'K -> unit) (series:Series<'K, 'T>) =
+    series.Keys |> Seq.iter f
 
   /// <summary>
   /// Retruns a new series whose values are converted using the specified conversion function.

--- a/src/Deedle/SeriesModule.fs
+++ b/src/Deedle/SeriesModule.fs
@@ -661,7 +661,7 @@ module Series =
   /// <param name="f">The function to apply to each key and optional value.</param>
   /// <param name="series">The input series.</param>
   /// <category>Series transformations</category>
-  [<CompiledName("IterateAll")>]
+  [<CompiledName("IterateAllValues")>]
   let iterAllValues (f: _ -> unit) (series: Series<'K, 'T>) =
     series
     |> observationsAll

--- a/tests/Deedle.Tests/Frame.fs
+++ b/tests/Deedle.Tests/Frame.fs
@@ -866,6 +866,59 @@ let ``distinctRowsBy with all duplicate rows returns one row`` () =
   result.RowCount |> shouldEqual 1
 
 // ------------------------------------------------------------------------------------------------
+// Iter Functions
+// ------------------------------------------------------------------------------------------------
+
+[<Test>]
+let ``Frame row iteration functions work correctly`` () =
+  let df = frame ["X" => series[1 => 10.0; 2 => nan; 3 => 30.0]
+                  "Y" => series[1 => 100.0; 2 => 200.0; 3 => 300.0]]
+
+  let rowsAcc = ResizeArray()
+  df |> Frame.iterRows (fun r row -> rowsAcc.Add(r, row.GetAs<float>("Y")))
+  List.ofSeq rowsAcc |> shouldEqual [(1, 100.0); (2, 200.0); (3, 300.0)]
+
+  let rowValsAcc = ResizeArray()
+  df |> Frame.iterRowValues (fun row -> rowValsAcc.Add(row.KeyCount))
+  List.ofSeq rowValsAcc |> shouldEqual [2; 2; 2]
+
+  let rowKeysAcc = ResizeArray()
+  df |> Frame.iterRowKeys (fun r -> rowKeysAcc.Add(r))
+  List.ofSeq rowKeysAcc |> shouldEqual [1; 2; 3]
+
+[<Test>]
+let ``Frame column iteration functions work correctly`` () =
+  let df = frame ["X" => series[1 => 10.0; 2 => nan; 3 => 30.0]
+                  "Y" => series[1 => 100.0; 2 => 200.0; 3 => 300.0]]
+
+  let colsAcc = ResizeArray()
+  df |> Frame.iterCols(fun c col -> colsAcc.Add(c, col.GetAs<float>(1)))
+  List.ofSeq colsAcc |> shouldEqual [("X", 10.0); ("Y", 100.0)]
+
+  let colValsAcc = ResizeArray()
+
+  df |> Frame.iterColValues (fun col -> colValsAcc.Add(col.ValueCount))
+  List.ofSeq colValsAcc |> shouldEqual [2; 3]
+
+  let colKeysAcc = ResizeArray()
+  df |> Frame.iterColKeys (fun c -> colKeysAcc.Add(c))
+  List.ofSeq colKeysAcc |> shouldEqual ["X"; "Y"]
+
+
+[<Test>]
+let ``Frame.iter and iterValues skip missing values and filter by type`` () =
+  let df = frame [ "A" => (series [ 1 => 10.0; 2 => nan; 3 => 30.0 ] :> ISeries<_>)
+                   "B" => (series [ 1 => "str1"; 2 => "str2"; 3 => "str3" ] :> ISeries<_>)]
+
+  let iterAcc = ResizeArray()
+  df |> Frame.iter(fun r c (v: float) -> iterAcc.Add(r, c, v))
+  List.ofSeq iterAcc |> shouldEqual [(1, "A", 10.0); (3, "A", 30.0)]
+
+  let iterValsAcc = ResizeArray()
+  df |> Frame.iterValues (fun (v: string) -> iterValsAcc.Add(v))
+  List.ofSeq iterValsAcc |> shouldEqual ["str1"; "str2"; "str3"]
+
+// ------------------------------------------------------------------------------------------------
 // Frame.mapCols / mapColValues / mapRows / mapRowValues / mapColKeys / mapRowKeys
 // ------------------------------------------------------------------------------------------------
 

--- a/tests/Deedle.Tests/Series.fs
+++ b/tests/Deedle.Tests/Series.fs
@@ -481,6 +481,41 @@ let ``Grouping series with missing values works on sample input``() =
   actual |> shouldEqual expected
 
 // ------------------------------------------------------------------------------------------------
+// Iter Functions
+// ------------------------------------------------------------------------------------------------
+[<Test>]
+let ``Series.iter and iterValues skip missing values`` () =
+  let s = series [1 => 10.0; 2 => nan; 3 => 30.0]
+
+  let iterAcc = ResizeArray()
+  s |> Series.iter (fun k v -> iterAcc.Add(k ,v))
+  List.ofSeq iterAcc |> shouldEqual [(1,10.0); (3,30.0)]
+
+  let iterValsAcc = ResizeArray()
+  s |> Series.iterValues (fun v -> iterValsAcc.Add(v))
+  List.ofSeq iterValsAcc |> shouldEqual [10.0; 30.0]
+
+[<Test>]
+let ``Series.iterKeys iterates over all keys regardless of missing values`` () =
+  let s = series[1 => 10.0; 2 => nan; 3 => 30.0]
+
+  let acc = ResizeArray()
+  s |> Series.iterKeys(fun k -> acc.Add(k))
+  List.ofSeq acc |> shouldEqual [1; 2; 3]
+
+[<Test>]
+let ``Series.iterAll and iterAllValues pass options and include missing values`` () =
+  let s = series[1 => 10.0; 2 => nan; 3 => 30.0]
+
+  let iterAllAcc = ResizeArray()
+  s |> Series.iterAll(fun k v -> iterAllAcc.Add(k ,v))
+  List.ofSeq iterAllAcc |> shouldEqual [(1, Some 10.0); (2, None); (3, Some 30.0)]
+
+  let iterAllValsAcc = ResizeArray()
+  s |> Series.iterAllValues (fun v -> iterAllValsAcc.Add(v))
+  List.ofSeq iterAllValsAcc |> shouldEqual [Some 10.0; None; Some 30.0]
+
+// ------------------------------------------------------------------------------------------------
 // Fill missing values
 // ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds missing iteration functions to the Series/Frame API.

Changes:

1. Added iter, iterValues, iterKeys, iterAll and iterAllValues to **Series**.
2. Added iterRows, iterRowValues, iterRowKeys, iterCols, iterColValues, iterColKeys, iterValues and iter to **Frame**.
